### PR TITLE
Use constexpr for topic names

### DIFF
--- a/ateam_ai/CMakeLists.txt
+++ b/ateam_ai/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(ateam_common REQUIRED)
 find_package(ateam_msgs REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
@@ -44,6 +45,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)
 ament_target_dependencies(${PROJECT_NAME}
   rclcpp
   rclcpp_components
+  ateam_common
   ateam_msgs
   Eigen3
 )

--- a/ateam_ai/package.xml
+++ b/ateam_ai/package.xml
@@ -12,6 +12,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2</depend>
+  <depend>ateam_common</depend>
   <depend>ateam_msgs</depend>
   <depend>eigen3_cmake_module</depend>
   <depend>eigen</depend>

--- a/ateam_ai/src/ateam_ai_node.cpp
+++ b/ateam_ai/src/ateam_ai_node.cpp
@@ -20,6 +20,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
+#include <ateam_common/topic_names.hpp>
 #include <ateam_msgs/msg/ball_state.hpp>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
 #include <ateam_msgs/msg/robot_state.hpp>
@@ -30,7 +31,7 @@
 #include <chrono>
 #include <functional>
 #include <mutex>
-
+#include <string>
 
 #include "behavior/behavior.hpp"
 #include "behavior/behavior_feedback.hpp"
@@ -66,18 +67,18 @@ public:
           robot_state_callback(world_.their_robots, id, robot_state_msg);
         };
       blue_robots_subscriptions_.at(id) = create_subscription<ateam_msgs::msg::RobotState>(
-        "/vision_filter/blue_team/robot" + std::to_string(id),
+        std::string(Topics::kBlueTeamRobotPrefix) + std::to_string(id),
         10,
         our_robot_callback);
       yellow_robots_subscriptions_.at(id) = create_subscription<ateam_msgs::msg::RobotState>(
-        "/vision_filter/yellow_team/robot" + std::to_string(id),
+        std::string(Topics::kYellowTeamRobotPrefix) + std::to_string(id),
         10,
         their_robot_callback);
     }
 
     for (std::size_t id = 0; id < robot_commands_publishers_.size(); id++) {
       robot_commands_publishers_.at(id) = create_publisher<ateam_msgs::msg::RobotMotionCommand>(
-        "~/robot_motion_commands/robot" + std::to_string(id),
+        std::string(Topics::kRobotMotionCommandPrefix) + std::to_string(id),
         rclcpp::SystemDefaultsQoS());
     }
 
@@ -85,7 +86,7 @@ public:
         ball_state_callback(world_.balls.at(0), ball_state_msg);
       };
     ball_subscription_ = create_subscription<ateam_msgs::msg::BallState>(
-      "/vision_filter/ball",
+      std::string(Topics::kBall),
       10,
       ball_callback);
 

--- a/ateam_common/include/ateam_common/topic_names.hpp
+++ b/ateam_common/include/ateam_common/topic_names.hpp
@@ -1,0 +1,47 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ATEAM_COMMON__TOPIC_NAMES_HPP_
+#define ATEAM_COMMON__TOPIC_NAMES_HPP_
+
+#include <string_view>
+
+namespace Topics
+{
+// Input from other systems
+constexpr std::string_view kVisionMessages = "/vision_messages";  // Raw vision protobufs
+constexpr std::string_view kRefereeMessages = "/referee_messages";  // Raw ref protobufs
+
+// Input from robots
+constexpr std::string_view kRobotFeedbackPrefix = "/robot_motion_commands/robot";
+
+// Output from vision filter
+constexpr std::string_view kBall = "/ball";
+constexpr std::string_view kYellowTeamRobotPrefix = "/yellow_team/robot";
+constexpr std::string_view kBlueTeamRobotPrefix = "/blue_team/robot";
+
+// Output from joysticks
+constexpr std::string_view kJoystick = "/joystick";
+
+// Output from AI
+constexpr std::string_view kRobotMotionCommandPrefix = "/robot_motion_commands/robot";
+}  // namespace Topics
+
+#endif  // ATEAM_COMMON__TOPIC_NAMES_HPP_

--- a/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
+++ b/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
@@ -22,6 +22,7 @@
 #include <rclcpp_components/register_node_macro.hpp>
 #include <ateam_common/multicast_receiver.hpp>
 #include <ateam_common/protobuf_logging.hpp>
+#include <ateam_common/topic_names.hpp>
 #include <ssl_league_msgs/msg/referee.hpp>
 #include <memory>
 #include <string>
@@ -39,7 +40,7 @@ public:
     SET_ROS_PROTOBUF_LOG_HANDLER("gc_multicast_bridge.protobuf");
 
     referee_publisher_ = create_publisher<ssl_league_msgs::msg::Referee>(
-      "~/referee_messages",
+      std::string(Topics::kRefereeMessages),
       rclcpp::SystemDefaultsQoS());
 
     const auto multicast_address =

--- a/ateam_joystick_control/CMakeLists.txt
+++ b/ateam_joystick_control/CMakeLists.txt
@@ -4,6 +4,7 @@ project(ateam_joystick_control)
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
+find_package(ateam_common REQUIRED)
 find_package(ateam_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
@@ -14,6 +15,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
 ament_target_dependencies(${PROJECT_NAME}
   rclcpp
   rclcpp_components
+  ateam_common
   ateam_msgs
   sensor_msgs
 )

--- a/ateam_joystick_control/package.xml
+++ b/ateam_joystick_control/package.xml
@@ -11,6 +11,7 @@
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>ateam_common</depend>
   <depend>ateam_msgs</depend>
   <depend>sensor_msgs</depend>
 

--- a/ateam_joystick_control/src/joystick_control_node.cpp
+++ b/ateam_joystick_control/src/joystick_control_node.cpp
@@ -20,6 +20,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
+#include <ateam_common/topic_names.hpp>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
 #include <sensor_msgs/msg/joy.hpp>
 #include <string>
@@ -35,7 +36,7 @@ public:
   : rclcpp::Node("joystick_control_node", options)
   {
     joy_subscription_ = create_subscription<sensor_msgs::msg::Joy>(
-      "~/joy", rclcpp::QoS{1}, std::bind(
+      std::string(Topics::kJoystick), rclcpp::QoS{1}, std::bind(
         &JoystickControlNode::JoyCallback, this,
         std::placeholders::_1));
     command_topic_template_ = declare_parameter<std::string>("command_topic_template", "");

--- a/ateam_joystick_control/test/launch_tests/joystick_control_node_test.py
+++ b/ateam_joystick_control/test/launch_tests/joystick_control_node_test.py
@@ -56,7 +56,7 @@ class TestJoystickControlNode(unittest.TestCase):
         self.message_pump = launch_testing_ros.MessagePump(
             self.node, context=self.context)
         self.pub = self.node.create_publisher(
-            sensor_msgs.msg.Joy, '/joystick_control_node/joy', 1)
+            sensor_msgs.msg.Joy, '/joystick', 1)
 
         self.sub_0 = self.node.create_subscription(
             ateam_msgs.msg.RobotMotionCommand, '/motion_commands/robot_0', self.callback_0, 1)

--- a/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
+++ b/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
@@ -22,6 +22,7 @@
 #include <rclcpp_components/register_node_macro.hpp>
 
 #include <ateam_common/bi_directional_udp.hpp>
+#include <ateam_common/topic_names.hpp>
 #include <ateam_msgs/msg/robot_feedback.hpp>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
 #include <ssl_league_protobufs/ssl_simulation_robot_control.pb.h>
@@ -58,12 +59,12 @@ public:
 
       command_subscriptions_.at(robot_id) =
         create_subscription<ateam_msgs::msg::RobotMotionCommand>(
-        "/ateam_ai/robot_motion_commands/robot" + std::to_string(robot_id),
+        std::string(Topics::kRobotMotionCommandPrefix) + std::to_string(robot_id),
         10,
         callback);
 
       feedback_publishers_.at(robot_id) = create_publisher<ateam_msgs::msg::RobotFeedback>(
-        "~/robot_feedback/robot" + std::to_string(robot_id),
+        std::string(Topics::kRobotFeedbackPrefix) + std::to_string(robot_id),
         rclcpp::SystemDefaultsQoS());
     }
   }

--- a/ateam_ssl_vision_bridge/src/ssl_vision_bridge_node.cpp
+++ b/ateam_ssl_vision_bridge/src/ssl_vision_bridge_node.cpp
@@ -23,8 +23,11 @@
 
 #include <ateam_common/multicast_receiver.hpp>
 #include <ateam_common/protobuf_logging.hpp>
+#include <ateam_common/topic_names.hpp>
 #include <ssl_league_msgs/msg/vision_wrapper.hpp>
 #include <ssl_league_protobufs/ssl_vision_wrapper.pb.h>
+
+#include <string>
 
 #include "message_conversions.hpp"
 
@@ -54,7 +57,7 @@ public:
   {
     SET_ROS_PROTOBUF_LOG_HANDLER("ssl_vision_bridge.protobuf");
     vision_publisher_ = create_publisher<ssl_league_msgs::msg::VisionWrapper>(
-      "~/vision_messages",
+      std::string(Topics::kVisionMessages),
       rclcpp::SystemDefaultsQoS());
   }
 

--- a/ateam_ui/src/src/main.js
+++ b/ateam_ui/src/src/main.js
@@ -88,7 +88,7 @@ ros.on('close', function() {
 // Set up ball subscribers and publishers
 var ballTopic = new ROSLIB.Topic({
     ros: ros,
-    name: '/vision_filter/ball',
+    name: '/ball',
     messageType: 'ateam_msgs/msg/BallState'
 });
 
@@ -114,7 +114,7 @@ for (var team in vm.state.teams) {
     for (var i = 0; i < 16; i++) {
         var robotTopic = new ROSLIB.Topic({
             ros: ros,
-            name: '/vision_filter/' + team + '_team/robot' + i,
+            name: '/' + team + '_team/robot' + i,
             messageType: 'ateam_msgs/msg/RobotState'
         });
 

--- a/ateam_vision_filter/src/ateam_vision_filter_node.cpp
+++ b/ateam_vision_filter/src/ateam_vision_filter_node.cpp
@@ -21,10 +21,13 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 
+#include <ateam_common/topic_names.hpp>
+
 #include <chrono>
 #include <functional>
 #include <mutex>
 #include <iostream>
+#include <string>
 
 #include "world.hpp"
 #include "message_conversions.hpp"
@@ -43,21 +46,21 @@ public:
     timer_ = create_wall_timer(10ms, std::bind(&VisionFilterNode::timer_callback, this));
 
     ball_publisher_ = create_publisher<ateam_msgs::msg::BallState>(
-      "~/ball",
+      std::string(Topics::kBall),
       rclcpp::SystemDefaultsQoS());
 
     for (std::size_t id = 0; id < blue_robots_publisher_.size(); id++) {
       blue_robots_publisher_.at(id) = create_publisher<ateam_msgs::msg::RobotState>(
-        "~/blue_team/robot" + std::to_string(id),
+        std::string(Topics::kBlueTeamRobotPrefix) + std::to_string(id),
         rclcpp::SystemDefaultsQoS());
       yellow_robots_publisher_.at(id) = create_publisher<ateam_msgs::msg::RobotState>(
-        "~/yellow_team/robot" + std::to_string(id),
+        std::string(Topics::kYellowTeamRobotPrefix) + std::to_string(id),
         rclcpp::SystemDefaultsQoS());
     }
 
     ssl_vision_subscription_ =
       create_subscription<ssl_league_msgs::msg::VisionWrapper>(
-      "/ssl_vision_bridge/vision_messages",
+      std::string(Topics::kVisionMessages),
       10,
       std::bind(&VisionFilterNode::message_callback, this, std::placeholders::_1));
   }


### PR DESCRIPTION
Closes #60 

I don't think theres a good way to keep the UI up to date with the topic names, but this should at least be a start toward keeping the C++ code cleaner