### PR TITLE
Change initial robot placement to scale based off renderConfig.scale

### DIFF
--- a/ateam_ui/src/src/main.js
+++ b/ateam_ui/src/src/main.js
@@ -40,8 +40,8 @@ for (var team in vm.state.teams) {
             team: team,
             pose: {
                 position: {
-                    x: (70*(i+xoffset)) - (70*(numVisible-1)/2),
-                    y: (120*yoffset) - 60
+                    x: vm.renderConfig.scale * 0.23 * (i+xoffset - ((numVisible-1)/2)),
+                    y: vm.renderConfig.scale * (0.4*yoffset) - 0.2
                 },
                 orientation: {}
             },


### PR DESCRIPTION
This should help fix the issue where using different resolutions or field dimensions results in the robots being overlapped or placed in weird locations.