### PR TITLE
Humble upgrade

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 jobs:
   buildAndTest:
-    runs-on: ubuntu-20.04
-    container: ros:galactic
+    runs-on: ubuntu-22.04
+    container: ros:humble
     steps:
       - uses: actions/checkout@v2
         with:
@@ -16,19 +16,19 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          source /opt/ros/galactic/setup.bash
+          source /opt/ros/humble/setup.bash
           sudo apt-get update
-          rosdep update --rosdistro=galactic
+          rosdep update --rosdistro=humble
           rosdep install --from-paths . --ignore-src -y
           ./src/ateam_software/ateam_ui/install_deps.sh
       - name: Build
         shell: bash
         run: |
-          source /opt/ros/galactic/setup.bash
+          source /opt/ros/humble/setup.bash
           colcon build
       - name: Test
         shell: bash
         run: |
-          source /opt/ros/galactic/setup.bash
+          source /opt/ros/humble/setup.bash
           colcon test --packages-skip ateam_ui
           colcon test-result --verbose 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,18 @@
 
 ## Gettings Started
 
+**Note:** The following instructions are written assuming you are using Bash as your shell. The file extension of the setup scripts may be different if you are using a different shell. (`.bash`, `.sh`, and `.zsh` are available)
+
 1. Install ROS 2
 
-   Follow the [instructions for ROS 2 Galactic](http://docs.ros.org/en/galactic/Installation.html) for your system.
+   Follow the [instructions for ROS 2 Humble](http://docs.ros.org/en/humble/Installation.html) for your system.
+
+1. Initialize rosdep dependency manager
+
+   ```bash
+   sudo rosdep init
+   rosdep update
+   ```
 
 1. Make a ROS workspace and clone our repo
 
@@ -19,6 +28,8 @@
 1. Install our ROS dependencies
 
    ```bash
+   # Source underlay if you haven't already in this terminal
+   source /opt/ros/humble/setup.bash
    # In the ateam_ws directory
    rosdep install --from-paths . --ignore-src -y
    ```
@@ -26,17 +37,28 @@
 1. Install our non-ROS dependencies
 
    ```bash
+   # Source underlay if you haven't already in this terminal
+   source /opt/ros/humble/setup.bash
    # In the ateam_ws directory
-   source /opt/ros/galactic/setup.bash
    ./src/software/ateam_ui/install_deps.sh
    ```
 
 1. Build the code
 
    ```bash
+   # Source underlay if you haven't already in this terminal
+   source /opt/ros/humble/setup.bash
    # In the ateam_ws directory
-   source /opt/ros/galactic/setup.bash
    colcon build
    ```
 
-**Note:** You'll need to source both the underlay (`/opt/ros/galactic/setup.bash`) and our workspace's overlay (`ateam_ws/install/setup.bash`) in every terminal session before running any of our code.
+1. [Optionally] Run the tests
+
+   ```bash
+   # Source underlay if you haven't already in this terminal
+   source /opt/ros/humble/setup.bash
+   # In the ateam_ws directory
+   colcon test && colcon test-result --verbose
+   ```
+
+**Note:** You'll need to source both the underlay (`/opt/ros/humble/setup.bash`) and our workspace's overlay (`ateam_ws/install/setup.bash`) in every terminal session before running any of our code.

--- a/ateam_ai/CMakeLists.txt
+++ b/ateam_ai/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(ateam_common REQUIRED)
 find_package(ateam_msgs REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
@@ -48,6 +49,8 @@ ament_target_dependencies(${PROJECT_NAME}
   ateam_common
   ateam_msgs
   Eigen3
+  tf2
+  tf2_geometry_msgs
 )
 rclcpp_components_register_node(
   ${PROJECT_NAME}

--- a/ateam_ai/package.xml
+++ b/ateam_ai/package.xml
@@ -12,6 +12,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>ateam_common</depend>
   <depend>ateam_msgs</depend>
   <depend>eigen3_cmake_module</depend>

--- a/ateam_ai/src/ateam_ai_node.cpp
+++ b/ateam_ai/src/ateam_ai_node.cpp
@@ -18,13 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <rclcpp/rclcpp.hpp>
-#include <rclcpp_components/register_node_macro.hpp>
-#include <ateam_common/topic_names.hpp>
-#include <ateam_msgs/msg/ball_state.hpp>
-#include <ateam_msgs/msg/robot_motion_command.hpp>
-#include <ateam_msgs/msg/robot_state.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 
 #include <array>
@@ -32,6 +25,15 @@
 #include <functional>
 #include <mutex>
 #include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+#include <ateam_common/topic_names.hpp>
+#include <ateam_msgs/msg/ball_state.hpp>
+#include <ateam_msgs/msg/robot_motion_command.hpp>
+#include <ateam_msgs/msg/robot_state.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
 
 #include "behavior/behavior.hpp"
 #include "behavior/behavior_feedback.hpp"

--- a/ateam_ai/src/ateam_ai_node.cpp
+++ b/ateam_ai/src/ateam_ai_node.cpp
@@ -24,7 +24,7 @@
 #include <ateam_msgs/msg/ball_state.hpp>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
 #include <ateam_msgs/msg/robot_state.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 
 #include <array>

--- a/ateam_ai/src/behavior/behavior_executor.hpp
+++ b/ateam_ai/src/behavior/behavior_executor.hpp
@@ -21,10 +21,10 @@
 #ifndef BEHAVIOR__BEHAVIOR_EXECUTOR_HPP_
 #define BEHAVIOR__BEHAVIOR_EXECUTOR_HPP_
 
+#include <array>
+
 #include <rclcpp/rclcpp.hpp>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
-
-#include <array>
 
 #include "behavior/behavior.hpp"
 #include "behavior/behavior_realization.hpp"

--- a/ateam_ai/src/behavior/behavior_feedback.hpp
+++ b/ateam_ai/src/behavior/behavior_feedback.hpp
@@ -23,6 +23,7 @@
 
 #include <Eigen/Dense>
 
+#include <optional>
 #include <variant>
 #include <vector>
 

--- a/ateam_ai/src/behavior/behavior_follower.hpp
+++ b/ateam_ai/src/behavior/behavior_follower.hpp
@@ -21,10 +21,10 @@
 #ifndef BEHAVIOR__BEHAVIOR_FOLLOWER_HPP_
 #define BEHAVIOR__BEHAVIOR_FOLLOWER_HPP_
 
+#include <array>
+
 #include <rclcpp/rclcpp.hpp>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
-
-#include <array>
 
 #include "behavior/behavior.hpp"
 #include "behavior/behavior_realization.hpp"

--- a/ateam_ai/src/trajectory_generation/ilqr_problem.hpp
+++ b/ateam_ai/src/trajectory_generation/ilqr_problem.hpp
@@ -21,8 +21,9 @@
 #ifndef TRAJECTORY_GENERATION__ILQR_PROBLEM_HPP_
 #define TRAJECTORY_GENERATION__ILQR_PROBLEM_HPP_
 
-#include <optional>
 #include <Eigen/Dense>
+
+#include <optional>
 #include <iostream>
 
 // Defines the abstract definition and solution to the iLQR problem

--- a/ateam_common/include/ateam_common/bi_directional_udp.hpp
+++ b/ateam_common/include/ateam_common/bi_directional_udp.hpp
@@ -21,10 +21,10 @@
 #ifndef ATEAM_COMMON__BI_DIRECTIONAL_UDP_HPP_
 #define ATEAM_COMMON__BI_DIRECTIONAL_UDP_HPP_
 
-#include <boost/asio.hpp>
-
 #include <functional>
 #include <string>
+
+#include <boost/asio.hpp>
 
 namespace ateam_common
 {

--- a/ateam_common/include/ateam_common/multicast_receiver.hpp
+++ b/ateam_common/include/ateam_common/multicast_receiver.hpp
@@ -21,10 +21,10 @@
 #ifndef ATEAM_COMMON__MULTICAST_RECEIVER_HPP_
 #define ATEAM_COMMON__MULTICAST_RECEIVER_HPP_
 
-#include <boost/asio.hpp>
-
 #include <functional>
 #include <string>
+
+#include <boost/asio.hpp>
 
 namespace ateam_common
 {

--- a/ateam_common/include/ateam_common/protobuf_logging.hpp
+++ b/ateam_common/include/ateam_common/protobuf_logging.hpp
@@ -21,10 +21,10 @@
 #ifndef ATEAM_COMMON__PROTOBUF_LOGGING_HPP_
 #define ATEAM_COMMON__PROTOBUF_LOGGING_HPP_
 
-#include <rclcpp/logger.hpp>
-#include <rclcpp/logging.hpp>
 #include <google/protobuf/stubs/logging.h>
 #include <string>
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
 
 /**
  * @brief Sets up the protobuf log handler to redirect all messages through ROS.

--- a/ateam_common/src/bi_directional_udp.cpp
+++ b/ateam_common/src/bi_directional_udp.cpp
@@ -20,7 +20,7 @@
 
 #include "ateam_common/bi_directional_udp.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <algorithm>
 #include <iostream>

--- a/ateam_common/src/bi_directional_udp.cpp
+++ b/ateam_common/src/bi_directional_udp.cpp
@@ -20,11 +20,11 @@
 
 #include "ateam_common/bi_directional_udp.hpp"
 
-#include <boost/bind/bind.hpp>
-
 #include <algorithm>
 #include <iostream>
 #include <string>
+
+#include <boost/bind/bind.hpp>
 
 namespace ateam_common
 {

--- a/ateam_common/src/multicast_receiver.cpp
+++ b/ateam_common/src/multicast_receiver.cpp
@@ -20,10 +20,10 @@
 
 #include "ateam_common/multicast_receiver.hpp"
 
-#include <boost/bind/bind.hpp>
-
 #include <iostream>
 #include <string>
+
+#include <boost/bind/bind.hpp>
 
 namespace ateam_common
 {

--- a/ateam_common/src/multicast_receiver.cpp
+++ b/ateam_common/src/multicast_receiver.cpp
@@ -20,7 +20,7 @@
 
 #include "ateam_common/multicast_receiver.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <iostream>
 #include <string>

--- a/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
+++ b/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
@@ -18,14 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <memory>
+#include <string>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <ateam_common/multicast_receiver.hpp>
 #include <ateam_common/protobuf_logging.hpp>
 #include <ateam_common/topic_names.hpp>
 #include <ssl_league_msgs/msg/referee.hpp>
-#include <memory>
-#include <string>
 #include "message_conversions.hpp"
 
 namespace ateam_game_controller_bridge

--- a/ateam_game_controller_bridge/src/message_conversions.cpp
+++ b/ateam_game_controller_bridge/src/message_conversions.cpp
@@ -19,8 +19,8 @@
 // THE SOFTWARE.
 
 #include "message_conversions.hpp"
-#include <rclcpp/time.hpp>
 #include <algorithm>
+#include <rclcpp/time.hpp>
 
 #define CopyOptional(proto_msg, ros_msg, var_name) \
   if (proto_msg.has_ ## var_name() ) { \

--- a/ateam_game_controller_bridge/src/message_conversions.hpp
+++ b/ateam_game_controller_bridge/src/message_conversions.hpp
@@ -21,17 +21,17 @@
 #ifndef MESSAGE_CONVERSIONS_HPP_
 #define MESSAGE_CONVERSIONS_HPP_
 
+#include <ssl_league_protobufs/ssl_gc_referee_message.pb.h>
+#include <ssl_league_protobufs/ssl_gc_game_event.pb.h>
+#include <ssl_league_protobufs/ssl_gc_common.pb.h>
+#include <ssl_league_protobufs/ssl_gc_geometry.pb.h>
+
 #include <ssl_league_msgs/msg/referee.hpp>
 #include <ssl_league_msgs/msg/team_info.hpp>
 #include <ssl_league_msgs/msg/division.hpp>
 #include <ssl_league_msgs/msg/robot_id.hpp>
 #include <ssl_league_msgs/msg/team.hpp>
 #include <geometry_msgs/msg/point32.hpp>
-
-#include <ssl_league_protobufs/ssl_gc_referee_message.pb.h>
-#include <ssl_league_protobufs/ssl_gc_game_event.pb.h>
-#include <ssl_league_protobufs/ssl_gc_common.pb.h>
-#include <ssl_league_protobufs/ssl_gc_geometry.pb.h>
 
 namespace ateam_game_controller_bridge::message_conversions
 {

--- a/ateam_game_controller_bridge/src/team_client.hpp
+++ b/ateam_game_controller_bridge/src/team_client.hpp
@@ -21,14 +21,14 @@
 #ifndef TEAM_CLIENT_HPP_
 #define TEAM_CLIENT_HPP_
 
-#include <boost/asio.hpp>
-#include <rclcpp/rclcpp.hpp>
 #include <ssl_league_protobufs/ssl_gc_rcon_team.pb.h>
 #include <array>
 #include <atomic>
 #include <mutex>
 #include <string>
 #include <vector>
+#include <boost/asio.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 namespace ateam_game_controller_bridge
 {

--- a/ateam_game_controller_bridge/src/team_client_node.cpp
+++ b/ateam_game_controller_bridge/src/team_client_node.cpp
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <string>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <ateam_common/protobuf_logging.hpp>
@@ -26,7 +27,6 @@
 #include <ateam_msgs/srv/reconnect_team_client.hpp>
 #include <ateam_msgs/srv/set_team_advantage_choice.hpp>
 #include <ateam_msgs/msg/team_client_connection_status.hpp>
-#include <string>
 #include "team_client.hpp"
 
 namespace ateam_game_controller_bridge

--- a/ateam_joystick_control/src/joystick_control_node.cpp
+++ b/ateam_joystick_control/src/joystick_control_node.cpp
@@ -18,13 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <string>
+#include <vector>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <ateam_common/topic_names.hpp>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
 #include <sensor_msgs/msg/joy.hpp>
-#include <string>
-#include <vector>
 
 namespace ateam_joystick_control
 {

--- a/ateam_ssl_simulation_radio_bridge/src/message_conversions.hpp
+++ b/ateam_ssl_simulation_radio_bridge/src/message_conversions.hpp
@@ -21,11 +21,11 @@
 #ifndef MESSAGE_CONVERSIONS_HPP_
 #define MESSAGE_CONVERSIONS_HPP_
 
-#include <ateam_msgs/msg/robot_feedback.hpp>
-#include <ateam_msgs/msg/robot_motion_command.hpp>
-
 #include <ssl_league_protobufs/ssl_simulation_robot_control.pb.h>
 #include <ssl_league_protobufs/ssl_simulation_robot_feedback.pb.h>
+
+#include <ateam_msgs/msg/robot_feedback.hpp>
+#include <ateam_msgs/msg/robot_motion_command.hpp>
 
 namespace ateam_ssl_simulation_radio_bridge::message_conversions
 {

--- a/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
+++ b/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
@@ -18,6 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <ssl_league_protobufs/ssl_simulation_robot_control.pb.h>
+#include <ssl_league_protobufs/ssl_simulation_robot_feedback.pb.h>
+
+#include <array>
+#include <string>
+#include <functional>
+
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 
@@ -25,12 +32,6 @@
 #include <ateam_common/topic_names.hpp>
 #include <ateam_msgs/msg/robot_feedback.hpp>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
-#include <ssl_league_protobufs/ssl_simulation_robot_control.pb.h>
-#include <ssl_league_protobufs/ssl_simulation_robot_feedback.pb.h>
-
-#include <array>
-#include <string>
-#include <functional>
 
 #include "message_conversions.hpp"
 

--- a/ateam_ssl_vision_bridge/CMakeLists.txt
+++ b/ateam_ssl_vision_bridge/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(ateam_common REQUIRED)
 find_package(ssl_league_msgs REQUIRED)
 find_package(ssl_league_protobufs REQUIRED)
@@ -24,6 +25,8 @@ ament_target_dependencies(${PROJECT_NAME}
   ateam_common
   ssl_league_msgs
   ssl_league_protobufs
+  tf2
+  tf2_geometry_msgs
 )
 rclcpp_components_register_node(
   ${PROJECT_NAME}

--- a/ateam_ssl_vision_bridge/package.xml
+++ b/ateam_ssl_vision_bridge/package.xml
@@ -12,6 +12,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>ateam_common</depend>
   <depend>ssl_league_msgs</depend>
   <depend>ssl_league_protobufs</depend>

--- a/ateam_ssl_vision_bridge/src/message_conversions.cpp
+++ b/ateam_ssl_vision_bridge/src/message_conversions.cpp
@@ -22,7 +22,7 @@
 
 #include <rclcpp/time.hpp>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 
 namespace ateam_ssl_vision_bridge::message_conversions

--- a/ateam_ssl_vision_bridge/src/message_conversions.cpp
+++ b/ateam_ssl_vision_bridge/src/message_conversions.cpp
@@ -20,10 +20,11 @@
 
 #include "message_conversions.hpp"
 
+#include <tf2/LinearMath/Quaternion.h>
+
 #include <rclcpp/time.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tf2/LinearMath/Quaternion.h>
 
 namespace ateam_ssl_vision_bridge::message_conversions
 {

--- a/ateam_ssl_vision_bridge/src/message_conversions.hpp
+++ b/ateam_ssl_vision_bridge/src/message_conversions.hpp
@@ -21,6 +21,10 @@
 #ifndef MESSAGE_CONVERSIONS_HPP_
 #define MESSAGE_CONVERSIONS_HPP_
 
+#include <ssl_league_protobufs/ssl_vision_detection.pb.h>
+#include <ssl_league_protobufs/ssl_vision_geometry.pb.h>
+#include <ssl_league_protobufs/ssl_vision_wrapper.pb.h>
+
 #include <ssl_league_msgs/msg/vision_detection_ball.hpp>
 #include <ssl_league_msgs/msg/vision_detection_robot.hpp>
 #include <ssl_league_msgs/msg/vision_detection_frame.hpp>
@@ -30,10 +34,6 @@
 #include <ssl_league_msgs/msg/vision_geometry_camera_calibration.hpp>
 #include <ssl_league_msgs/msg/vision_geometry_data.hpp>
 #include <ssl_league_msgs/msg/vision_wrapper.hpp>
-
-#include <ssl_league_protobufs/ssl_vision_detection.pb.h>
-#include <ssl_league_protobufs/ssl_vision_geometry.pb.h>
-#include <ssl_league_protobufs/ssl_vision_wrapper.pb.h>
 
 namespace ateam_ssl_vision_bridge::message_conversions
 {

--- a/ateam_ssl_vision_bridge/src/ssl_vision_bridge_node.cpp
+++ b/ateam_ssl_vision_bridge/src/ssl_vision_bridge_node.cpp
@@ -18,6 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <ssl_league_protobufs/ssl_vision_wrapper.pb.h>
+
+#include <string>
+
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 
@@ -25,9 +29,6 @@
 #include <ateam_common/protobuf_logging.hpp>
 #include <ateam_common/topic_names.hpp>
 #include <ssl_league_msgs/msg/vision_wrapper.hpp>
-#include <ssl_league_protobufs/ssl_vision_wrapper.pb.h>
-
-#include <string>
 
 #include "message_conversions.hpp"
 

--- a/ateam_ui/test/launch_tests/ateam_ui_test.py
+++ b/ateam_ui/test/launch_tests/ateam_ui_test.py
@@ -103,7 +103,7 @@ class TestUI(unittest.TestCase):
         # Check robot subscriptions
         for team in ["yellow", "blue"]:
             for id in range(0, 16):
-                topic = (f"/{team}/robot{id}", ['ateam_msgs/msg/RobotState'])
+                topic = (f"/{team}_team/robot{id}", ['ateam_msgs/msg/RobotState'])
                 self.assertIn(topic, subscriptions)
 
         # Check subscription to /overlay

--- a/ateam_vision_filter/CMakeLists.txt
+++ b/ateam_vision_filter/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(ateam_common REQUIRED)
 find_package(ateam_msgs REQUIRED)
 find_package(ssl_league_msgs REQUIRED)
@@ -52,6 +53,8 @@ ament_target_dependencies(${PROJECT_NAME}
   ateam_msgs
   ssl_league_msgs
   Eigen3
+  tf2
+  tf2_geometry_msgs
 )
 rclcpp_components_register_node(
   ${PROJECT_NAME}

--- a/ateam_vision_filter/package.xml
+++ b/ateam_vision_filter/package.xml
@@ -12,6 +12,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>ateam_common</depend>
   <depend>ateam_msgs</depend>
   <depend>ssl_league_msgs</depend>

--- a/ateam_vision_filter/src/ateam_vision_filter_node.cpp
+++ b/ateam_vision_filter/src/ateam_vision_filter_node.cpp
@@ -18,16 +18,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <rclcpp/rclcpp.hpp>
-#include <rclcpp_components/register_node_macro.hpp>
-
-#include <ateam_common/topic_names.hpp>
-
 #include <chrono>
 #include <functional>
 #include <mutex>
 #include <iostream>
 #include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+
+#include <ateam_common/topic_names.hpp>
 
 #include "world.hpp"
 #include "message_conversions.hpp"

--- a/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.cpp
+++ b/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.cpp
@@ -20,14 +20,14 @@
 
 #include "filters/multiple_hypothesis_tracker.hpp"
 
-#include <boost/graph/successive_shortest_path_nonnegative_weights.hpp>
-
 #include <algorithm>
 #include <map>
 #include <set>
 #include <utility>
 #include <vector>
 #include <iostream>
+
+#include <boost/graph/successive_shortest_path_nonnegative_weights.hpp>
 
 void MultipleHypothesisTracker::set_base_track(const InteractingMultipleModelFilter & base_track)
 {

--- a/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.hpp
+++ b/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.hpp
@@ -27,11 +27,12 @@
 // Returns best track
 
 #include <Eigen/Dense>
-#include <boost/graph/adjacency_list.hpp>
 
 #include <map>
 #include <utility>
 #include <vector>
+
+#include <boost/graph/adjacency_list.hpp>
 
 #include "filters/interacting_multiple_model_filter.hpp"
 

--- a/ateam_vision_filter/src/generators/generator_util.hpp
+++ b/ateam_vision_filter/src/generators/generator_util.hpp
@@ -21,10 +21,10 @@
 #ifndef GENERATORS__GENERATOR_UTIL_HPP_
 #define GENERATORS__GENERATOR_UTIL_HPP_
 
-#include <optional>
 #include <Eigen/Dense>
 
 #include <array>
+#include <optional>
 
 #include "types/robot.hpp"
 

--- a/ateam_vision_filter/src/generators/transmission_probability_generator.hpp
+++ b/ateam_vision_filter/src/generators/transmission_probability_generator.hpp
@@ -29,6 +29,7 @@
 #include <Eigen/Dense>
 
 #include <array>
+#include <optional>
 
 #include "types/ball.hpp"
 #include "types/models.hpp"

--- a/ateam_vision_filter/src/message_conversions.cpp
+++ b/ateam_vision_filter/src/message_conversions.cpp
@@ -20,8 +20,9 @@
 
 #include "message_conversions.hpp"
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2/LinearMath/Quaternion.h>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace ateam_vision_filter::message_conversions
 {

--- a/ateam_vision_filter/src/message_conversions.cpp
+++ b/ateam_vision_filter/src/message_conversions.cpp
@@ -20,7 +20,7 @@
 
 #include "message_conversions.hpp"
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 
 namespace ateam_vision_filter::message_conversions


### PR DESCRIPTION
This PR updates the repo to build against ROS 2 Humble Hawksbill / Ubuntu 22.04.

Key changes for upgrade compatibility:
- Update CI setup to use Humble & Ubuntu 22.04
- Add missing dependencies and includes to certain packages / files.
- Fix include order to match fixes made to the cpplint tool.

One issue encountered during upgrade: #85 