### PR TITLE
[iLQR Refactor 3] Swap regularization strategies

### DIFF
--- a/ateam_ai/test/trajectory_generation/ilqr_problem_test.cpp
+++ b/ateam_ai/test/trajectory_generation/ilqr_problem_test.cpp
@@ -63,7 +63,6 @@ TEST(iLQRProblem, SamplePointMass)
   auto maybe_trajectory = computer.calculate(Eigen::Vector2d{0, 0});
 
   ASSERT_TRUE(maybe_trajectory.has_value());
-  // TODO(jneiger): Remove tests for now as a later PR will fix convergence
-  // EXPECT_NEAR(maybe_trajectory.value().back().x(), 10, 1e-1);
-  // EXPECT_NEAR(maybe_trajectory.value().back().y(), 0, 1e-4);
+  EXPECT_NEAR(maybe_trajectory.value().back().x(), 10, 1e-1);
+  EXPECT_NEAR(maybe_trajectory.value().back().y(), 0, 1e-1);
 }


### PR DESCRIPTION
Following Kyle's suggestion about strategies.

> At first glance it seems mostly correct but I think the regularization scheme is probably the first thing to try. You're doing Quu regularization which works, but IIRC Yuval found that regularizing Vxx (by adding a small multiple of the identity matrix) is usually a bit better.

This will be one of many refactors trying to clean up the implementation.