### PR TITLE
Move robots in circles using trapz

### DIFF
--- a/ateam_ai/src/behavior/behavior_evaluator.cpp
+++ b/ateam_ai/src/behavior/behavior_evaluator.cpp
@@ -22,6 +22,7 @@
 
 #include <functional>
 #include <vector>
+#include <cmath>
 
 #include "behavior/behavior_feedback.hpp"
 
@@ -70,13 +71,20 @@ DirectedGraph<Behavior> BehaviorEvaluator::get_best_behaviors(const World & worl
 
   // direct_shot.add_node(shot);
 
+  // Generate 16 move behaviors towards the ball, we'll figure out which
+  // ones we can fill later
   DirectedGraph<Behavior> simple_move;
-  Behavior move{
-    Behavior::Type::MoveToPoint,
-    Behavior::Priority::Required,
-    MoveParam(world.get_unique_ball().value_or(Ball()).pos)};
+  static double j = 0;
+  j += 0.002;
+  for (int i = 0; i < 16; i++) {
+    double theta = i / 11.0 * 3.14 * 2 + j;
+    Behavior move{
+      Behavior::Type::MoveToPoint,
+      Behavior::Priority::Required,
+      MoveParam(Eigen::Vector2d{cos(theta) - 2, sin(theta)})};
 
-  simple_move.add_node(move);
+    simple_move.add_node(move);
+  }
 
   //
   // Add background behaviors

--- a/ateam_ai/src/behavior/behavior_realization.cpp
+++ b/ateam_ai/src/behavior/behavior_realization.cpp
@@ -30,11 +30,30 @@ DirectedGraph<BehaviorFeedback> BehaviorRealization::realize_behaviors(
 
   // Assign robots to behaviors
   // Calculate the BehaviorFeedback and build the same directed graph shape
-  // BehaviorFeedback feedback =
-  //    trajectory_generation.get_feedback_from_behavior(
-  //    behavior,
-  //    assigned_robot,
-  //    world);
+
+
+  // Just assign robots in number order if they are available
+  std::size_t robot_id = 0;
+  for (const auto & root_id : behaviors.get_root_nodes()) {
+    // Assume there are no children for now
+    const auto & root_node = behaviors.get_node(root_id);
+
+    while (robot_id < world.our_robots.size() && !world.our_robots.at(robot_id).has_value()) {
+      robot_id++;
+    }
+    if (robot_id < world.our_robots.size()) {
+      BehaviorFeedback feedback =
+        trajectory_generation.get_feedback_from_behavior(
+        root_node,
+        robot_id,
+        world);
+      behavior_results.add_node(feedback);
+      robot_id++;
+    } else {
+      // If we don't have enough robots, show the behavior isn't assigned
+      behavior_results.add_node(BehaviorFeedback());
+    }
+  }
 
   return behavior_results;
 }


### PR DESCRIPTION
Part 2: Integrate the trapezoidal motion planner into a simple spinning circle behavior. This results in using the evaluator + realization + feedback system closer to how it's supposed to be used.

Closes #20 for now. I think we can avoid doing obstacle avoidance for now.