### PR TITLE
First pass at in-GUI Game Controller buttons

### DIFF
--- a/ateam_ui/src/src/App.vue
+++ b/ateam_ui/src/src/App.vue
@@ -5,6 +5,7 @@
         </v-app-bar>
         <v-main>
             <v-container class="d-flex flex-row" ref="Main Components">
+                <RefButtonsComponent/>
                 <StatusComponent/>
                 <FieldComponent/>
             </v-container>
@@ -16,6 +17,7 @@
 <script lang="js">
 import FieldComponent from './components/FieldComponent.vue'
 import StatusComponent from './components/StatusComponent.vue'
+import RefButtonsComponent from './components/RefButtonsComponent.vue'
 import { provide } from 'vue'
 
 export default {
@@ -78,9 +80,10 @@ export default {
         }
     },
     components: {
-        FieldComponent,
-        StatusComponent
-    }
+    FieldComponent,
+    StatusComponent,
+    RefButtonsComponent
+}
 }
 
 </script>

--- a/ateam_ui/src/src/components/RefButtonsComponent.vue
+++ b/ateam_ui/src/src/components/RefButtonsComponent.vue
@@ -1,0 +1,60 @@
+<template>
+    <v-container class="d-flex flex-column">
+        <b>Game Controller</b>
+        <v-btn
+            id="gc_start_button"
+            color="green"
+            class="d-flex my-1 justify-space-around"
+            v-on:click="sendGCCommand('NORMAL_START')">Start</v-btn>
+        <v-btn
+            id="gc_force_start_button"
+            color="green-darken-4"
+            class="d-flex my-1 justify-space-around"
+            v-on:click="sendGCCommand('FORCE_START')">Force Start</v-btn>
+        <v-btn
+            id="gc_stop_button"
+            color="red"
+            class="d-flex my-1 justify-space-around"
+            v-on:click="sendGCCommand('STOP')">Stop</v-btn>
+        <v-btn
+            id="gc_halt_button"
+            color="red-darken-4"
+            class="d-flex my-1 justify-space-around"
+            v-on:click="sendGCCommand('HALT')">Halt</v-btn>
+    </v-container>
+</template>
+
+<script lang="js">
+
+export default {
+    data: function() {
+        return {
+            connection: null
+        }
+    },
+    created: function() {
+        console.log("Opening API websocket connection to GC")
+        // TODO(barulicm) The GC IP and port should be parameterized. Not sure how.
+        this.connection = new WebSocket("ws://localhost:8081/api/control")
+        this.connection.onmessage = function(event) {
+            // TODO(barulicm) enable / disable buttons based on game state?
+        }
+        this.connection.onopen = function(event) {
+            console.log("Successfully connected to the GC API server.")
+        }
+        this.connection.onerror = function(event) {
+            console.log(event)
+            document.getElementById("gc_start_button").disabled = true;
+            document.getElementById("gc_force_start_button").disabled = true;
+            document.getElementById("gc_stop_button").disabled = true;
+            document.getElementById("gc_halt_button").disabled = true;
+        }
+    },
+    methods: {
+        sendGCCommand: function(command_type) {
+            console.log("Sending GC command: " + command_type)
+            this.connection.send('{ "change": {"origin":"UI", "revertible":true, "newCommand":{"command":{"type":"' + command_type + '", "forTeam":"UNKNOWN"}}}}')
+        }
+    }
+}
+</script>

--- a/ateam_ui/src/src/components/RefButtonsComponent.vue
+++ b/ateam_ui/src/src/components/RefButtonsComponent.vue
@@ -5,22 +5,28 @@
             id="gc_start_button"
             color="green"
             class="d-flex my-1 justify-space-around"
-            v-on:click="sendGCCommand('NORMAL_START')">Start</v-btn>
+            v-on:click="sendGCCommand('NORMAL_START', 'UNKNOWN')"
+            :disabled="!normalStartAllowed">Start</v-btn>
         <v-btn
             id="gc_force_start_button"
             color="green-darken-4"
             class="d-flex my-1 justify-space-around"
-            v-on:click="sendGCCommand('FORCE_START')">Force Start</v-btn>
+            v-on:click="sendGCCommand('FORCE_START', 'UNKNOWN')"
+            :disabled="!forceStartAllowed">Force Start</v-btn>
         <v-btn
             id="gc_stop_button"
             color="red"
             class="d-flex my-1 justify-space-around"
-            v-on:click="sendGCCommand('STOP')">Stop</v-btn>
+            v-on:click="sendGCCommand('STOP', 'UNKNOWN')"
+            :disabled="!stopAllowed">Stop</v-btn>
         <v-btn
             id="gc_halt_button"
             color="red-darken-4"
             class="d-flex my-1 justify-space-around"
-            v-on:click="sendGCCommand('HALT')">Halt</v-btn>
+            v-on:click="sendGCCommand('HALT', 'UNKNOWN')"
+            :disabled="!haltAllowed">Halt</v-btn>
+        <!-- TODO(barulicm) Add a settings modal for chaning GC address / reconnecting. -->
+        <!-- TODO(barulicm) Add buttons / drop down for sending team-specific commands (ie. blue kickoff). -->
     </v-container>
 </template>
 
@@ -29,32 +35,65 @@
 export default {
     data: function() {
         return {
-            connection: null
+            gcAddress: "ws://localhost:8081",
+            connection: null,
+            connectionState: WebSocket.CLOSED
         }
     },
     created: function() {
-        console.log("Opening API websocket connection to GC")
-        // TODO(barulicm) The GC IP and port should be parameterized. Not sure how.
-        this.connection = new WebSocket("ws://localhost:8081/api/control")
-        this.connection.onmessage = function(event) {
-            // TODO(barulicm) enable / disable buttons based on game state?
-        }
-        this.connection.onopen = function(event) {
-            console.log("Successfully connected to the GC API server.")
-        }
-        this.connection.onerror = function(event) {
-            console.log(event)
-            document.getElementById("gc_start_button").disabled = true;
-            document.getElementById("gc_force_start_button").disabled = true;
-            document.getElementById("gc_stop_button").disabled = true;
-            document.getElementById("gc_halt_button").disabled = true;
-        }
+        this.attemptToConnect()
+    },
+    beforeUnmount: function() {
+        this.connection.close()
     },
     methods: {
-        sendGCCommand: function(command_type) {
-            console.log("Sending GC command: " + command_type)
-            this.connection.send('{ "change": {"origin":"UI", "revertible":true, "newCommand":{"command":{"type":"' + command_type + '", "forTeam":"UNKNOWN"}}}}')
+        sendGCCommand: function(command_type, team) {
+            this.connection.send(JSON.stringify({
+                change: {
+                    origin: "UI",
+                    revertible: true,
+                    newCommand: {
+                        command: {
+                            type: command_type,
+                            forTeam: team
+                        }
+                    }
+                }
+            }))
+        },
+        attemptToConnect: function() {
+            var vue_object = this
+            this.connection = new WebSocket(this.gcAddress + "/api/control")
+            this.connection.onmessage = function(event) {
+                // TODO(barulicm) enable / disable buttons based on game state?
+            }
+            this.connection.onopen = function(event) {
+                console.log("Connected to the GC API server.")
+                vue_object.connectionState = event.target.readyState
+            }
+            this.connection.onerror = function(event) {
+                console.log("Error communicating with GC API server:")
+                console.log(event)
+                vue_object.connectionState = event.target.readyState
+            }
+            this.connection.onclose = function(event) {
+                vue_object.connectionState = event.target.readyState
+            }
         }
+    },
+    computed: {
+        normalStartAllowed() {
+            return this.connectionState === WebSocket.OPEN
+        },
+        forceStartAllowed() {
+            return this.connectionState === WebSocket.OPEN
+        },
+        stopAllowed() {
+            return this.connectionState === WebSocket.OPEN
+        },
+        haltAllowed() {
+            return this.connectionState === WebSocket.OPEN
+        },
     }
 }
 </script>


### PR DESCRIPTION
This adds an MVP GUI component that provides the 4 basic game controller command buttons (start, force start, stop, and halt). Still lots of room for making this better, but I wanted to start small and make sure I'm not way off track with the vue / JS stuff before getting too far in.

These buttons talk directly to the GC using its "API websocket." (Same way the GC's GUI sends updates.) Any updates triggered by our UI are thus indistinguishable from those triggered by the GC's GUI, so they propagate through our system via our existing bridge and ROS topics.

Related to #14 and #6