### PR TITLE
Fix angle conversion to Quat and angle wrapping

### DIFF
--- a/ateam_ai/src/ateam_ai_node.cpp
+++ b/ateam_ai/src/ateam_ai_node.cpp
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 #include <tf2/LinearMath/Quaternion.h>
+#include <tf2/utils.h>
 
 #include <array>
 #include <chrono>
@@ -132,7 +133,7 @@ private:
     robot_states.at(id).value().pos.y() = robot_state_msg->pose.position.y;
     tf2::Quaternion tf2_quat;
     tf2::fromMsg(robot_state_msg->pose.orientation, tf2_quat);
-    robot_states.at(id).value().theta = tf2_quat.getAngle();
+    robot_states.at(id).value().theta = tf2::getYaw(tf2_quat);
     robot_states.at(id).value().vel.x() = robot_state_msg->twist.linear.x;
     robot_states.at(id).value().vel.y() = robot_state_msg->twist.linear.y;
     robot_states.at(id).value().omega = robot_state_msg->twist.angular.z;

--- a/ateam_vision_filter/src/camera.cpp
+++ b/ateam_vision_filter/src/camera.cpp
@@ -108,6 +108,7 @@ void Camera::setup_ball_interacting_multiple_model_filter(
   base_kf_model.set_H(Models::Ball::H);
   base_kf_model.set_Q(Models::Ball::Q);
   base_kf_model.set_R(Models::Ball::R);
+  base_kf_model.set_AngleMask(Models::Ball::AngleMask);
   base_kf_model.set_initial_x_hat(Eigen::Matrix<double, 6, 1>::Zero());
   base_kf_model.set_initial_p(Eigen::Matrix<double, 6, 6>::Identity());
 
@@ -138,6 +139,7 @@ void Camera::setup_robot_interacting_multiple_model_filter(
   base_kf_model.set_H(Models::Robot::H);
   base_kf_model.set_Q(Models::Robot::Q);
   base_kf_model.set_R(Models::Robot::R);
+  base_kf_model.set_AngleMask(Models::Robot::AngleMask);
   base_kf_model.set_initial_x_hat(Eigen::Matrix<double, 9, 1>::Zero());
   base_kf_model.set_initial_p(Eigen::Matrix<double, 9, 9>::Identity());
 

--- a/ateam_vision_filter/src/filters/kalman_filter.hpp
+++ b/ateam_vision_filter/src/filters/kalman_filter.hpp
@@ -35,6 +35,7 @@ public:
   void set_H(const Eigen::MatrixXd & H);
   void set_Q(const Eigen::MatrixXd & Q);
   void set_R(const Eigen::MatrixXd & R);
+  void set_AngleMask(const Eigen::MatrixXd & angleMask);
 
   void predict(const Eigen::VectorXd & u);
   void update(const Eigen::VectorXd & z);
@@ -46,6 +47,7 @@ public:
   Eigen::VectorXd get_potential_measurement_error(const Eigen::VectorXd & z);
 
 private:
+  Eigen::MatrixXd AngleMask;
   Eigen::MatrixXd F;
   Eigen::MatrixXd B;
   Eigen::MatrixXd H;

--- a/ateam_vision_filter/src/message_conversions.cpp
+++ b/ateam_vision_filter/src/message_conversions.cpp
@@ -20,6 +20,7 @@
 
 #include "message_conversions.hpp"
 
+#include <tf2/utils.h>
 #include <tf2/LinearMath/Quaternion.h>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
@@ -88,7 +89,7 @@ RobotMeasurement fromMsg(const ssl_league_msgs::msg::VisionDetectionRobot & ros_
   robotDetection.position.x() = ros_msg.pose.position.x;
   robotDetection.position.y() = ros_msg.pose.position.y;
   tf2::fromMsg(ros_msg.pose.orientation, tf2_quat);
-  robotDetection.theta = tf2_quat.getAngle();
+  robotDetection.theta = tf2::getYaw(tf2_quat);
   return robotDetection;
 }
 

--- a/ateam_vision_filter/src/types/models.hpp
+++ b/ateam_vision_filter/src/types/models.hpp
@@ -52,6 +52,10 @@ const double rolling_friction_accel = 0.1;  // m/s^2 decel of rolling friction
 const double sliding_friction_accel = 0.1;  // m/s^2 decel of sliding friction
 
 // pos_x, pos_y, vel_x, vel_y, accel_x, accel_y
+
+const Eigen::MatrixXd AngleMask =
+  (Eigen::MatrixXd(6, 1) << 0, 0, 0, 0, 0, 0).finished();
+
 const double dt22 = dt * dt / 2;  // accel -> position
 const Eigen::MatrixXd F =
   (Eigen::MatrixXd(6, 6) <<
@@ -92,7 +96,7 @@ const Eigen::MatrixXd Q =
   dt2, 0, dt, 0, 1, 0,
   0, dt2, 0, dt, 0, 1).finished() * sigma_alpha_squared;
 
-const double sigma_pos_squared = 0.1;  // Position measurement error
+const double sigma_pos_squared = 0.01;  // Position measurement error
 const Eigen::MatrixXd R =
   (Eigen::MatrixXd(2, 2) <<
   sigma_pos_squared, 0,
@@ -109,6 +113,10 @@ const double max_speed = 6;
 const double max_acceleration = 12;
 
 // pos_x, pos_y, theta, vel_x, vel_y, omega, accel_x, accel_y, alpha
+
+const Eigen::MatrixXd AngleMask =
+  (Eigen::MatrixXd(9, 1) << 0, 0, 1, 0, 0, 0, 0, 0, 0).finished();
+
 const double dt22 = dt * dt / 2;  // accel -> position
 const Eigen::MatrixXd F =
   (Eigen::MatrixXd(9, 9) <<
@@ -171,8 +179,8 @@ const Eigen::MatrixXd Q =
   0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, dt2, 0, 0, dt, 0, 0, 1).finished() * sigma_angular_alpha_squared;
 
-const double sigma_pos_squared = 0.1;  // Position measurement error
-const double sigma_theta_squared = 0.1;  // Angular heading measurement error
+const double sigma_pos_squared = 0.01;  // Position measurement error
+const double sigma_theta_squared = 0.01;  // Angular heading measurement error
 const Eigen::MatrixXd R =
   (Eigen::MatrixXd(3, 3) <<
   sigma_pos_squared, 0, 0,


### PR DESCRIPTION
The quat calculations were only returning angles between 0 and PI. In addition, the kalman filters weren't well suited for the wrapping of angles. This fixes both issues

Part of #87 