### PR TITLE
Dedup radio that was in both grsim and full_stack

### DIFF
--- a/ateam_bringup/launch/full_stack.launch.xml
+++ b/ateam_bringup/launch/full_stack.launch.xml
@@ -1,6 +1,5 @@
 <launch>
   <node name="ssl_vision_bridge" pkg="ateam_ssl_vision_bridge" exec="ssl_vision_bridge_node" />
   <node name="vision_filter" pkg="ateam_vision_filter" exec="ateam_vision_filter_node" />
-  <node name="radio_bridge" pkg="ateam_ssl_simulation_radio_bridge" exec="ssl_simulation_radio_bridge_node" />
   <node name="ateam_ai" pkg="ateam_ai" exec="ateam_ai_node" />
 </launch>


### PR DESCRIPTION
We had 2 radios being launched, one in ssl_grsim and one in full_stack. This removes the one for full_stack as the radio is moreso tied to sim vs irl instead of the rest of the autonomy stack