### PR TITLE
Adds indexed topic helpers

### DIFF
--- a/ateam_common/include/ateam_common/indexed_topic_helpers.hpp
+++ b/ateam_common/include/ateam_common/indexed_topic_helpers.hpp
@@ -1,0 +1,70 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ATEAM_COMMON__INDEXED_TOPIC_HELPERS_HPP_
+#define ATEAM_COMMON__INDEXED_TOPIC_HELPERS_HPP_
+
+#include <array>
+#include <functional>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace ateam_common::indexed_topic_helpers
+{
+
+const int kRobotCount = 16;
+
+template<typename MessageType, typename NodeType>
+void create_indexed_subscribers(
+  std::array<typename rclcpp::Subscription<MessageType>::SharedPtr, kRobotCount> & destination,
+  const std::string & topic_base,
+  const rclcpp::QoS & qos,
+  void (NodeType::* callback_pointer)(const typename MessageType::SharedPtr, const int),
+  NodeType * node
+)
+{
+  for (int robot_id = 0; robot_id < kRobotCount; ++robot_id) {
+    std::function<void(const typename MessageType::SharedPtr)> callback =
+      std::bind(callback_pointer, node, std::placeholders::_1, robot_id);
+    destination.at(robot_id) = node->template create_subscription<MessageType>(
+      topic_base + std::to_string(
+        robot_id), qos, callback);
+  }
+}
+
+template<typename MessageType, typename NodeType>
+void create_indexed_publishers(
+  std::array<typename rclcpp::Publisher<MessageType>::SharedPtr, kRobotCount> & destination,
+  const std::string & topic_base,
+  const rclcpp::QoS & qos,
+  NodeType * node
+)
+{
+  for (int robot_id = 0; robot_id < kRobotCount; ++robot_id) {
+    destination.at(robot_id) = node->template create_publisher<MessageType>(
+      topic_base + std::to_string(
+        robot_id), qos);
+  }
+}
+
+}  // namespace ateam_common::indexed_topic_helpers
+
+#endif  // ATEAM_COMMON__INDEXED_TOPIC_HELPERS_HPP_

--- a/ateam_common/include/ateam_common/indexed_topic_helpers.hpp
+++ b/ateam_common/include/ateam_common/indexed_topic_helpers.hpp
@@ -24,6 +24,7 @@
 #include <array>
 #include <functional>
 #include <string>
+#include <string_view>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -35,7 +36,7 @@ const int kRobotCount = 16;
 template<typename MessageType, typename NodeType>
 void create_indexed_subscribers(
   std::array<typename rclcpp::Subscription<MessageType>::SharedPtr, kRobotCount> & destination,
-  const std::string & topic_base,
+  const std::string_view & topic_base,
   const rclcpp::QoS & qos,
   void (NodeType::* callback_pointer)(const typename MessageType::SharedPtr, const int),
   NodeType * node
@@ -45,23 +46,21 @@ void create_indexed_subscribers(
     std::function<void(const typename MessageType::SharedPtr)> callback =
       std::bind(callback_pointer, node, std::placeholders::_1, robot_id);
     destination.at(robot_id) = node->template create_subscription<MessageType>(
-      topic_base + std::to_string(
-        robot_id), qos, callback);
+      std::string(topic_base) + std::to_string(robot_id), qos, callback);
   }
 }
 
 template<typename MessageType, typename NodeType>
 void create_indexed_publishers(
   std::array<typename rclcpp::Publisher<MessageType>::SharedPtr, kRobotCount> & destination,
-  const std::string & topic_base,
+  const std::string_view & topic_base,
   const rclcpp::QoS & qos,
   NodeType * node
 )
 {
   for (int robot_id = 0; robot_id < kRobotCount; ++robot_id) {
     destination.at(robot_id) = node->template create_publisher<MessageType>(
-      topic_base + std::to_string(
-        robot_id), qos);
+      std::string(topic_base) + std::to_string(robot_id), qos);
   }
 }
 

--- a/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
+++ b/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
@@ -52,14 +52,14 @@ public:
     ateam_common::indexed_topic_helpers::create_indexed_subscribers
     <ateam_msgs::msg::RobotMotionCommand>(
       command_subscriptions_,
-      "/ateam_ai/robot_motion_commands/robot",
+      Topics::kRobotMotionCommandPrefix,
       rclcpp::SystemDefaultsQoS(),
       &SSLSimulationRadioBridgeNode::message_callback,
       this);
 
     ateam_common::indexed_topic_helpers::create_indexed_publishers<ateam_msgs::msg::RobotFeedback>(
       feedback_publishers_,
-      "~/robot_feedback/robot",
+      Topics::kRobotFeedbackPrefix,
       rclcpp::SystemDefaultsQoS(),
       this);
   }

--- a/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
+++ b/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
@@ -29,6 +29,7 @@
 #include <rclcpp_components/register_node_macro.hpp>
 
 #include <ateam_common/bi_directional_udp.hpp>
+#include <ateam_common/indexed_topic_helpers.hpp>
 #include <ateam_common/topic_names.hpp>
 #include <ateam_msgs/msg/robot_feedback.hpp>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
@@ -48,26 +49,19 @@ public:
       std::placeholders::_1,
       std::placeholders::_2))
   {
-    for (int robot_id = 0; robot_id < 16; robot_id++) {
-      // Full type is required
-      // https://answers.ros.org/question/289207/function-callback-using-stdbind-in-ros-2-subscription/
-      std::function<void(const ateam_msgs::msg::RobotMotionCommand::SharedPtr)> callback =
-        std::bind(
-        &SSLSimulationRadioBridgeNode::message_callback,
-        this,
-        std::placeholders::_1,
-        robot_id);
+    ateam_common::indexed_topic_helpers::create_indexed_subscribers
+    <ateam_msgs::msg::RobotMotionCommand>(
+      command_subscriptions_,
+      "/ateam_ai/robot_motion_commands/robot",
+      rclcpp::SystemDefaultsQoS(),
+      &SSLSimulationRadioBridgeNode::message_callback,
+      this);
 
-      command_subscriptions_.at(robot_id) =
-        create_subscription<ateam_msgs::msg::RobotMotionCommand>(
-        std::string(Topics::kRobotMotionCommandPrefix) + std::to_string(robot_id),
-        10,
-        callback);
-
-      feedback_publishers_.at(robot_id) = create_publisher<ateam_msgs::msg::RobotFeedback>(
-        std::string(Topics::kRobotFeedbackPrefix) + std::to_string(robot_id),
-        rclcpp::SystemDefaultsQoS());
-    }
+    ateam_common::indexed_topic_helpers::create_indexed_publishers<ateam_msgs::msg::RobotFeedback>(
+      feedback_publishers_,
+      "~/robot_feedback/robot",
+      rclcpp::SystemDefaultsQoS(),
+      this);
   }
 
   void message_callback(

--- a/ateam_vision_filter/src/ateam_vision_filter_node.cpp
+++ b/ateam_vision_filter/src/ateam_vision_filter_node.cpp
@@ -28,6 +28,7 @@
 #include <rclcpp_components/register_node_macro.hpp>
 
 #include <ateam_common/topic_names.hpp>
+#include <ateam_common/indexed_topic_helpers.hpp>
 
 #include "world.hpp"
 #include "message_conversions.hpp"
@@ -49,14 +50,20 @@ public:
       std::string(Topics::kBall),
       rclcpp::SystemDefaultsQoS());
 
-    for (std::size_t id = 0; id < blue_robots_publisher_.size(); id++) {
-      blue_robots_publisher_.at(id) = create_publisher<ateam_msgs::msg::RobotState>(
-        std::string(Topics::kBlueTeamRobotPrefix) + std::to_string(id),
-        rclcpp::SystemDefaultsQoS());
-      yellow_robots_publisher_.at(id) = create_publisher<ateam_msgs::msg::RobotState>(
-        std::string(Topics::kYellowTeamRobotPrefix) + std::to_string(id),
-        rclcpp::SystemDefaultsQoS());
-    }
+    ateam_common::indexed_topic_helpers::create_indexed_publishers
+    <ateam_msgs::msg::RobotState>(
+      blue_robots_publisher_,
+      Topics::kBlueTeamRobotPrefix,
+      rclcpp::SystemDefaultsQoS(),
+      this
+    );
+    ateam_common::indexed_topic_helpers::create_indexed_publishers
+    <ateam_msgs::msg::RobotState>(
+      yellow_robots_publisher_,
+      Topics::kYellowTeamRobotPrefix,
+      rclcpp::SystemDefaultsQoS(),
+      this
+    );
 
     vision_state_publisher_ = create_publisher<ateam_msgs::msg::VisionWorldState>(
       std::string(Topics::kVisionState),


### PR DESCRIPTION
Another utility made while working on the radio bridge.

This adds a new header to ateam_common which provides `create_indexed_publishers` and `create_indexed_subscribers`. These functions create publishers / subscribers for each robot ID from a topic base name.

This PR also changes the simulation radio bridge and vision filter to use this new utility.