### PR TITLE
minor fixes from setup on a fresh OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
    Follow the [instructions for ROS 2 Galactic](http://docs.ros.org/en/galactic/Installation.html) for your system.
 
+   Initialize rosdep with the following
+   ```bash
+   sudo rosdep init
+   # galactic went EOL Dec 1 2022 so we need the flag
+   rosdep update --include-eol-distros
+   ```
+
 1. Make a ROS workspace and clone our repo
 
    ```bash
@@ -17,17 +24,16 @@
    ```
 
 1. Install our ROS dependencies
-   Remember to source the underlay script corresponding to your shell (.sh, .bash, and .zsh are available). 
 
    ```bash
    # source the underlay
    source /opt/ros/galactic/setup.bash
+
    # In the ateam_ws directory
    rosdep install --from-paths . --ignore-src -y
    ```
 
 1. Install our non-ROS dependencies
-   Remember to source the underlay script corresponding to your shell (.sh, .bash, and .zsh are available). 
 
    ```bash
    # In the ateam_ws directory
@@ -37,10 +43,11 @@
 
 1. Build the code
 
+
    ```bash
    # In the ateam_ws directory
    source /opt/ros/galactic/setup.bash
    colcon build
    ```
 
-**Note:** You'll need to source both the underlay (`/opt/ros/galactic/setup.bash`) and our workspace's overlay (`ateam_ws/install/setup.bash`) in every terminal session before running any of our code.
+**Note:** You'll need to source both the underlay (`/opt/ros/galactic/setup.bash`) and our workspace's overlay (`ateam_ws/install/setup.bash`) in every terminal session before running any of our code. Remember to source the underlay script corresponding to your shell (.sh, .bash, and .zsh are available). 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@
 
 1. Build the code
 
-
    ```bash
    # In the ateam_ws directory
    source /opt/ros/galactic/setup.bash

--- a/README.md
+++ b/README.md
@@ -17,13 +17,17 @@
    ```
 
 1. Install our ROS dependencies
+   Remember to source the underlay script corresponding to your shell (.sh, .bash, and .zsh are available). 
 
    ```bash
+   # source the underlay
+   source /opt/ros/galactic/setup.bash
    # In the ateam_ws directory
    rosdep install --from-paths . --ignore-src -y
    ```
 
 1. Install our non-ROS dependencies
+   Remember to source the underlay script corresponding to your shell (.sh, .bash, and .zsh are available). 
 
    ```bash
    # In the ateam_ws directory

--- a/ateam_ui/install_deps.sh
+++ b/ateam_ui/install_deps.sh
@@ -15,7 +15,7 @@ fi
 install_npm_package_if_missing () {
   local package_name=$1
   echo "Checking for npm package: $package_name"
-  if npm list --depth 1 --global $package_name > /dev/null; then
+  if npm list --depth 1 --global $package_name > /dev/null 2>&1; then
     echo "$package_name already installed"
   else
     echo "Installing $package_name"

--- a/ateam_ui/install_deps.sh
+++ b/ateam_ui/install_deps.sh
@@ -8,14 +8,8 @@ set -e
 
 if ! command -v npm; then
   echo "ERROR: npm is not installed"
-
-  echo "attempting to install nodejs and npm"
-  sudo apt update -y
-  sudo apt install nodejs npm -y
-  if ! command -v npm; then
-    echo "failed to install npm"
-    exit 1
-  fi
+  echo "it is expected this is installed by rosdep. Did something go wrong?"
+  exit 1
 fi
 
 install_npm_package_if_missing () {

--- a/ateam_ui/install_deps.sh
+++ b/ateam_ui/install_deps.sh
@@ -6,10 +6,22 @@
 
 set -e
 
+if ! command -v npm; then
+  echo "ERROR: npm is not installed"
+
+  echo "attempting to install nodejs and npm"
+  sudo apt update -y
+  sudo apt install nodejs npm -y
+  if ! command -v npm; then
+    echo "failed to install npm"
+    exit 1
+  fi
+fi
+
 install_npm_package_if_missing () {
   local package_name=$1
   echo "Checking for npm package: $package_name"
-  if npm list --depth 1 --global $package_name > /dev/null 2>&1; then
+  if npm list --depth 1 --global $package_name > /dev/null; then
     echo "$package_name already installed"
   else
     echo "Installing $package_name"


### PR DESCRIPTION
I recently had to reinstall 20.04 so I have a fairly pristine system. A few setup things didn't work. I've worked through some and I touched up:
- it seems necessary to source the underlay before installing our dependencies in step `3`, this is reflected in the readme
- bash compatible shells (like ZSH) don't work if sourcing setup.bash. This silently fails to set a few env vars. A reminder is added to source the correct setup file for your shell since it's silent. This applies to `most steps`.
- the out-of-ROS dependency script in ateam_ui silently suppresses errors if npm or nodejs are not installed. The script now prints the missing core dependency and attempts to install it. This applies to step `4`