### PR TITLE
Add state logging to the vision filter

### DIFF
--- a/ateam_common/include/ateam_common/topic_names.hpp
+++ b/ateam_common/include/ateam_common/topic_names.hpp
@@ -36,6 +36,7 @@ constexpr std::string_view kRobotFeedbackPrefix = "/robot_feedback/robot";
 constexpr std::string_view kBall = "/ball";
 constexpr std::string_view kYellowTeamRobotPrefix = "/yellow_team/robot";
 constexpr std::string_view kBlueTeamRobotPrefix = "/blue_team/robot";
+constexpr std::string_view kVisionState = "/vision_state";  // Internal vision filter state
 
 // Output from joysticks
 constexpr std::string_view kJoystick = "/joystick";

--- a/ateam_msgs/CMakeLists.txt
+++ b/ateam_msgs/CMakeLists.txt
@@ -19,6 +19,11 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/Sample3d.msg
   msg/TeamClientConnectionStatus.msg
   msg/Trajectory.msg
+  msg/VisionCameraState.msg
+  msg/VisionIMMState.msg
+  msg/VisionMHTState.msg
+  msg/VisionModelState.msg
+  msg/VisionWorldState.msg
   msg/World.msg
 
   srv/ReconnectTeamClient.srv

--- a/ateam_msgs/msg/VisionCameraState.msg
+++ b/ateam_msgs/msg/VisionCameraState.msg
@@ -1,0 +1,4 @@
+uint8 camera_id
+ateam_msgs/VisionMHTState[] yellow_robots
+ateam_msgs/VisionMHTState[] blue_robots
+ateam_msgs/VisionMHTState ball

--- a/ateam_msgs/msg/VisionIMMState.msg
+++ b/ateam_msgs/msg/VisionIMMState.msg
@@ -1,0 +1,2 @@
+ateam_msgs/VisionModelState[] models
+uint32 updates_until_valid_track

--- a/ateam_msgs/msg/VisionMHTState.msg
+++ b/ateam_msgs/msg/VisionMHTState.msg
@@ -1,0 +1,1 @@
+ateam_msgs/VisionIMMState[] tracks

--- a/ateam_msgs/msg/VisionModelState.msg
+++ b/ateam_msgs/msg/VisionModelState.msg
@@ -1,0 +1,2 @@
+int32 model_type
+float32 mu

--- a/ateam_msgs/msg/VisionWorldState.msg
+++ b/ateam_msgs/msg/VisionWorldState.msg
@@ -1,0 +1,1 @@
+ateam_msgs/VisionCameraState[] camera_states

--- a/ateam_vision_filter/src/ateam_vision_filter_node.cpp
+++ b/ateam_vision_filter/src/ateam_vision_filter_node.cpp
@@ -58,6 +58,10 @@ public:
         rclcpp::SystemDefaultsQoS());
     }
 
+    vision_state_publisher_ = create_publisher<ateam_msgs::msg::VisionWorldState>(
+      std::string(Topics::kVisionState),
+      rclcpp::SystemDefaultsQoS());
+
     ssl_vision_subscription_ =
       create_subscription<ssl_league_msgs::msg::VisionWrapper>(
       std::string(Topics::kVisionMessages),
@@ -78,6 +82,8 @@ public:
   void timer_callback()
   {
     const std::lock_guard<std::mutex> lock(world_mutex_);
+    vision_state_publisher_->publish(world_.get_vision_world_state());
+
     world_.predict();
 
     std::optional<Ball> maybe_ball = world_.get_ball_estimate();
@@ -108,6 +114,7 @@ private:
   std::array<rclcpp::Publisher<ateam_msgs::msg::RobotState>::SharedPtr, 16> blue_robots_publisher_;
   std::array<rclcpp::Publisher<ateam_msgs::msg::RobotState>::SharedPtr,
     16> yellow_robots_publisher_;
+  rclcpp::Publisher<ateam_msgs::msg::VisionWorldState>::SharedPtr vision_state_publisher_;
   rclcpp::Subscription<ssl_league_msgs::msg::VisionWrapper>::SharedPtr ssl_vision_subscription_;
 
   std::mutex world_mutex_;

--- a/ateam_vision_filter/src/camera.cpp
+++ b/ateam_vision_filter/src/camera.cpp
@@ -24,6 +24,8 @@
 #include <utility>
 #include <vector>
 
+#include <ateam_msgs/msg/vision_mht_state.hpp>
+
 #include "filters/kalman_filter.hpp"
 #include "filters/interacting_multiple_model_filter.hpp"
 #include "types/models.hpp"
@@ -96,6 +98,25 @@ std::array<std::optional<Camera::RobotWithScore>,
 std::array<std::optional<Camera::RobotWithScore>, 16> Camera::get_blue_robot_estimates_with_score()
 {
   return get_robot_estimates_with_score(blue_team);
+}
+
+ateam_msgs::msg::VisionCameraState Camera::get_vision_camera_state() const
+{
+  ateam_msgs::msg::VisionCameraState camera_state;
+
+  // Prefill up to team size
+  for (std::size_t i = 0; i < yellow_team.size(); i++) {
+    camera_state.yellow_robots.push_back(ateam_msgs::msg::VisionMHTState());
+    camera_state.blue_robots.push_back(ateam_msgs::msg::VisionMHTState());
+  }
+
+  for (std::size_t i = 0; i < yellow_team.size(); i++) {
+    camera_state.yellow_robots.at(i) = yellow_team.at(i).get_vision_mht_state();
+    camera_state.blue_robots.at(i) = blue_team.at(i).get_vision_mht_state();
+  }
+  camera_state.ball = ball.get_vision_mht_state();
+
+  return camera_state;
 }
 
 void Camera::setup_ball_interacting_multiple_model_filter(

--- a/ateam_vision_filter/src/camera.hpp
+++ b/ateam_vision_filter/src/camera.hpp
@@ -28,6 +28,8 @@
 #include <utility>
 #include <vector>
 
+#include <ateam_msgs/msg/vision_camera_state.hpp>
+
 #include "filters/multiple_hypothesis_tracker.hpp"
 #include "generators/model_input_generator.hpp"
 #include "generators/transmission_probability_generator.hpp"
@@ -69,6 +71,11 @@ public:
    * @return Returns blue robots with a corresponding likelihood score (if exists)
    */
   std::array<std::optional<RobotWithScore>, 16> get_blue_robot_estimates_with_score();
+
+  /**
+   * @return ROS2 msg containing the current internal state
+   */
+  ateam_msgs::msg::VisionCameraState get_vision_camera_state() const;
 
 private:
   void setup_ball_interacting_multiple_model_filter(

--- a/ateam_vision_filter/src/filters/interacting_multiple_model_filter.cpp
+++ b/ateam_vision_filter/src/filters/interacting_multiple_model_filter.cpp
@@ -161,6 +161,20 @@ double InteractingMultipleModelFilter::get_potential_measurement_error(
   return potential_measurement_error.norm();
 }
 
+ateam_msgs::msg::VisionIMMState InteractingMultipleModelFilter::get_vision_imm_state() const
+{
+  ateam_msgs::msg::VisionIMMState imm_state;
+  for (const auto & model_type : model_types) {
+    ateam_msgs::msg::VisionModelState model_state;
+    model_state.model_type = model_type;
+    model_state.mu = mu.at(model_type);
+    imm_state.models.push_back(model_state);
+  }
+  imm_state.updates_until_valid_track = updates_until_valid_track;
+
+  return imm_state;
+}
+
 void InteractingMultipleModelFilter::update_mu(const Eigen::VectorXd & zt)
 {
   // Eq 14

--- a/ateam_vision_filter/src/filters/interacting_multiple_model_filter.hpp
+++ b/ateam_vision_filter/src/filters/interacting_multiple_model_filter.hpp
@@ -39,6 +39,8 @@
 #include <memory>
 #include <vector>
 
+#include <ateam_msgs/msg/vision_imm_state.hpp>
+
 #include "filters/kalman_filter.hpp"
 #include "types/models.hpp"
 #include "generators/model_input_generator.hpp"
@@ -92,6 +94,11 @@ public:
    * @return Score of how far off a potential measurement error is
    */
   double get_potential_measurement_error(const Eigen::VectorXd & measurement);
+
+  /**
+   * @return ROS2 msg containing the current internal state
+   */
+  ateam_msgs::msg::VisionIMMState get_vision_imm_state() const;
 
 private:
   void update_mu(const Eigen::VectorXd & zt);

--- a/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.cpp
+++ b/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.cpp
@@ -186,6 +186,16 @@ get_state_estimate() const
   return std::make_pair(best_track->get_state_estimate(), best_track->get_validity_score());
 }
 
+ateam_msgs::msg::VisionMHTState MultipleHypothesisTracker::get_vision_mht_state() const
+{
+  ateam_msgs::msg::VisionMHTState mht_state;
+  for (const auto & track : tracks) {
+    mht_state.tracks.push_back(track.get_vision_imm_state());
+  }
+
+  return mht_state;
+}
+
 void MultipleHypothesisTracker::add_edge_to_graph(
   graph_t & graph,
   edge_capacity_list_t & edge_capacity_list,

--- a/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.hpp
+++ b/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.hpp
@@ -32,6 +32,8 @@
 #include <utility>
 #include <vector>
 
+#include <ateam_msgs/msg/vision_mht_state.hpp>
+
 #include <boost/graph/adjacency_list.hpp>
 
 #include "filters/interacting_multiple_model_filter.hpp"
@@ -47,6 +49,11 @@ public:
   void predict();
 
   std::optional<StateWithScore> get_state_estimate() const;
+
+  /**
+   * @return ROS2 msg containing the current internal state
+   */
+  ateam_msgs::msg::VisionMHTState get_vision_mht_state() const;
 
 private:
   using adjacency_list_traits = boost::adjacency_list_traits<boost::vecS, boost::vecS,

--- a/ateam_vision_filter/src/world.cpp
+++ b/ateam_vision_filter/src/world.cpp
@@ -216,3 +216,15 @@ std::array<std::optional<Robot>, 16> World::get_blue_robots_estimate()
 
   return blue_robots_estimates;
 }
+
+ateam_msgs::msg::VisionWorldState World::get_vision_world_state() const
+{
+  ateam_msgs::msg::VisionWorldState world_state;
+  for (const auto & camera_pair : cameras) {
+    ateam_msgs::msg::VisionCameraState camera_state = camera_pair.second.get_vision_camera_state();
+    camera_state.camera_id = camera_pair.first;
+    world_state.camera_states.push_back(camera_state);
+  }
+
+  return world_state;
+}

--- a/ateam_vision_filter/src/world.hpp
+++ b/ateam_vision_filter/src/world.hpp
@@ -27,6 +27,8 @@
 #include <map>
 #include <memory>
 
+#include <ateam_msgs/msg/vision_world_state.hpp>
+
 #include "camera.hpp"
 #include "generators/model_input_generator.hpp"
 #include "generators/transmission_probability_generator.hpp"
@@ -68,6 +70,11 @@ public:
    * @return The best possible estimate for each blue robot (if one exists)
    */
   std::array<std::optional<Robot>, 16> get_blue_robots_estimate();
+
+  /**
+   * @return ROS2 msg containing the current internal state
+   */
+  ateam_msgs::msg::VisionWorldState get_vision_world_state() const;
 
 private:
   std::shared_ptr<ModelInputGenerator> model_input_generator;


### PR DESCRIPTION
For part of #94

We will now be able to log and inspect the internal state of the vision filter. This should allow us to easily tell the relative change in mode's mu as well as other critical pieces of information to debug. Started light on which elements exactly to log, but we can expand this easily as more needs arise.

![image](https://user-images.githubusercontent.com/5797304/227425442-bdd4e1eb-96e0-4fa5-b28e-929c78333162.png)
