### PR TITLE
Add a ros logger

### DIFF
--- a/ateam_common/include/ateam_common/logger.hpp
+++ b/ateam_common/include/ateam_common/logger.hpp
@@ -1,0 +1,115 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ATEAM_COMMON__LOGGER_HPP_
+#define ATEAM_COMMON__LOGGER_HPP_
+
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+#include <optional>
+#include <string>
+#include <utility>
+
+/**
+ * @brief Sets up the global logger to redirect all logged output through ROS.
+ *
+ * Recommended use:
+ * Call this macro in the constructor of your node.
+ * @code{.cpp}
+ * SET_ROS_LOG_HANDLER("my_node");
+ * @endcode
+ */
+#define SET_ROS_LOG_HANDLER(logger_name) \
+  ateam_common::Logger::GetLogger().SetRosLogHandler(logger_name);
+
+/**
+ * @brief Logs INFO/WARN/ERROR/FATAL using the standard printf style format + args setup. The filename and line number are automatically added as a prefix.
+ */
+#define LOG_INFO(format, ...) \
+  _LOG_LINE(ateam_common::Logger::Level::INFO, format, __VA_ARGS__);
+#define LOG_WARN(format, ...) \
+  _LOG_LINE(ateam_common::Logger::Level::WARN, format, __VA_ARGS__);
+#define LOG_ERROR(format, ...) \
+  _LOG_LINE(ateam_common::Logger::Level::ERROR, format, __VA_ARGS__);
+#define LOG_FATAL(format, ...) \
+  _LOG_LINE(ateam_common::Logger::Level::FATAL, format, __VA_ARGS__);
+
+#define _LOG_LINE(level, format, ...) \
+  ateam_common::Logger::GetLogger().Log( \
+    level, std::string("[%s:%d] ") + std::string( \
+      format), __FILE__, __LINE__, __VA_ARGS__);
+
+namespace ateam_common
+{
+class Logger
+{
+public:
+  enum Level
+  {
+    INFO,
+    WARN,
+    ERROR,
+    FATAL
+  };
+
+  static Logger & GetLogger()
+  {
+    static Logger l;
+    return l;
+  }
+
+  void SetRosLogHandler(const std::string & logger_name)
+  {
+    ros_logger = rclcpp::get_logger(logger_name);
+  }
+
+  template<class ... Args>
+  void Log(const Level & level, const std::string & format, Args && ... args)
+  {
+    if (ros_logger.has_value()) {
+      switch (level) {
+        case Level::INFO:
+          RCLCPP_INFO(ros_logger.value(), format, std::forward<Args>(args)...);
+          break;
+        case Level::WARN:
+          RCLCPP_WARN(ros_logger.value(), format, std::forward<Args>(args)...);
+          break;
+        case Level::ERROR:
+          RCLCPP_ERROR(ros_logger.value(), format, std::forward<Args>(args)...);
+          break;
+        case Level::FATAL:
+          RCLCPP_FATAL(ros_logger.value(), format, std::forward<Args>(args)...);
+          break;
+      }
+    } else {
+      // Support logging in non-ros contexts (like unit testing)
+      printf(format.c_str(), std::forward<Args>(args)...);
+      printf("\n\r");
+    }
+  }
+
+private:
+  Logger() = default;
+
+  std::optional<rclcpp::Logger> ros_logger;
+};
+}  // namespace ateam_common
+
+#endif  // ATEAM_COMMON__LOGGER_HPP_

--- a/ateam_common/test/CMakeLists.txt
+++ b/ateam_common/test/CMakeLists.txt
@@ -2,3 +2,7 @@ find_package(ament_cmake_gmock REQUIRED)
 find_package(ament_cmake_gtest REQUIRED)
 ament_add_gmock(test_protobuf_logging test_protobuf_logging.cpp)
 target_link_libraries(test_protobuf_logging ${PROJECT_NAME})
+
+ament_add_gmock(test_logging test_logging.cpp)
+set_target_properties(test_logging PROPERTIES CXX_STANDARD 17)
+target_link_libraries(test_logging ${PROJECT_NAME})

--- a/ateam_common/test/test_logging.cpp
+++ b/ateam_common/test/test_logging.cpp
@@ -1,0 +1,125 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <string>
+#include "ateam_common/logger.hpp"
+
+const char * logger_name = "test";
+size_t log_calls = 0;
+rclcpp::Logger logger = rclcpp::get_logger(logger_name);
+
+struct LogEvent
+{
+  const rcutils_log_location_t * location;
+  int level;
+  std::string name;
+  rcutils_time_point_value_t timestamp;
+  std::string message;
+};
+LogEvent last_log_event;
+
+class TestLogging : public testing::Test
+{
+public:
+  rcutils_logging_output_handler_t previous_output_handler;
+
+  void SetUp()
+  {
+    log_calls = 0;
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+    rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_DEBUG);
+
+    auto output_handler = [](const rcutils_log_location_t * location,
+        int level, const char * name, rcutils_time_point_value_t timestamp,
+        const char * format, va_list * args) {
+        ++log_calls;
+        last_log_event = LogEvent{
+          location,
+          level,
+          (name ? name : ""),
+          timestamp,
+          ""
+        };
+        char buffer[1024];
+        vsnprintf(buffer, sizeof(buffer), format, *args);
+        last_log_event.message = buffer;
+      };
+
+    previous_output_handler = rcutils_logging_get_output_handler();
+    rcutils_logging_set_output_handler(output_handler);
+  }
+
+  void TearDown()
+  {
+    rcutils_logging_set_output_handler(previous_output_handler);
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+    EXPECT_FALSE(g_rcutils_logging_initialized);
+  }
+};
+
+TEST_F(TestLogging, test_info)
+{
+  SET_ROS_LOG_HANDLER(logger_name);
+  LOG_INFO("Hello %s", "World");
+  EXPECT_EQ(log_calls, 1u);
+  EXPECT_EQ(last_log_event.level, RCUTILS_LOG_SEVERITY_INFO);
+  EXPECT_EQ(last_log_event.name, logger_name);
+  EXPECT_THAT(
+    last_log_event.message,
+    ::testing::MatchesRegex("\\[.*test_logging\\.cpp\\:[0-9]+\\] Hello World"));
+}
+
+TEST_F(TestLogging, test_warn)
+{
+  SET_ROS_LOG_HANDLER(logger_name);
+  LOG_WARN("Hello %s", "World");
+  EXPECT_EQ(log_calls, 1u);
+  EXPECT_EQ(last_log_event.level, RCUTILS_LOG_SEVERITY_WARN);
+  EXPECT_EQ(last_log_event.name, logger_name);
+  EXPECT_THAT(
+    last_log_event.message,
+    ::testing::MatchesRegex("\\[.*test_logging\\.cpp\\:[0-9]+\\] Hello World"));
+}
+
+TEST_F(TestLogging, test_error)
+{
+  SET_ROS_LOG_HANDLER(logger_name);
+  LOG_ERROR("Hello %s", "World");
+  EXPECT_EQ(log_calls, 1u);
+  EXPECT_EQ(last_log_event.level, RCUTILS_LOG_SEVERITY_ERROR);
+  EXPECT_EQ(last_log_event.name, logger_name);
+  EXPECT_THAT(
+    last_log_event.message,
+    ::testing::MatchesRegex("\\[.*test_logging\\.cpp\\:[0-9]+\\] Hello World"));
+}
+
+TEST_F(TestLogging, test_fatal)
+{
+  SET_ROS_LOG_HANDLER(logger_name);
+  LOG_FATAL("Hello %s", "World");
+  EXPECT_EQ(log_calls, 1u);
+  EXPECT_EQ(last_log_event.level, RCUTILS_LOG_SEVERITY_FATAL);
+  EXPECT_EQ(last_log_event.name, logger_name);
+  EXPECT_THAT(
+    last_log_event.message,
+    ::testing::MatchesRegex("\\[.*test_logging\\.cpp\\:[0-9]+\\] Hello World"));
+}


### PR DESCRIPTION
Adds a singleton so that we can easily log from within our vanilla C++ classes without having to pass down all the ros info