### PR TITLE
Add iLQR interface

### DIFF
--- a/ateam_ai/CMakeLists.txt
+++ b/ateam_ai/CMakeLists.txt
@@ -60,6 +60,7 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(${PROJECT_NAME}_test
+    test/trajectory_generation/ilqr_problem_test.cpp
     test/trajectory_generation/trajectory_editor_test.cpp
     test/trajectory_generation/trapezoidal_motion_profile_test.cpp
   )

--- a/ateam_ai/CMakeLists.txt
+++ b/ateam_ai/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(${PROJECT_NAME} SHARED
   src/behavior/behavior_realization.cpp
   src/behavior/behavior_realization.hpp
   src/behavior/behavior.hpp
+  src/trajectory_generation/ilqr_problem.hpp
   src/trajectory_generation/trajectory_editor.cpp
   src/trajectory_generation/trajectory_editor.hpp
   src/trajectory_generation/trajectory_generation.cpp

--- a/ateam_ai/src/trajectory_generation/ilqr_problem.hpp
+++ b/ateam_ai/src/trajectory_generation/ilqr_problem.hpp
@@ -1,0 +1,256 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef TRAJECTORY_GENERATION__ILQR_PROBLEM_HPP_
+#define TRAJECTORY_GENERATION__ILQR_PROBLEM_HPP_
+
+#include <Eigen/Dense>
+
+// Defines the abstract definition and solution to the iLQR problem
+// https://homes.cs.washington.edu/~todorov/papers/TassaICRA14.pdf
+// https://studywolf.wordpress.com/2016/02/03/the-iterative-linear-quadratic-regulator-method/
+// X = num states, U = num inputs, T = num timesteps
+template<typename X, typename U, typename T>
+class iLQRProblem {
+public:
+  using State = Eigen::Vector<X>;
+  using Input = Eigen::Vector<U>;
+  using Jacobian = Eigen::Matrix<X, X + U>;
+  using Cost = double;
+  using Gradiant = Eigen::Vector<X + U>;
+  using Hessian = Eigen::Matrix<X + U, X + U>;
+  using Time = int;
+
+  using Trajectory = std::array<State, T>;
+  using Actions = std::array<Input, T>;
+
+  using Feedforwards = std::array<Input, T>;
+  using Feedbacks = std::array<Eigen::Matrix<U, X>, T>;
+
+  // Assume second derivative of dynamics is 0 so we don't have do tensor math
+  virtual State dynamics(const State& x_t1, const Input& u_t1, Time t) = 0;
+  virtual Jacobian jacobian(const State& x, const Input& u, Time t) {
+    Jacobian out;
+
+    State d = dynamics(x, u, t);
+    for (std::size_t i = 0; i < X; i++) {
+      State x_eps = x;
+      x_eps(i) += eps;
+      out.col(i) = (dynamics(x_eps, u, t) - d) / eps;
+    }
+
+    for (std::size_t i = 0; i < U; i++) {
+      Input u_eps = u;
+      u_eps(i) += eps;
+      out.col(i + X) = (dynamics(x, u_eps, t) - d) / eps;
+    }
+
+    return out;
+  }
+
+  virtual Cost cost(const State& x, const Input& u, Time t) = 0;
+  virtual Gradiant gradiant(const State& x, const Input& u, Time t) {
+    Gradiant out;
+
+    Cost c = cost(x, u, t);
+    for (std::size_t i = 0; i < X; i++) {
+      State x_eps = x;
+      x_eps(i) += eps;
+      out(i) = (cost(x_eps, u, t) - c) / eps;
+    }
+
+    for (std::size_t i = 0; i < U; i++) {
+      Input u_eps = u;
+      u_eps(i) += eps;
+      out(i + X) = (cost(x, u_eps, t) - c) / eps;
+    }
+
+    return out;
+  }
+
+  virtual Hessian hessian(const State& x, const Input& u, Time t, const Gradiant& g) {
+    Hessian out;
+
+    for (std::size_t i = 0; i < X; i++) {
+      State x_eps = x;
+      x_eps(i) += eps;
+      out.col(i) = (gradiant(x_eps, u, t) - g) / eps;
+    }
+
+    for (std::size_t i = 0; i < U; i++) {
+      Input u_eps = u;
+      u_eps(i) += eps;
+      out.col(i + X) = (gradiant(x, u_eps, t) - g) / eps;
+    }
+
+    return out;
+  }
+
+  Trajectory calculate(const State& initial_state) {
+    forward_rollout(initial_state);
+    backward_pass();
+
+    return trajectory;
+  }
+
+private:
+  using Jacobians = std::array<Jacobian, T>;
+  using Hessians = std::array<Hessian, T>;
+  using Gradiants = std::array<Gradiant, T>;
+
+
+  void forward_rollout(const State& initial_state) {
+    // Step 1: Forward Rollout
+    trajectory.front() = initial_state;
+    actions.front() = Input::Zeros();
+    overall_cost = cost(trajectory.at(0), actions.at(0), 0);
+
+    for (Time t = 1; t < T; t++) {
+      trajectory.at(t) = trajectory.at(t - 1) + dynamics(trajectory.at(t - 1), actions.at(i - 1));
+      actions.at(t) = Input::Zeros();
+      overall_cost += cost(trajectory.at(t), actions.at(t), t);
+    }
+
+    // Step 2: Calculate jacobian/hessian for x,u
+    for (Time t = 0; t < T; i++) {
+      j.at(t) = jacobian(trajectory.at(t), actions.at(t), t);
+
+      g.at(t) = gradiant(trajectory.at(t), actions.at(t), t);
+      h.at(t) = hessian(trajectory.at(t), actions.at(t), t, j.at(t));
+    }
+  }
+
+  void backward_pass() {
+    std::size_t num_iterations = 0;
+
+    while (num_iterations < max_num_iterations) {
+      // Step 3: Determine best control signal update
+      // Determine 
+      Feedforwards k;
+      Feedbacks K;
+
+      Cost cost_at_next_time;
+      Gradiant q_dxu; // Derivative of V(f(x, u))
+      Hessian q_ddxu;
+      Gradiant v_dx = g.back(); // Derivative of V(x)
+      Hessian v_ddx = h.back();
+
+      k.at(T - 1) = k.at(T - 1)::Zeros();
+      K.at(T - 1) = K.at(T - 1)::Zeros();
+
+      for (Time t = T - 2; t >= 0; t--) {
+        // eq 4a
+        Q_dxu.block<X, 1>(0, 0) =
+          g.at(t).block<X, 1>(0, 0) +
+          j.at(t).block<X, X>(0, 0).transpose() *
+          v_dx.block<X, 1>(0, 0);
+        // eq 4b
+        Q_dxu.block<U, 1>(X, 0) =
+          g.at(t).block<U, 1>(X, 0) +
+          j.at(t).block<X, U>(0, X).transpose() *
+          v_dx.block<X, 1>(X, 0);
+        // eq 4c
+        Q_ddxu.block<X, X>(0, 0) =
+          h.at(t).block<X, X>(0, 0) +
+          j.at(t).block<X, X>(0, 0).transpose() *
+          v_ddx.block<X, X>(0, 0) *
+          j.at(t).block<X, X>(0, 0);
+        // eq 4d
+        Q_ddxu.block<U, X>(X, 0) =
+          h.at(t).block<U, X>(X, 0) +
+          j.at(t).block<X, U>(0, X).transpose() *
+          v_ddx.block<X, X>(0, 0) *
+          j.at(t).block<X, U>(0, X);
+        // eq 4e
+        Q_ddxu.block<U, U>(X, X) =
+          g.at(t).block<U, U>(X, X) +
+          j.at(t).block<X, U>(0, X).transpose() *
+          v_ddx.block<X, X>(0, 0) *
+          j.at(t).block<X, U>(0, X);
+
+        // eq 5b
+        k.at(t) = -Q_ddxu.block<U, U>(X, X).inverse() * Q_dxu.block<U, 1>(X, 0);
+        K.at(t) = -Q_ddxu.block<U, U>(X, X).inverse() * Q_ddxu.block<U, X>(X, 0);
+
+        // eq 6b
+        v_dx = Q_dxu.block<X, 1>(0, 0) - K.at(t).transpose() * Q_ddxu.block<U, U>(X, X) * k.at(t);
+        // eq 6c
+        v_ddx = Q_ddxu.block<X, X>(0, 0) - K.at(t).transepose() * Q_ddxu.block<U, U>(X, X) * K.at(t);
+      }
+
+      // Step 3.5: Update possible control signal, states, costs
+      Cost test_cost;
+      Trajectory test_trajectory;
+      Actions test_actions;
+      test_trajectory.at(0) = trajectory.at(0);
+      test_actions.at(0) = actions.at(0) + k.at(t);  // xhat_0 == x_0 so Kt term goes away
+      test_cost = cost(test_trajectory.at(0), test_actions.at(0), 0);
+      for (Time t = 1; t < T; t++) {
+        test_trajectory.at(t) = test_trajectory.at(t - 1) + dynamics(test_trajectory.at(t - 1), test_actions.at(t - 1));
+        test_actions.at(t) = actions.at(t) + alpha * k.at(t) + K.at(t) * (test_trajectory.at(t) - trajectory.at(t));
+        test_cost = cost(test_trajectory.at(t), test_actions.at(t), t);
+      }
+
+      // Step 4: Compare Costs and update update size
+      if (test_cost < overall_cost) {
+        trajectory = test_trajectory;
+        actions = test_actions;
+
+        // If we converge, just return
+        if (std::abs(test_cost - overall_cost) / test_cost < converge_threshold) {
+          return;
+        }
+
+        overall_cost = test_cost;
+
+        // Step 4.5: Calculate jacobian/hessian for x,u
+        for (Time t = 0; t < T; i++) {
+          j.at(t) = jacobian(trajectory.at(t), actions.at(t), t);
+
+          g.at(t) = gradiant(trajectory.at(t), actions.at(t), t);
+          h.at(t) = hessian(trajectory.at(t), actions.at(t), t, j.at(t));
+        }
+
+        alpha *= alpha_change;
+      } else {
+        alpha /= alpha_change;
+      }
+
+      num_iterations++;
+    }
+  }
+
+  constexpr std::size_t max_num_iterations = 100;
+  constexpr double converge_threshold = 0.1;
+  constexpr double alpha_change = 0.9;
+  constexpr double eps = 1e-5;
+
+  double alpha = 1;  // backtracking serach parameter
+  Trajectory trajectory;
+  Actions actions;
+
+  Jacobians j;
+  Gradiants g;
+  Hessians h;
+
+  Cost overall_cost;
+};
+
+#endif  // TRAJECTORY_GENERATION__ILQR_PROBLEM_HPP_

--- a/ateam_ai/src/trajectory_generation/ilqr_problem.hpp
+++ b/ateam_ai/src/trajectory_generation/ilqr_problem.hpp
@@ -22,31 +22,34 @@
 #define TRAJECTORY_GENERATION__ILQR_PROBLEM_HPP_
 
 #include <Eigen/Dense>
+#include <iostream>
 
 // Defines the abstract definition and solution to the iLQR problem
 // https://homes.cs.washington.edu/~todorov/papers/TassaICRA14.pdf
 // https://studywolf.wordpress.com/2016/02/03/the-iterative-linear-quadratic-regulator-method/
 // X = num states, U = num inputs, T = num timesteps
-template<typename X, typename U, typename T>
-class iLQRProblem {
+template<int X, int U, int T>
+class iLQRProblem
+{
 public:
-  using State = Eigen::Vector<X>;
-  using Input = Eigen::Vector<U>;
-  using Jacobian = Eigen::Matrix<X, X + U>;
+  using State = Eigen::Matrix<double, X, 1>;
+  using Input = Eigen::Matrix<double, U, 1>;
+  using Jacobian = Eigen::Matrix<double, X, X + U>;
   using Cost = double;
-  using Gradiant = Eigen::Vector<X + U>;
-  using Hessian = Eigen::Matrix<X + U, X + U>;
+  using Gradiant = Eigen::Matrix<double, X + U, 1>;
+  using Hessian = Eigen::Matrix<double, X + U, X + U>;
   using Time = int;
 
   using Trajectory = std::array<State, T>;
   using Actions = std::array<Input, T>;
 
   using Feedforwards = std::array<Input, T>;
-  using Feedbacks = std::array<Eigen::Matrix<U, X>, T>;
+  using Feedbacks = std::array<Eigen::Matrix<double, U, X>, T>;
 
   // Assume second derivative of dynamics is 0 so we don't have do tensor math
-  virtual State dynamics(const State& x_t1, const Input& u_t1, Time t) = 0;
-  virtual Jacobian jacobian(const State& x, const Input& u, Time t) {
+  virtual State dynamics(const State & x_t1, const Input & u_t1, Time t) = 0;
+  virtual Jacobian jacobian(const State & x, const Input & u, Time t)
+  {
     Jacobian out;
 
     State d = dynamics(x, u, t);
@@ -65,27 +68,32 @@ public:
     return out;
   }
 
-  virtual Cost cost(const State& x, const Input& u, Time t) = 0;
-  virtual Gradiant gradiant(const State& x, const Input& u, Time t) {
+  virtual Cost cost(const State & x, const Input & u, Time t) = 0;
+  virtual Gradiant gradiant(const State & x, const Input & u, Time t)
+  {
     Gradiant out;
 
-    Cost c = cost(x, u, t);
     for (std::size_t i = 0; i < X; i++) {
-      State x_eps = x;
-      x_eps(i) += eps;
-      out(i) = (cost(x_eps, u, t) - c) / eps;
+      State x_eps_p = x;
+      State x_eps_n = x;
+      x_eps_p(i) += eps;
+      x_eps_n(i) -= eps;
+      out(i) = (cost(x_eps_p, u, t) - cost(x_eps_n, u, t)) / (2*eps);
     }
 
     for (std::size_t i = 0; i < U; i++) {
-      Input u_eps = u;
-      u_eps(i) += eps;
-      out(i + X) = (cost(x, u_eps, t) - c) / eps;
+      Input u_eps_p = u;
+      Input u_eps_n = u;
+      u_eps_p(i) += eps;
+      u_eps_n(i) -= eps;
+      out(i + X) = (cost(x, u_eps_p, t) - cost(x, u_eps_n, t)) / (2*eps);
     }
 
     return out;
   }
 
-  virtual Hessian hessian(const State& x, const Input& u, Time t, const Gradiant& g) {
+  virtual Hessian hessian(const State & x, const Input & u, Time t, const Gradiant & g)
+  {
     Hessian out;
 
     for (std::size_t i = 0; i < X; i++) {
@@ -103,9 +111,13 @@ public:
     return out;
   }
 
-  Trajectory calculate(const State& initial_state) {
+  Trajectory calculate(const State & initial_state)
+  {
+    std::cout << "Forward rollout" << std::endl;
     forward_rollout(initial_state);
+    std::cout << "Backward pass" << std::endl;
     backward_pass();
+    std::cout << "Return" << std::endl;
 
     return trajectory;
   }
@@ -116,83 +128,115 @@ private:
   using Gradiants = std::array<Gradiant, T>;
 
 
-  void forward_rollout(const State& initial_state) {
+  void forward_rollout(const State & initial_state)
+  {
     // Step 1: Forward Rollout
     trajectory.front() = initial_state;
-    actions.front() = Input::Zeros();
+    actions.front().setZero();
     overall_cost = cost(trajectory.at(0), actions.at(0), 0);
 
     for (Time t = 1; t < T; t++) {
-      trajectory.at(t) = trajectory.at(t - 1) + dynamics(trajectory.at(t - 1), actions.at(i - 1));
-      actions.at(t) = Input::Zeros();
+      trajectory.at(t) = dynamics(trajectory.at(t - 1), actions.at(t - 1), t);
+      actions.at(t).setZero();
       overall_cost += cost(trajectory.at(t), actions.at(t), t);
     }
 
     // Step 2: Calculate jacobian/hessian for x,u
-    for (Time t = 0; t < T; i++) {
+    for (Time t = 0; t < T; t++) {
       j.at(t) = jacobian(trajectory.at(t), actions.at(t), t);
 
       g.at(t) = gradiant(trajectory.at(t), actions.at(t), t);
-      h.at(t) = hessian(trajectory.at(t), actions.at(t), t, j.at(t));
+      h.at(t) = hessian(trajectory.at(t), actions.at(t), t, g.at(t));
     }
+
+    std::cout << "Initial cost " << overall_cost << std::endl;
   }
 
-  void backward_pass() {
+  void backward_pass()
+  {
     std::size_t num_iterations = 0;
 
     while (num_iterations < max_num_iterations) {
       // Step 3: Determine best control signal update
-      // Determine 
       Feedforwards k;
       Feedbacks K;
 
-      Cost cost_at_next_time;
-      Gradiant q_dxu; // Derivative of V(f(x, u))
-      Hessian q_ddxu;
-      Gradiant v_dx = g.back(); // Derivative of V(x)
-      Hessian v_ddx = h.back();
+      Gradiant Q_dxu;  // Derivative of V(f(x, u))
+      Hessian Q_ddxu;
+      State v_dx = g.back().block(0, 0, X, 1);  // Derivative of V(x)
+      Eigen::Matrix<double, X, X> v_ddx = h.back().block(0, 0, X, X);
+      // std::cout << "g.at(t).block(0, 0, X, 1) " << g.back().block(0, 0, X, 1).norm() << std::endl;
+      // std::cout << "j.at(t).block(0, 0, X, 1) " << j.back().block(0, 0, X, X).norm() << std::endl;
+      // std::cout << "h.at(t).block(0, 0, X, 1) " << h.back().block(0, 0, X, X).norm() << std::endl;
 
-      k.at(T - 1) = k.at(T - 1)::Zeros();
-      K.at(T - 1) = K.at(T - 1)::Zeros();
+      k.at(T - 1).setZero();
+      K.at(T - 1).setZero();
 
       for (Time t = T - 2; t >= 0; t--) {
         // eq 4a
-        Q_dxu.block<X, 1>(0, 0) =
-          g.at(t).block<X, 1>(0, 0) +
-          j.at(t).block<X, X>(0, 0).transpose() *
-          v_dx.block<X, 1>(0, 0);
+        Q_dxu.block(0, 0, X, 1) =
+          g.at(t).block(0, 0, X, 1) +
+          j.at(t).block(0, 0, X, X).transpose() *
+          v_dx.block(0, 0, X, 1);
         // eq 4b
-        Q_dxu.block<U, 1>(X, 0) =
-          g.at(t).block<U, 1>(X, 0) +
-          j.at(t).block<X, U>(0, X).transpose() *
-          v_dx.block<X, 1>(X, 0);
+        Q_dxu.block(X, 0, U, 1) =
+          g.at(t).block(X, 0, U, 1) +
+          j.at(t).block(0, X, X, U).transpose() *
+          v_dx.block(0, 0, X, 1);
         // eq 4c
-        Q_ddxu.block<X, X>(0, 0) =
-          h.at(t).block<X, X>(0, 0) +
-          j.at(t).block<X, X>(0, 0).transpose() *
-          v_ddx.block<X, X>(0, 0) *
-          j.at(t).block<X, X>(0, 0);
+        Q_ddxu.block(0, 0, X, X) =
+          h.at(t).block(0, 0, X, X) +
+          j.at(t).block(0, 0, X, X).transpose() *
+          v_ddx.block(0, 0, X, X) *
+          j.at(t).block(0, 0, X, X);
         // eq 4d
-        Q_ddxu.block<U, X>(X, 0) =
-          h.at(t).block<U, X>(X, 0) +
-          j.at(t).block<X, U>(0, X).transpose() *
-          v_ddx.block<X, X>(0, 0) *
-          j.at(t).block<X, U>(0, X);
+        Q_ddxu.block(X, 0, U, X) =
+          h.at(t).block(X, 0, U, X) +
+          j.at(t).block(0, X, X, U).transpose() *
+          v_ddx.block(0, 0, X, X) *
+          j.at(t).block(0, 0, X, X);
         // eq 4e
-        Q_ddxu.block<U, U>(X, X) =
-          g.at(t).block<U, U>(X, X) +
-          j.at(t).block<X, U>(0, X).transpose() *
-          v_ddx.block<X, X>(0, 0) *
-          j.at(t).block<X, U>(0, X);
+        Q_ddxu.block(X, X, U, U) =
+          h.at(t).block(X, X, U, U) +
+          j.at(t).block(0, X, X, U).transpose() *
+          v_ddx.block(0, 0, X, X) *
+          j.at(t).block(0, X, X, U);
 
         // eq 5b
-        k.at(t) = -Q_ddxu.block<U, U>(X, X).inverse() * Q_dxu.block<U, 1>(X, 0);
-        K.at(t) = -Q_ddxu.block<U, U>(X, X).inverse() * Q_ddxu.block<U, X>(X, 0);
+        Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double, U, U>> eigensolver(Q_ddxu.block(X, X, U, U));
+        if (eigensolver.info() != Eigen::Success) {
+          std::cout << "Failed to solve eigen vectors" << std::endl;
+          abort();
+        }
+        Eigen::Matrix<double, U, 1> eigen_vals = eigensolver.eigenvalues();
+        Eigen::Matrix<double, U, U> eigen_vals_diag;
+        eigen_vals_diag.setZero();
+        for (int i = 0; i < U; i++) {
+          if (eigen_vals[i] < 0) {
+            eigen_vals[i] = 0;
+          }
+          eigen_vals[i] += alpha;
+          eigen_vals_diag(i, i) = 1.0 / eigen_vals[i];
+        }
+        Eigen::Matrix<double, U, U> eigen_vecs = eigensolver.eigenvectors();
+        Eigen::Matrix<double, U, U> inv = eigen_vecs * eigen_vals_diag * eigen_vecs.transpose();
+        // std::cout << "T " << t << std::endl;
+        // std::cout << "Inv norm " << inv.norm() << std::endl;
+        // std::cout << "Q_ddxu.block(X, X, U, U) " << Q_ddxu.block(X, X, U, U).norm() << std::endl;
+        // std::cout << "v_ddx.block(0, 0, X, X) " << v_ddx.block(0, 0, X, X).norm() << std::endl;
+        // std::cout << "K " << v_ddx.block(0, 0, X, X).norm() << std::endl;
+        // std::cout << "g.at(t).block(0, 0, X, 1) " << g.at(t).block(0, 0, X, 1).norm() << std::endl;
+        // std::cout << "j.at(t).block(0, 0, X, 1) " << j.at(t).block(0, 0, X, X).norm() << std::endl;
+        // std::cout << "h.at(t).block(0, 0, X, 1) " << h.at(t).block(0, 0, X, X).norm() << std::endl;
+
+        k.at(t) = -1 * inv * Q_dxu.block(X, 0, U, 1);
+        K.at(t) = -1 * inv * Q_ddxu.block(X, 0, U, X);
 
         // eq 6b
-        v_dx = Q_dxu.block<X, 1>(0, 0) - K.at(t).transpose() * Q_ddxu.block<U, U>(X, X) * k.at(t);
+        v_dx = Q_dxu.block(0, 0, X, 1) - K.at(t).transpose() * Q_ddxu.block(X, X, U, U) * k.at(t);
         // eq 6c
-        v_ddx = Q_ddxu.block<X, X>(0, 0) - K.at(t).transepose() * Q_ddxu.block<U, U>(X, X) * K.at(t);
+        v_ddx =
+          Q_ddxu.block(0, 0, X, X) - K.at(t).transpose() * Q_ddxu.block(X, X, U, U) * K.at(t);
       }
 
       // Step 3.5: Update possible control signal, states, costs
@@ -200,12 +244,20 @@ private:
       Trajectory test_trajectory;
       Actions test_actions;
       test_trajectory.at(0) = trajectory.at(0);
-      test_actions.at(0) = actions.at(0) + k.at(t);  // xhat_0 == x_0 so Kt term goes away
+      test_actions.at(0) = actions.at(0) + k.at(0);  // xhat_0 == x_0 so Kt term goes away
       test_cost = cost(test_trajectory.at(0), test_actions.at(0), 0);
       for (Time t = 1; t < T; t++) {
-        test_trajectory.at(t) = test_trajectory.at(t - 1) + dynamics(test_trajectory.at(t - 1), test_actions.at(t - 1));
-        test_actions.at(t) = actions.at(t) + alpha * k.at(t) + K.at(t) * (test_trajectory.at(t) - trajectory.at(t));
+        test_trajectory.at(t) = dynamics(
+          test_trajectory.at(
+            t - 1), test_actions.at(t - 1), t);
+        test_actions.at(t) = actions.at(t) + k.at(t) + K.at(t) *
+          (test_trajectory.at(t) - trajectory.at(t));
         test_cost = cost(test_trajectory.at(t), test_actions.at(t), t);
+      }
+
+      std::cout << "test_cost " << test_cost << std::endl;
+      for (const auto& a : test_trajectory) {
+        std::cout << a.x() << std::endl;
       }
 
       // Step 4: Compare Costs and update update size
@@ -221,11 +273,11 @@ private:
         overall_cost = test_cost;
 
         // Step 4.5: Calculate jacobian/hessian for x,u
-        for (Time t = 0; t < T; i++) {
+        for (Time t = 0; t < T; t++) {
           j.at(t) = jacobian(trajectory.at(t), actions.at(t), t);
 
           g.at(t) = gradiant(trajectory.at(t), actions.at(t), t);
-          h.at(t) = hessian(trajectory.at(t), actions.at(t), t, j.at(t));
+          h.at(t) = hessian(trajectory.at(t), actions.at(t), t, g.at(t));
         }
 
         alpha *= alpha_change;
@@ -235,12 +287,13 @@ private:
 
       num_iterations++;
     }
+    std::cout << "Iterations taken " << num_iterations << std::endl;
   }
 
-  constexpr std::size_t max_num_iterations = 100;
-  constexpr double converge_threshold = 0.1;
-  constexpr double alpha_change = 0.9;
-  constexpr double eps = 1e-5;
+  static constexpr std::size_t max_num_iterations = 1000;
+  static constexpr double converge_threshold = 1e-6;
+  static constexpr double alpha_change = 0.99;
+  static constexpr double eps = 1e-3;
 
   double alpha = 1;  // backtracking serach parameter
   Trajectory trajectory;

--- a/ateam_ai/test/trajectory_generation/ilqr_problem_test.cpp
+++ b/ateam_ai/test/trajectory_generation/ilqr_problem_test.cpp
@@ -1,0 +1,60 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "trajectory_generation/ilqr_problem.hpp"
+
+#include <gtest/gtest.h>
+#include <iostream>
+
+class PointMass1dProblem : public iLQRProblem<2, 1, 50>
+{
+public:
+  State dynamics(const State & x_t1, const Input & u_t1, Time t) override
+  {
+    Eigen::Matrix<double, 2, 2> A; A << 0, 1, 0, 0;
+    Eigen::Matrix<double, 2, 1> B; B << 0, 1;
+
+    constexpr double dt = 0.01;
+
+    return x_t1 + dt * (A * x_t1 + B * u_t1);
+  }
+
+  Cost cost(const State & x, const Input & u, Time t) override
+  {
+    if (t == 49) {
+      Eigen::Vector2d target{10, 0};
+      Eigen::Vector2d weights{1, 1};
+      return 1e4 * (target - x).dot(target - x);
+    } else {
+      return u.dot(u);
+    }
+  }
+};
+
+TEST(iLQRProblem, SamplePointMass)
+{
+  PointMass1dProblem problem;
+  auto trajectory = problem.calculate(Eigen::Vector2d{0, 0});
+
+  for (const auto & state : trajectory) {
+    std::cout << state.x() << " " << state.y() << std::endl;
+  }
+  EXPECT_TRUE(false);
+}

--- a/ateam_ai/test/trajectory_generation/ilqr_problem_test.cpp
+++ b/ateam_ai/test/trajectory_generation/ilqr_problem_test.cpp
@@ -52,8 +52,9 @@ public:
 TEST(iLQRProblem, SamplePointMass)
 {
   PointMass1dProblem problem;
-  auto trajectory = problem.calculate(Eigen::Vector2d{0, 0});
+  auto maybe_trajectory = problem.calculate(Eigen::Vector2d{0, 0});
 
-  EXPECT_NEAR(trajectory.back().x(), 10, 1e-1);
-  EXPECT_NEAR(trajectory.back().y(), 0, 1e-4);
+  ASSERT_TRUE(maybe_trajectory.has_value());
+  EXPECT_NEAR(maybe_trajectory.value().back().x(), 10, 1e-1);
+  EXPECT_NEAR(maybe_trajectory.value().back().y(), 0, 1e-4);
 }


### PR DESCRIPTION
Adds an abstract iLQR problem interface and solver. Ideally, we'll be able to use this to generate trajectories for movement + capture + kicks.

Features
- Overridable interface for dynamics and cost functions as a function of time
- Automatic differentiation for all dynamics and cost
- Tune-able max iteration count + alpha gain to control convergence

Not Features
- Only supports dynamics with no second derivative (I didn't want to deal with tensor math lol)