### PR TITLE
Adds TeamColorListener.

### DIFF
--- a/ateam_common/CMakeLists.txt
+++ b/ateam_common/CMakeLists.txt
@@ -10,16 +10,19 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Protobuf REQUIRED)
+find_package(ssl_league_msgs REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/multicast_receiver.cpp
   src/bi_directional_udp.cpp
   src/parameters.cpp
+  src/team_color_listener.cpp
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
 ament_target_dependencies(${PROJECT_NAME}
   rclcpp
   rclcpp_components
+  ssl_league_msgs
 )
 target_link_libraries(${PROJECT_NAME}
   Boost::boost

--- a/ateam_common/include/ateam_common/team_color_listener.hpp
+++ b/ateam_common/include/ateam_common/team_color_listener.hpp
@@ -1,0 +1,86 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ATEAM_COMMON__TEAM_COLOR_LISTENER_HPP_
+#define ATEAM_COMMON__TEAM_COLOR_LISTENER_HPP_
+
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <ssl_league_msgs/msg/referee.hpp>
+
+namespace ateam_common
+{
+
+/**
+ * @brief Utility for subscribing to referee messages and extracting our team color
+ *
+ * The SSL game controller (GC) is the authoritative source for which color is assigned to which team. This utility
+ * provides a simple interface for any node to query our currently assigned team color. This class subscribes to
+ * and parses the referee messages from the GC to check our team's color.
+ * 
+ * Users can query the current team color using TeamColorListener::GetTeamColor() or provide a callback to be called
+ * when the team color changes.
+ * 
+ * This class adds two parameters to the node:
+ * 
+ * - gc_team_name  (string)
+ *   The name of our team as it appears in the GC.
+ * 
+ * - default_team_color  (string)
+ *   The team color assumed before the first referee message is received. Can be set to 'yellow', 'blue', or 'unknown'
+ */
+class TeamColorListener
+{
+public:
+  enum class TeamColor
+  {
+    Unknown,
+    Yellow,
+    Blue
+  };
+
+  using Callback = std::function<void (TeamColor)>;
+
+  /**
+   * @brief Construct a new Team Color Listener object
+   *
+   * @param node ROS node
+   * @param callback Optional callback called on color change
+   */
+  explicit TeamColorListener(rclcpp::Node & node, Callback callback = {});
+
+  const TeamColor & GetTeamColor() const
+  {
+    return team_color_;
+  }
+
+private:
+  const std::string team_name_;
+  TeamColor team_color_{TeamColor::Unknown};
+  Callback callback_;
+  rclcpp::Subscription<ssl_league_msgs::msg::Referee>::SharedPtr ref_subscription_;
+
+  void RefereeMessageCallback(const ssl_league_msgs::msg::Referee::ConstSharedPtr msg);
+};
+
+}  // namespace ateam_common
+
+#endif  // ATEAM_COMMON__TEAM_COLOR_LISTENER_HPP_

--- a/ateam_common/include/ateam_common/team_color_listener.hpp
+++ b/ateam_common/include/ateam_common/team_color_listener.hpp
@@ -35,15 +35,15 @@ namespace ateam_common
  * The SSL game controller (GC) is the authoritative source for which color is assigned to which team. This utility
  * provides a simple interface for any node to query our currently assigned team color. This class subscribes to
  * and parses the referee messages from the GC to check our team's color.
- * 
+ *
  * Users can query the current team color using TeamColorListener::GetTeamColor() or provide a callback to be called
  * when the team color changes.
- * 
+ *
  * This class adds two parameters to the node:
- * 
+ *
  * - gc_team_name  (string)
  *   The name of our team as it appears in the GC.
- * 
+ *
  * - default_team_color  (string)
  *   The team color assumed before the first referee message is received. Can be set to 'yellow', 'blue', or 'unknown'
  */

--- a/ateam_common/package.xml
+++ b/ateam_common/package.xml
@@ -12,6 +12,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>boost</depend>
+  <depend>ssl_league_msgs</depend>
 
   <build_depend>protobuf-dev</build_depend>
   <exec_depend>protobuf</exec_depend>

--- a/ateam_common/src/team_color_listener.cpp
+++ b/ateam_common/src/team_color_listener.cpp
@@ -1,0 +1,69 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "ateam_common/team_color_listener.hpp"
+#include <string>
+
+namespace ateam_common
+{
+
+TeamColorListener::TeamColorListener(rclcpp::Node & node, Callback callback)
+: team_name_(node.declare_parameter<std::string>("gc_team_name", "A-Team")),
+  callback_(callback)
+{
+  const auto default_team_color =
+    node.declare_parameter<std::string>("default_team_color", "yellow");
+  if (default_team_color == "yellow") {
+    team_color_ = TeamColor::Yellow;
+  } else if (default_team_color == "blue") {
+    team_color_ = TeamColor::Blue;
+  } else if (default_team_color == "unknown") {
+    team_color_ = TeamColor::Unknown;
+  } else {
+    RCLCPP_WARN(
+      node.get_logger(),
+      "Unrecognized value for param 'default_team_color'. Ignoring and defaulting to Unknown.");
+  }
+
+  rclcpp::QoS qos(1);
+  qos.reliable();
+  qos.transient_local();
+  ref_subscription_ = node.create_subscription<ssl_league_msgs::msg::Referee>(
+    "/gc_multicast_bridge_node/referee_messages", qos,
+    std::bind(&TeamColorListener::RefereeMessageCallback, this, std::placeholders::_1));
+}
+
+void TeamColorListener::RefereeMessageCallback(
+  const ssl_league_msgs::msg::Referee::ConstSharedPtr msg)
+{
+  const auto prev_color = team_color_;
+  if (msg->blue.name == team_name_) {
+    team_color_ = TeamColor::Blue;
+  } else if (msg->yellow.name == team_name_) {
+    team_color_ = TeamColor::Yellow;
+  } else {
+    team_color_ = TeamColor::Unknown;
+  }
+  if (team_color_ != prev_color && callback_) {
+    callback_(team_color_);
+  }
+}
+
+}  // namespace ateam_common


### PR DESCRIPTION
Getting started on merging the stuff I wrote while working on the radio bridge. First up: TeamColorListener.

This gives us an easy way for any node to check our actual assigned team color from the GC. 