### PR TITLE
Joystick updates from quals

### DIFF
--- a/ateam_bringup/launch/joystick_only_stack.launch.xml
+++ b/ateam_bringup/launch/joystick_only_stack.launch.xml
@@ -1,0 +1,4 @@
+<launch>
+  <include file="$(find-pkg-share ateam_joystick_control)/launch/joystick_controller.launch.xml"/>
+  <node name="radio_bridge" pkg="ateam_radio_bridge" exec="radio_bridge_node" />
+</launch>

--- a/ateam_common/include/ateam_common/topic_names.hpp
+++ b/ateam_common/include/ateam_common/topic_names.hpp
@@ -38,7 +38,7 @@ constexpr std::string_view kYellowTeamRobotPrefix = "/yellow_team/robot";
 constexpr std::string_view kBlueTeamRobotPrefix = "/blue_team/robot";
 
 // Output from joysticks
-constexpr std::string_view kJoystick = "/joystick";
+constexpr std::string_view kJoystick = "/joy";
 
 // Output from AI
 constexpr std::string_view kRobotMotionCommandPrefix = "/robot_motion_commands/robot";

--- a/ateam_joystick_control/config/common_params.yaml
+++ b/ateam_joystick_control/config/common_params.yaml
@@ -1,0 +1,3 @@
+/joystick_control_node:
+  ros__parameters:
+    dribbler_speed_step: 10.0

--- a/ateam_joystick_control/config/xbox_joy_config.yaml
+++ b/ateam_joystick_control/config/xbox_joy_config.yaml
@@ -3,12 +3,17 @@
     mapping:
       linear:
         x:
-          axis: 1
-          scale: 1.0
-        y:
           axis: 0
-          scale: 1.0
+          scale: 0.01
+        y:
+          axis: 1
+          scale: 0.01
       angular:
         z:
           axis: 3
-          scale: 1.0
+          scale: 0.01
+      kick: 5
+      dribbler:
+        increment: 3
+        decrement: 2
+        spin: 4

--- a/ateam_joystick_control/launch/joystick_controller.launch.xml
+++ b/ateam_joystick_control/launch/joystick_controller.launch.xml
@@ -4,6 +4,7 @@
   <node name="joystick_node" pkg="joy" exec="joy_node"/>
   <node name="joystick_control_node" pkg="ateam_joystick_control" exec="joystick_control_node">
     <param from="$(var joy_config_file)"/>
+    <param from="$(find-pkg-share ateam_joystick_control)/config/common_params.yaml"/>
     <param name="command_topic_template" value="/radio_bridge/robot_motion_commands/robot{}" />
     <remap from="~/joy" to="/joy"/>
   </node>

--- a/ateam_joystick_control/src/joystick_control_node.cpp
+++ b/ateam_joystick_control/src/joystick_control_node.cpp
@@ -69,6 +69,9 @@ public:
         {"dribbler.min", 0.0}
       });
 
+    // controls the size of steps when changing dribbler speed
+    declare_parameter<double>("dribbler_speed_step", 10.0);
+
     CreatePublisher(declare_parameter<int>("robot_id", 0));
     parameter_callback_handle_ =
       add_on_set_parameters_callback(
@@ -114,10 +117,10 @@ private:
     const auto dribbler_dec_button = get_parameter("mapping.dribbler.decrement").as_int();
 
     if (joy_message->buttons[dribbler_inc_button] && !prev_joy_msg_.buttons[dribbler_inc_button]) {
-      dribbler_speed_ += 10;  // TODO(barulicm) parameterize
+      dribbler_speed_ += get_parameter("dribbler_speed_step").as_double();
     }
     if (joy_message->buttons[dribbler_dec_button] && !prev_joy_msg_.buttons[dribbler_dec_button]) {
-      dribbler_speed_ -= 10;
+      dribbler_speed_ -= get_parameter("dribbler_speed_step").as_double();
     }
     dribbler_speed_ =
       std::clamp(

--- a/ateam_joystick_control/test/launch_tests/joystick_control_node_test.py
+++ b/ateam_joystick_control/test/launch_tests/joystick_control_node_test.py
@@ -56,7 +56,7 @@ class TestJoystickControlNode(unittest.TestCase):
         self.message_pump = launch_testing_ros.MessagePump(
             self.node, context=self.context)
         self.pub = self.node.create_publisher(
-            sensor_msgs.msg.Joy, '/joystick', 1)
+            sensor_msgs.msg.Joy, '/joy', 1)
 
         self.sub_0 = self.node.create_subscription(
             ateam_msgs.msg.RobotMotionCommand, '/motion_commands/robot_0', self.callback_0, 1)

--- a/ateam_msgs/msg/RobotMotionCommand.msg
+++ b/ateam_msgs/msg/RobotMotionCommand.msg
@@ -2,3 +2,5 @@
 # XY in translation (m/s)
 # Z in rotation (rad/s)
 geometry_msgs/Twist twist
+float32 dribbler_speed  # rpm
+bool kick  # TODO: radio protocol uses float to support multiple kick speeds / powers


### PR DESCRIPTION
This PR includes changes made to the joystick controller while developing the radio bridge in preparation for qualification.

These changes include:
- Additional parameters on the joystick control node for controlling the dribbler and kicker
- A new bringup file that starts the joystick and radio bridge (coming soon) for simple manual control
- New fields in the robot motion command message for dribbler speed and kicking (will require some minor conflict resolution with other branches that added similar fields).