### PR TITLE
[iLQR] Improve convergence

### DIFF
--- a/ateam_ai/test/trajectory_generation/ilqr_problem_test.cpp
+++ b/ateam_ai/test/trajectory_generation/ilqr_problem_test.cpp
@@ -22,11 +22,10 @@
 #include "trajectory_generation/ilqr_computer.hpp"
 
 #include <gtest/gtest.h>
-#include <iostream>
 
-constexpr int num_samples = 100;
+constexpr int num_samples1 = 100;
 constexpr double dt = 0.01;
-class PointMass1dProblem : public iLQRProblem<2, 1, num_samples>
+class PointMass1dProblem : public iLQRProblem<2, 1, num_samples1>
 {
 public:
   State dynamics(const State & x_t1, const Input & u_t1, Time t) override
@@ -39,13 +38,16 @@ public:
 
   Cost cost(const State & x, const Input & u, Time t) override
   {
-    constexpr double final_gain = 1e6;
-    if (t == num_samples - 1) {
-      Eigen::Vector2d target{10, 0};
-      Eigen::Vector2d weights{1, 1};
-      return final_gain * (target - x).dot(target - x);
+    Eigen::Vector2d target{10, 0};
+    Eigen::Vector2d error = x - target;
+    Eigen::Matrix2d Q;
+    Q << 1, 0, 0, 0;
+    Eigen::Matrix<double, 1, 1> R;
+    R << 0;
+    if (t == num_samples1 - 1) {
+      return (error.transpose() * Q * error).value();
     } else {
-      return dt * u.dot(u);
+      return (error.transpose() * Q * error).value();
     }
   }
 };
@@ -54,14 +56,68 @@ TEST(iLQRProblem, SamplePointMass)
 {
   PointMass1dProblem point_mass_problem;
   iLQRParams params{
-    .max_ilqr_iterations = 1,
-    .max_forward_pass_iterations = 1,
-    .converge_threshold = 1e-1,
+    .max_ilqr_iterations = 100,
+    .max_forward_pass_iterations = 10,
+    .converge_threshold = 1e-3,
     .gamma = 0.5,
     .lambda_min = 1e-6,
     .delta_zero = 2
   };
   iLQRComputer computer(point_mass_problem, params);
+
+  auto maybe_trajectory = computer.calculate(Eigen::Vector2d{0, 0});
+
+  ASSERT_TRUE(maybe_trajectory.has_value());
+  EXPECT_NEAR(maybe_trajectory.value().back().x(), 10, 1e-1);
+  EXPECT_NEAR(maybe_trajectory.value().back().y(), 0, 1e-1);
+}
+
+constexpr int num_samples2 = 100;
+class NLPointMass1dProblem : public iLQRProblem<2, 1, num_samples2>
+{
+public:
+  State dynamics(const State & x_t1, const Input & u_t1, Time t) override
+  {
+    Eigen::Matrix<double, 2, 2> A; A << 0, 1, 0, 0;
+    Eigen::Matrix<double, 2, 1> B; B << 0, 1;
+
+    return x_t1 + dt * (A * x_t1 + B * u_t1);
+  }
+
+  double exp_boundary(double x, double q1 = 1, double q2 = 1e-2)
+  {
+    return q1 * exp(q2 * x);
+  }
+
+  Cost cost(const State & x, const Input & u, Time t) override
+  {
+    Eigen::Vector2d target{10, 0};
+    Eigen::Vector2d error = x - target;
+    Eigen::Matrix2d Q;
+    Q << 1, 0, 0, 0.1;
+    Eigen::Matrix<double, 1, 1> R;
+    R << 0;
+    if (t == num_samples2 - 1) {
+      return 1e3 * (error.transpose() * Q * error).value();
+    } else {
+      return (error.transpose() * Q * error).value() + exp_boundary(u.value());
+    }
+  }
+};
+
+TEST(iLQRProblem, PointMassLimitedU)
+{
+  NLPointMass1dProblem point_mass_problem;
+  iLQRParams params{
+    .max_ilqr_iterations = 100,
+    .max_forward_pass_iterations = 10,
+    .converge_threshold = 1e-3,
+    .gamma = 0.5,
+    .lambda_min = 1e-6,
+    .delta_zero = 2
+  };
+  iLQRComputer computer(point_mass_problem, params);
+
   auto maybe_trajectory = computer.calculate(Eigen::Vector2d{0, 0});
 
   ASSERT_TRUE(maybe_trajectory.has_value());


### PR DESCRIPTION
- Revert to the regularization in the original paper
- Use delta_v (split into 2 parts) to compute the estimated change in cost for a given alpha in the line search
- Use absolute change in cost for the convergence threshold instead of relative change in cost (May need to change this as a small alpha will result in a very small change in cost)
- Add unit tests for non-linear boundary costs for limiting acceleration magnitude