### PR TITLE
Add immutable duration (#5)

### DIFF
--- a/ateam_ai/src/behavior/behavior_executor.cpp
+++ b/ateam_ai/src/behavior/behavior_executor.cpp
@@ -64,17 +64,17 @@ std::array<std::optional<Trajectory>, 16> BehaviorExecutor::execute_behaviors(
       Trajectory trajectory = root_node.trajectory;
       std::size_t assigned_robot = root_node.assigned_robot_id.value();
 
-      Sample3d command;
-      if (root_node.trajectory.samples.size() >= 2) {
-        command = root_node.trajectory.samples.at(1);  // Where I want to be next frame
-      } else if (root_node.trajectory.samples.size() == 1) {
-        // Already at target since only sample is current position
-        command = root_node.trajectory.samples.front();
-      } else {
-        continue;
+      if (self_state.previous_trajectories.at(assigned_robot).has_value()) {
+        const double immutable_duration = 0.1;
+        const double dt = 0.01;
+        trajectory = trajectory_editor::apply_immutable_duration(
+          self_state.previous_trajectories.at(assigned_robot).value(),
+          trajectory,
+          immutable_duration,
+          dt, world.current_time);
       }
 
-      output_trajectories.at(assigned_robot) = root_node.trajectory;
+      output_trajectories.at(root_node.assigned_robot_id.value()) = root_node.trajectory;
       self_state.previous_trajectories.at(assigned_robot) = trajectory;
     }
   }

--- a/ateam_ai/src/trajectory_generation/trajectory_generation.cpp
+++ b/ateam_ai/src/trajectory_generation/trajectory_generation.cpp
@@ -20,6 +20,7 @@
 
 #include "trajectory_generation/trajectory_generation.hpp"
 
+#include "trajectory_generation/trajectory_editor.hpp"
 #include "trajectory_generation/trapezoidal_motion_profile.hpp"
 
 BehaviorFeedback TrajectoryGeneration::get_feedback_from_behavior(
@@ -47,13 +48,15 @@ BehaviorFeedback TrajectoryGeneration::get_feedback_from_behavior(
 
     case Behavior::Type::MoveToPoint:
       {
+        Robot current_robot = world.plan_from_our_robots.at(assigned_robot).value();
+
         Eigen::Vector3d current, current_vel, target, target_vel;
-        current.x() = world.our_robots.at(assigned_robot).value().pos.x();
-        current.y() = world.our_robots.at(assigned_robot).value().pos.y();
-        current.z() = 0;  // world.our_robots.at(assigned_robot).value().theta;
-        current_vel.x() = world.our_robots.at(assigned_robot).value().vel.x();
-        current_vel.y() = world.our_robots.at(assigned_robot).value().vel.y();
-        current_vel.z() = 0;  // world.our_robots.at(assigned_robot).value().omega;
+        current.x() = current_robot.pos.x();
+        current.y() = current_robot.pos.y();
+        current.z() = 0;  // current_robot.theta;
+        current_vel.x() = current_robot.vel.x();
+        current_vel.y() = current_robot.vel.y();
+        current_vel.z() = 0;  // current_robot.omega;
 
         target.x() = std::get<MoveParam>(behavior.params).target_location.x();
         target.y() = std::get<MoveParam>(behavior.params).target_location.y();
@@ -64,10 +67,12 @@ BehaviorFeedback TrajectoryGeneration::get_feedback_from_behavior(
         Eigen::Vector3d max_vel{2, 2, 0.5};  // TODO(jneiger): Set as params
         Eigen::Vector3d max_accel{2, 2, 0.5};
         double dt = 0.01;  // TODO(jneiger): Feed this down from above
-        feedback.trajectory = TrapezoidalMotionProfile::Generate3d(
+        Trajectory trajectory = TrapezoidalMotionProfile::Generate3d(
           current, current_vel, target,
           target_vel, max_vel, max_accel,
           dt, world.current_time);
+
+        feedback.trajectory = trajectory;
       }
       break;
 

--- a/ateam_ai/src/types/world.hpp
+++ b/ateam_ai/src/types/world.hpp
@@ -57,6 +57,8 @@ struct World
   std::array<std::optional<Robot>, 16> our_robots;
   std::array<std::optional<Robot>, 16> their_robots;
 
+  std::array<std::optional<Robot>, 16> plan_from_our_robots;
+
   BehaviorExecutorState behavior_executor_state;
 };
 


### PR DESCRIPTION
Adds an immutable duration which results in the next X seconds of the trajectory being locked in and unable to be replanned. 

Adds `plan_from` robot states which are the robot states at the end of the immutable duration. All planning is done using the planned position instead of the actual measured position. It's up to the behavior_follower to keep up

Part 5 for #68 