### PR TITLE
Add initial status checks

### DIFF
--- a/ateam_common/CMakeLists.txt
+++ b/ateam_common/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(ateam_common)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -g)
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -23,12 +23,15 @@ ament_target_dependencies(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
   Boost::boost
   protobuf::libprotobuf
+  ${CMAKE_DL_LIBS}
 )
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
+# Export symbols so we can backtrace
+set_property(TARGET ${PROJECT_NAME} PROPERTY ENABLE_EXPORTS ON)
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(Boost Protobuf)

--- a/ateam_common/include/ateam_common/status.hpp
+++ b/ateam_common/include/ateam_common/status.hpp
@@ -1,0 +1,162 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ATEAM_COMMON__STATUS_HPP_
+#define ATEAM_COMMON__STATUS_HPP_
+
+// Use backtrace so we get line numbers and files
+#define BOOST_STACKTRACE_USE_ADDR2LINE
+
+#include <boost/outcome.hpp>
+#include <boost/stacktrace.hpp>
+
+#include <utility>
+#include <string>
+#include <iostream>
+
+// Utilities to improve the error checking workflow
+//
+// We now have access to a ateam::Status or ateam::StatusOr<T> type.
+// Both are used as a return from a function to signal success or faliure
+//
+// Eg:
+// ateam::Status log_to_console(std::string);
+// or
+// ateam::StatusOr<double> sqrt(double);
+//
+// The sqrt function will then be able to return a failure if the input is invalid.
+// Eg:
+// ateam::StatusOr<double> sqrt(double input) {
+//   ATEAM_SCHECK(input >= 0, "input must be non-negative");
+//   return math.sqrt(input);
+// }
+//
+// This will allow significant improvements to safety surrounding assumptions a function
+// can ensure.
+
+
+// From the user POV, we can simplify catching and throwing these exceptions.
+// There are two main classes user functions, ATEAM_ASSIGN_OR_* and ATEAM_*CHECK
+//
+// ATEAM_ASSIGN_OR_RETURN(auto var, func_that_returns_statusor(), "failure string");
+// will set var to the result of the function if and only if, the function doesn't fail.
+// If it fails, it will propegate the failure up the stack
+//
+// ATEAM_ASSIGN_OR_THROW(auto var, func_that_returns_statusor(), "failure string");
+// will set var to the result of the function if and only if, the function doesn't fail.
+// If it fails, it will throw an exception
+//
+// ATEAM_SCHECK(condition, "failure string") will check that the condition is true.
+// If the condition is false, it will return a status::Failure with the given failure string.
+//
+// ATEAM_CHECK(condition, "failure string") will check that the condition is true.
+// If the condition is false, it will throw an exception with the given failure string.
+//
+// In most code, you will always use ATEAM_ASSIGN_OR_RETURN or ATEAM_SCHECK to propogate the
+// errors correctly.
+
+
+namespace ateam
+{
+
+class ErrorType
+{
+public:
+  std::string cause;
+  std::stringstream stack_trace;
+
+  ErrorType() {}
+
+  explicit ErrorType(std::string cause)
+  : cause(cause)
+  {
+    stack_trace << boost::stacktrace::stacktrace() << std::endl;
+  }
+};
+
+std::ostream & operator<<(std::ostream & os, const ErrorType & error)
+{
+  os << error.cause << "\n\n" << error.stack_trace.str();
+  return os;
+}
+
+using Status = BOOST_OUTCOME_V2_NAMESPACE::result<void, ErrorType,
+    BOOST_OUTCOME_V2_NAMESPACE::policy::terminate>;
+
+template<typename T>
+using StatusOr = BOOST_OUTCOME_V2_NAMESPACE::result<T, ErrorType,
+    BOOST_OUTCOME_V2_NAMESPACE::policy::terminate>;
+
+// Wrappers around success / failure so we can simplify the interface
+Status Ok()
+{
+  return BOOST_OUTCOME_V2_NAMESPACE::success();
+}
+Status Failure(std::string && s)
+{
+  return ErrorType(std::move(s));
+}
+
+template<typename T>
+StatusOr<T> Ok(T && s)
+{
+  return BOOST_OUTCOME_V2_NAMESPACE::success(std::move(s));
+}
+template<typename T>
+StatusOr<T> Failure(std::string && s)
+{
+  return ErrorType(std::move(s));
+}
+
+#define ATEAM_ASSIGN_OR_RETURN(lhs, rhs, text) \
+  lhs = ({auto __status_or_lhs = rhs; \
+      if (!__status_or_lhs) { \
+        return ateam::Failure(text); \
+      } \
+      __status_or_lhs.value()});
+
+#define ATEAM_ASSIGN_OR_THROW(lhs, rhs, text) \
+  lhs = ({auto __status_or_lhs = rhs; \
+      if (!__status_or_lhs) { \
+        std::stringstream s; \
+        s << text << "\n" << __status_or_lhs.error() << std::endl; \
+        throw s.str(); \
+      } __status_or_lhs.value();});
+
+#define ATEAM_SCHECK(x, text) \
+  do { \
+    auto __value = x; \
+    if (!__value) { \
+      return ateam::Failure(text); \
+    } \
+  } while (false);
+
+#define ATEAM_CHECK(x, text) \
+  do { \
+    auto __value = x; \
+    if (!__value) { \
+      std::stringstream s; \
+      s << ateam::Failure(text).error() << std::endl; \
+      throw s.str(); \
+    } \
+  } while (false);
+
+}  // namespace ateam
+#endif  // ATEAM_COMMON__STATUS_HPP_

--- a/ateam_common/include/ateam_common/status.hpp
+++ b/ateam_common/include/ateam_common/status.hpp
@@ -24,12 +24,12 @@
 // Use backtrace so we get line numbers and files
 #define BOOST_STACKTRACE_USE_ADDR2LINE
 
-#include <boost/outcome.hpp>
-#include <boost/stacktrace.hpp>
-
 #include <utility>
 #include <string>
 #include <iostream>
+
+#include <boost/outcome.hpp>
+#include <boost/stacktrace.hpp>
 
 // Utilities to improve the error checking workflow
 //

--- a/ateam_common/test/CMakeLists.txt
+++ b/ateam_common/test/CMakeLists.txt
@@ -2,3 +2,8 @@ find_package(ament_cmake_gmock REQUIRED)
 find_package(ament_cmake_gtest REQUIRED)
 ament_add_gmock(test_protobuf_logging test_protobuf_logging.cpp)
 target_link_libraries(test_protobuf_logging ${PROJECT_NAME})
+
+add_compile_options(-g)
+ament_add_gtest(test_status test_status.cpp)
+target_link_libraries(test_status ${PROJECT_NAME})
+set_property(TARGET test_status PROPERTY ENABLE_EXPORTS ON)

--- a/ateam_common/test/test_status.cpp
+++ b/ateam_common/test/test_status.cpp
@@ -1,0 +1,63 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include <string>
+#include "ateam_common/status.hpp"
+
+ateam::Status AlwaysFailStatus()
+{
+  return ateam::Failure("Fail string");
+}
+
+ateam::Status AlwaysPassStatus()
+{
+  return ateam::Ok();
+}
+
+ateam::StatusOr<int> AlwaysFailInt()
+{
+  return ateam::Failure<int>("Fail string");
+}
+
+ateam::StatusOr<int> Always10Int()
+{
+  return ateam::Ok(10);
+}
+
+TEST(Status, assign_or_throw_bad)
+{
+  EXPECT_THROW(ATEAM_ASSIGN_OR_THROW(auto a, AlwaysFailInt(), "Oops failed1"), std::string);
+  EXPECT_THROW(ATEAM_ASSIGN_OR_THROW(auto b, AlwaysFailInt(), "Oops failed2"), std::string);
+}
+
+TEST(Status, assign_or_throw_good)
+{
+  ATEAM_ASSIGN_OR_THROW(auto a, Always10Int(), "Oops failed");
+  EXPECT_EQ(a, 10);
+  ATEAM_ASSIGN_OR_THROW(auto b, Always10Int(), "Oops failed");
+  EXPECT_EQ(b, 10);
+}
+
+TEST(Status, always)
+{
+  EXPECT_NO_THROW(ATEAM_CHECK(AlwaysPassStatus(), "Oops failed1"));
+  EXPECT_THROW(ATEAM_CHECK(AlwaysFailStatus(), "Oops failed1"), std::string);
+}


### PR DESCRIPTION
Add initial status checks. This should make life really nice when we start having bugs around breaking assumptions that functions have. I imagine this will need to be improved as we see the results, but this is a good start.

Example code
```
ateam::StatusOr<double> sqrt(double input) {
  ATEAM_SCHECK(input >= 0.0, "Input must be positive");
  return math.sqrt(input);
}

ATEAM_ASSIGN_OR_RETURN(auto num, sqrt(x*x + y*y), "Failed to normalize vector);
```

There is still some work to do to clean up the ATEAM_SCHECK's to make them more like the gtest EXPECT/ASSERT checks with the clean output. I believe I will also need to do some work on how we should propagate the error stack up the chain, that is whether to overwrite the error or to keep the lowest level stack trace. Additionally, these should be logged to the ros log, instead of just throwing exceptions.