### PR TITLE
Changes the UI field dimensions to match Div A rules.

### DIFF
--- a/ateam_ui/src/src/App.vue
+++ b/ateam_ui/src/src/App.vue
@@ -47,27 +47,28 @@ export default {
                 },
                 underlays: {},
                 overlays: {},
+                // Using Div A dimensions
                 fieldDimensions: {
-                    length: 9,
-                    width: 6,
+                    length: 12,
+                    width: 9,
                     border: .7,
                     lineWidth: .01,
-                    goalWidth: 1,
+                    goalWidth: 1.8,
                     goalDepth: .18,
                     goalHeight: .16,
-                    penaltyShort: 1,
-                    penaltyLong: 2,
+                    penaltyShort: 1.8,
+                    penaltyLong: 3.6,
                     centerRadius: .5,
                     centerDiameter: 1,
                     goalFlat: .5,
-                    floorLength: 10.4,
-                    floorWidth: 7.4
+                    floorLength: 13.4,
+                    floorWidth: 10.4
                 }
             },
             renderConfig: {
                 angle: 0,
-                scale: 300, // Pixels per meter
-                factor: .4 // Field Scaling Factor
+                scale: 300, // Pixels per meter (in the rendering canvas)
+                factor: .25 // Field Scaling Factor (applied to the canvas when it's added to the UI)
             }
         }
     },


### PR DESCRIPTION
Fixes #53 

Dimensions pulled from [figure 1 in section 2.1.1 in the league rules](https://robocup-ssl.github.io/ssl-rules/sslrules.html#field-dimensions-a).

Scaling adjust to keep new field similar in size to previous field render.