### PR TITLE
Add Line Search to iLQR

### DIFF
--- a/ateam_ai/src/trajectory_generation/ilqr_problem.hpp
+++ b/ateam_ai/src/trajectory_generation/ilqr_problem.hpp
@@ -275,10 +275,10 @@ private:
 
   static constexpr std::size_t max_num_iterations = 1000;
   static constexpr double converge_threshold = 1e-6;
-  static constexpr double alpha_change = 0.99;
+  static constexpr double alpha_change = 0.5;
   static constexpr double eps = 1e-3;
 
-  double alpha = 1;  // backtracking serach parameter
+  double alpha = 1e-3;  // backtracking serach parameter
   Trajectory trajectory;
   Actions actions;
 


### PR DESCRIPTION
In this PR I will add a line search taken from [this paper](https://bjack205.github.io/papers/AL_iLQR_Tutorial.pdf) which uses an estimated vs actual cost reduction ratio for each ilqr step to break the line search. I apply a minor cleanup to some variable names and calculations due to how annoyingly confusing it was with all the eigen.block operations. 