### PR TITLE
Adds protobuf log handler macro.

### DIFF
--- a/ateam_common/CMakeLists.txt
+++ b/ateam_common/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(Boost REQUIRED)
+find_package(Protobuf REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/multicast_receiver.cpp
@@ -21,6 +22,7 @@ ament_target_dependencies(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME}
   Boost::boost
+  protobuf::libprotobuf
 )
 target_include_directories(${PROJECT_NAME}
   PUBLIC
@@ -29,7 +31,7 @@ target_include_directories(${PROJECT_NAME}
 )
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(Boost)
+ament_export_dependencies(Boost Protobuf)
 
 install(
   DIRECTORY include/
@@ -46,6 +48,7 @@ install(TARGETS ${PROJECT_NAME}
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  add_subdirectory(test)
 endif()
 
 ament_package()

--- a/ateam_common/include/ateam_common/protobuf_logging.hpp
+++ b/ateam_common/include/ateam_common/protobuf_logging.hpp
@@ -1,0 +1,64 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ATEAM_COMMON__PROTOBUF_LOGGING_HPP_
+#define ATEAM_COMMON__PROTOBUF_LOGGING_HPP_
+
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+#include <google/protobuf/stubs/logging.h>
+#include <string>
+
+/**
+ * @brief Sets up the protobuf log handler to redirect all messages through ROS.
+ *
+ * Recommended use:
+ * Call this macro in the constructor of your node. For the logger name, append ".protobuf" to your
+ * node name to create a child of your node's logger.
+ * @code{.cpp}
+ * SET_ROS_PROTOBUF_LOG_HANDLER("my_node.protobuf");
+ * @endcode
+ *
+ */
+#define SET_ROS_PROTOBUF_LOG_HANDLER(logger_name) \
+  { \
+    google::protobuf::SetLogHandler( \
+      [](google::protobuf::LogLevel level, const char * filename, int line, \
+      const std::string & message) { \
+        auto ros_logger = rclcpp::get_logger(logger_name); \
+        switch (level) { \
+          case google::protobuf::LogLevel::LOGLEVEL_INFO: \
+            RCLCPP_INFO(ros_logger, "[%s:%d] %s", filename, line, message.c_str()); \
+            break; \
+          case google::protobuf::LogLevel::LOGLEVEL_WARNING: \
+            RCLCPP_WARN(ros_logger, "[%s:%d] %s", filename, line, message.c_str()); \
+            break; \
+          case google::protobuf::LogLevel::LOGLEVEL_ERROR: \
+            RCLCPP_ERROR(ros_logger, "[%s:%d] %s", filename, line, message.c_str()); \
+            break; \
+          case google::protobuf::LogLevel::LOGLEVEL_FATAL: \
+            RCLCPP_FATAL(ros_logger, "[%s:%d] %s", filename, line, message.c_str()); \
+            break; \
+        } \
+      }); \
+    RCLCPP_INFO(rclcpp::get_logger(logger_name), "Routing protobuf logs through ROS"); \
+  }
+
+#endif  // ATEAM_COMMON__PROTOBUF_LOGGING_HPP_

--- a/ateam_common/package.xml
+++ b/ateam_common/package.xml
@@ -13,6 +13,9 @@
   <depend>rclcpp_components</depend>
   <depend>boost</depend>
 
+  <build_depend>protobuf-dev</build_depend>
+  <exec_depend>protobuf</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/ateam_common/test/CMakeLists.txt
+++ b/ateam_common/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+find_package(ament_cmake_gmock REQUIRED)
+find_package(ament_cmake_gtest REQUIRED)
+ament_add_gmock(test_protobuf_logging test_protobuf_logging.cpp)
+target_link_libraries(test_protobuf_logging ${PROJECT_NAME})

--- a/ateam_common/test/test_protobuf_logging.cpp
+++ b/ateam_common/test/test_protobuf_logging.cpp
@@ -1,0 +1,139 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <google/protobuf/stubs/common.h>
+#include <string>
+#include "ateam_common/protobuf_logging.hpp"
+
+const char * logger_name = "test.protobuf";
+size_t log_calls = 0;
+rclcpp::Logger logger = rclcpp::get_logger(logger_name);
+
+struct LogEvent
+{
+  const rcutils_log_location_t * location;
+  int level;
+  std::string name;
+  rcutils_time_point_value_t timestamp;
+  std::string message;
+};
+LogEvent last_log_event;
+
+class TestProtobufLogging : public testing::Test
+{
+public:
+  rcutils_logging_output_handler_t previous_output_handler;
+
+  void SetUp()
+  {
+    log_calls = 0;
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+    rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_DEBUG);
+
+    auto output_handler = [](const rcutils_log_location_t * location,
+        int level, const char * name, rcutils_time_point_value_t timestamp,
+        const char * format, va_list * args) {
+        ++log_calls;
+        last_log_event = LogEvent{
+          location,
+          level,
+          (name ? name : ""),
+          timestamp,
+          ""
+        };
+        char buffer[1024];
+        vsnprintf(buffer, sizeof(buffer), format, *args);
+        last_log_event.message = buffer;
+      };
+
+    previous_output_handler = rcutils_logging_get_output_handler();
+    rcutils_logging_set_output_handler(output_handler);
+  }
+
+  void TearDown()
+  {
+    rcutils_logging_set_output_handler(previous_output_handler);
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+    EXPECT_FALSE(g_rcutils_logging_initialized);
+  }
+};
+
+TEST_F(TestProtobufLogging, test_setup_message)
+{
+  SET_ROS_PROTOBUF_LOG_HANDLER(logger_name);
+  EXPECT_EQ(1u, log_calls);
+  EXPECT_EQ(RCUTILS_LOG_SEVERITY_INFO, last_log_event.level);
+  EXPECT_EQ(logger_name, last_log_event.name);
+  EXPECT_EQ("Routing protobuf logs through ROS", last_log_event.message);
+}
+
+TEST_F(TestProtobufLogging, test_info)
+{
+  SET_ROS_PROTOBUF_LOG_HANDLER(logger_name);
+  GOOGLE_LOG(INFO) << "Info log";
+  EXPECT_EQ(2u, log_calls);
+  EXPECT_EQ(RCUTILS_LOG_SEVERITY_INFO, last_log_event.level);
+  EXPECT_EQ(logger_name, last_log_event.name);
+  EXPECT_THAT(
+    last_log_event.message,
+    ::testing::MatchesRegex("\\[.*test_protobuf_logging\\.cpp\\:[0-9]+\\] Info log"));
+}
+
+TEST_F(TestProtobufLogging, test_warning)
+{
+  SET_ROS_PROTOBUF_LOG_HANDLER(logger_name);
+  GOOGLE_LOG(WARNING) << "Warning log";
+  EXPECT_EQ(2u, log_calls);
+  EXPECT_EQ(RCUTILS_LOG_SEVERITY_WARN, last_log_event.level);
+  EXPECT_EQ(logger_name, last_log_event.name);
+  EXPECT_THAT(
+    last_log_event.message,
+    ::testing::MatchesRegex("\\[.*test_protobuf_logging\\.cpp\\:[0-9]+\\] Warning log"));
+}
+
+TEST_F(TestProtobufLogging, test_error)
+{
+  SET_ROS_PROTOBUF_LOG_HANDLER(logger_name);
+  GOOGLE_LOG(ERROR) << "Error log";
+  EXPECT_EQ(2u, log_calls);
+  EXPECT_EQ(RCUTILS_LOG_SEVERITY_ERROR, last_log_event.level);
+  EXPECT_EQ(logger_name, last_log_event.name);
+  EXPECT_THAT(
+    last_log_event.message,
+    ::testing::MatchesRegex("\\[.*test_protobuf_logging\\.cpp\\:[0-9]+\\] Error log"));
+}
+
+TEST_F(TestProtobufLogging, test_fatal)
+{
+  SET_ROS_PROTOBUF_LOG_HANDLER(logger_name);
+  try {
+    GOOGLE_LOG(FATAL) << "Fatal log";
+  } catch (const google::protobuf::FatalException &) {
+    // ignore the exception thrown every time fatal errors are logged
+  }
+  EXPECT_EQ(2u, log_calls);
+  EXPECT_EQ(RCUTILS_LOG_SEVERITY_FATAL, last_log_event.level);
+  EXPECT_EQ(logger_name, last_log_event.name);
+  EXPECT_THAT(
+    last_log_event.message,
+    ::testing::MatchesRegex("\\[.*test_protobuf_logging\\.cpp\\:[0-9]+\\] Fatal log"));
+}


### PR DESCRIPTION
While working more on the ref bridge, I ran into some protobuf errors and figured this might be useful.

By default, protobuf just logs error details to the standard error stream. The macro added here, `SET_ROS_PROTOBUF_LOG_HANDLER`, redirects all protobuf logs through the ROS logging system. Puts all of our logs in the same place for nodes that use protobuf.

It's a macro because protobuf's `SetLogHandler` only accepts a raw function pointer. Lambdas with captures can't decompose to a function pointer, so I'm using the macro to get the logger name into the lambda at compile time. Very open to ideas if anyone can figure out a cleaner way to do this.