### PR TITLE
[iLQR] Add line search

### DIFF
--- a/ateam_ai/test/trajectory_generation/ilqr_problem_test.cpp
+++ b/ateam_ai/test/trajectory_generation/ilqr_problem_test.cpp
@@ -56,8 +56,10 @@ TEST(iLQRProblem, SamplePointMass)
   iLQRParams params{
     .max_ilqr_iterations = 1,
     .max_forward_pass_iterations = 1,
-    .alpha_change = 0.5,
-    .converge_threshold = 1e-1
+    .converge_threshold = 1e-1,
+    .gamma = 0.5,
+    .lambda_min = 1e-6,
+    .delta_zero = 2
   };
   iLQRComputer computer(point_mass_problem, params);
   auto maybe_trajectory = computer.calculate(Eigen::Vector2d{0, 0});


### PR DESCRIPTION
Add the line search to iLQR such that during the backward pass, we try a few multiples of the input feedback. Another suggestion by Kyle

> Line search: Basically, after computing K(t) and k(t), you do a forward rollout with pi(x, t) = uhat(t) + k(t) + K(t)(x(t) - xhat(t)). Then, if it doesn't reduce costs (this line), you should try doing another forward pass with the same feedback gains, but multiplying the FF gains by some constant. If you do multiple forward passes without improving performance, then you can redo a new backwards pass with more regularization.
> 
> You can probably change the factor by which you increase/decrease regularization in this case to 0.5 (rather than 0.9). Waiting for many many failed backwards passes to accumulate before regularization gets large enough is pretty slow. Usually you'd multiply by something like 0.9 on success, and multiply by 2 on failure. Also, FWIW, I've seen people use various schemes for updating this parameter - the most common is to increase it whenever the eigenvalues of Quu become negative somewhere in the backwards pass (the condition you've got is more like the standard line search condition).
