### PR TITLE
Updates to UDP utils from radio bridge dev.

### DIFF
--- a/ateam_common/include/ateam_common/bi_directional_udp.hpp
+++ b/ateam_common/include/ateam_common/bi_directional_udp.hpp
@@ -31,24 +31,32 @@ namespace ateam_common
 class BiDirectionalUDP
 {
 public:
-  using ReceiveCallback = std::function<void (const char * const data, const size_t length)>;
+  using ReceiveCallback = std::function<void (const uint8_t * const data, const size_t length)>;
 
   BiDirectionalUDP(
     const std::string & udp_ip_address,
     const int16_t udp_port,
     ReceiveCallback receive_callback);
 
-  void send(const char * const data, const size_t length);
+  void send(const uint8_t * const data, const size_t length);
 
   ~BiDirectionalUDP();
+
+  uint16_t GetLocalPort() const;
+
+  std::string GetLocalIPAddress() const;
+
+  uint16_t GetRemotePort() const;
+
+  std::string GetRemoteIPAddress() const;
 
 private:
   ReceiveCallback receive_callback_;
   boost::asio::io_service io_service_;
   boost::asio::ip::udp::socket udp_socket_;
   boost::asio::ip::udp::endpoint endpoint_;
-  std::array<char, 1024> send_buffer_;
-  std::array<char, 1024> receive_buffer_;
+  std::array<uint8_t, 1024> send_buffer_;
+  std::array<uint8_t, 1024> receive_buffer_;
   std::thread io_service_thread_;
 
   void HandleUDPSendTo(const boost::system::error_code & error, std::size_t bytes_transferred);

--- a/ateam_common/include/ateam_common/multicast_receiver.hpp
+++ b/ateam_common/include/ateam_common/multicast_receiver.hpp
@@ -32,27 +32,38 @@ class MulticastReceiver
 {
 public:
   /**
-   * @param uint8_t* Data received in latest packet
-   * @param size_t Length of data received
+   * @param sender_address IP address of sender
+   * @param sender_port Port number of sender
+   * @param data Data received in latest packet
+   * @param data_length Length of data received
    */
-  using ReceiveCallback = std::function<void (uint8_t *, size_t)>;
+  using ReceiveCallback =
+    std::function<void (const std::string & sender_address, const uint16_t sender_port,
+      uint8_t * data, size_t data_length)>;
 
   MulticastReceiver(
     std::string multicast_ip_address,
-    int16_t multicast_port,
+    uint16_t multicast_port,
     ReceiveCallback receive_callback);
 
   ~MulticastReceiver();
+
+  void SendTo(
+    const std::string & address, const uint16_t port, const char * const data,
+    const size_t length);
 
 private:
   ReceiveCallback receive_callback_;
   boost::asio::io_service io_service_;
   boost::asio::ip::udp::socket multicast_socket_;
   boost::asio::ip::udp::endpoint sender_endpoint_;
+  std::array<uint8_t, 4096> send_buffer_;
   std::array<uint8_t, 4096> buffer_;
   std::thread io_service_thread_;
 
   void HandleMulticastReceiveFrom(const boost::system::error_code & error, size_t bytes_received);
+
+  void HandleUDPSendTo(const boost::system::error_code & error, size_t bytes_sent);
 };
 
 }  // namespace ateam_common

--- a/ateam_common/src/bi_directional_udp.cpp
+++ b/ateam_common/src/bi_directional_udp.cpp
@@ -42,7 +42,8 @@ BiDirectionalUDP::BiDirectionalUDP(
   udp_socket_.open(endpoint_.protocol());
 
   // Binding to port 0 assigns an arbitrary available port number
-  // Doing this now allows the local port info to be queried before any data is sent (needed for radio bridge)
+  // Doing this now allows the local port info to be queried before any data is sent
+  // (needed for radio bridge)
   udp_socket_.bind(boost::asio::ip::udp::endpoint(endpoint_.protocol(), 0));
 
   udp_socket_.async_receive_from(

--- a/ateam_common/src/bi_directional_udp.cpp
+++ b/ateam_common/src/bi_directional_udp.cpp
@@ -41,6 +41,10 @@ BiDirectionalUDP::BiDirectionalUDP(
 {
   udp_socket_.open(endpoint_.protocol());
 
+  // Binding to port 0 assigns an arbitrary available port number
+  // Doing this now allows the local port info to be queried before any data is sent (needed for radio bridge)
+  udp_socket_.bind(boost::asio::ip::udp::endpoint(endpoint_.protocol(), 0));
+
   udp_socket_.async_receive_from(
     boost::asio::buffer(receive_buffer_, receive_buffer_.size()),
     endpoint_,
@@ -63,7 +67,7 @@ BiDirectionalUDP::~BiDirectionalUDP()
   }
 }
 
-void BiDirectionalUDP::send(const char * const data, const size_t length)
+void BiDirectionalUDP::send(const uint8_t * const data, const size_t length)
 {
   if (length >= send_buffer_.size()) {
     // RCLCPP_ERROR(get_logger(), "UDP send data length is larger than buffer");
@@ -85,9 +89,30 @@ void BiDirectionalUDP::send(const char * const data, const size_t length)
       boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 }
 
+
+uint16_t BiDirectionalUDP::GetLocalPort() const
+{
+  return udp_socket_.local_endpoint().port();
+}
+
+std::string BiDirectionalUDP::GetLocalIPAddress() const
+{
+  return udp_socket_.local_endpoint().address().to_string();
+}
+
+uint16_t BiDirectionalUDP::GetRemotePort() const
+{
+  return endpoint_.port();
+}
+
+std::string BiDirectionalUDP::GetRemoteIPAddress() const
+{
+  return endpoint_.address().to_string();
+}
+
 void BiDirectionalUDP::HandleUDPSendTo(
   const boost::system::error_code & error,
-  std::size_t /** bytes_transferred **/)
+  std::size_t bytes_transferred)
 {
   if (error) {
     // RCLCPP_ERROR(get_logger(), "Error during udp send");

--- a/ateam_common/src/multicast_receiver.cpp
+++ b/ateam_common/src/multicast_receiver.cpp
@@ -20,6 +20,7 @@
 
 #include "ateam_common/multicast_receiver.hpp"
 
+#include <algorithm>
 #include <iostream>
 #include <string>
 
@@ -30,7 +31,7 @@ namespace ateam_common
 
 MulticastReceiver::MulticastReceiver(
   std::string multicast_address_string,
-  int16_t multicast_port,
+  uint16_t multicast_port,
   ReceiveCallback receive_callback)
 : receive_callback_(receive_callback),
   multicast_socket_(io_service_)
@@ -49,7 +50,9 @@ MulticastReceiver::MulticastReceiver(
 
   io_service_thread_ = std::thread(
     [this]() {
+      std::cout << "Multicast io_service START" << std::endl;
       io_service_.run();
+      std::cout << "Multicast io_service STOP" << std::endl;
     });
 }
 
@@ -61,6 +64,31 @@ MulticastReceiver::~MulticastReceiver()
   }
 }
 
+void MulticastReceiver::SendTo(
+  const std::string & address, const uint16_t port,
+  const char * const data, const size_t length)
+{
+  if (length >= send_buffer_.size()) {
+    std::cout << "WARNING: UDP send data length is larger than buffer" << std::endl;
+
+    return;
+  }
+
+  // Copy to buffer
+  // Better to send an invalid packet than to overrun the buffer
+  // With the if statement above, this should never happen
+  memcpy(send_buffer_.data(), data, std::min(send_buffer_.size(), length));
+
+  boost::asio::ip::udp::endpoint endpoint(boost::asio::ip::address::from_string(address), port);
+
+  multicast_socket_.async_send_to(
+    boost::asio::buffer(send_buffer_, length),
+    endpoint,
+    boost::bind(
+      &MulticastReceiver::HandleUDPSendTo, this,
+      boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
+}
+
 void MulticastReceiver::HandleMulticastReceiveFrom(
   const boost::system::error_code & error,
   size_t bytes_received)
@@ -70,13 +98,23 @@ void MulticastReceiver::HandleMulticastReceiveFrom(
     return;
   }
 
-  receive_callback_(buffer_.data(), bytes_received);
+  receive_callback_(
+    sender_endpoint_.address().to_string(), sender_endpoint_.port(),
+    buffer_.data(), bytes_received);
 
   multicast_socket_.async_receive_from(
     boost::asio::buffer(buffer_), sender_endpoint_,
     boost::bind(
       &MulticastReceiver::HandleMulticastReceiveFrom, this,
       boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
+}
+
+
+void MulticastReceiver::HandleUDPSendTo(const boost::system::error_code & error, size_t)
+{
+  if (error) {
+    std::cerr << "Error sending UDP data: " << error.message() << std::endl;
+  }
 }
 
 }  // namespace ateam_common

--- a/ateam_common/src/multicast_receiver.cpp
+++ b/ateam_common/src/multicast_receiver.cpp
@@ -50,9 +50,7 @@ MulticastReceiver::MulticastReceiver(
 
   io_service_thread_ = std::thread(
     [this]() {
-      std::cout << "Multicast io_service START" << std::endl;
       io_service_.run();
-      std::cout << "Multicast io_service STOP" << std::endl;
     });
 }
 

--- a/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
+++ b/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
@@ -52,8 +52,8 @@ public:
     multicast_receiver_ = std::make_unique<ateam_common::MulticastReceiver>(
       multicast_address,
       multicast_port, std::bind(
-        &GCMulticastBridgeNode::PublishMulticastMessage, this, std::placeholders::_1,
-        std::placeholders::_2));
+        &GCMulticastBridgeNode::PublishMulticastMessage, this, std::placeholders::_3,
+        std::placeholders::_4));
   }
 
 private:

--- a/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
+++ b/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
@@ -70,13 +70,14 @@ public:
   {
     RobotControl robots_control = message_conversions::fromMsg(*robot_commands_msg, robot_id);
 
-    std::string protobuf_msg;
-    if (robots_control.SerializeToString(&protobuf_msg)) {
-      udp_.send(protobuf_msg.data(), protobuf_msg.size());
+    std::vector<uint8_t> buffer;
+    buffer.resize(robots_control.ByteSizeLong());
+    if (robots_control.SerializeToArray(buffer.data(), buffer.size())) {
+      udp_.send(static_cast<uint8_t*>(buffer.data()), buffer.size());
     }
   }
 
-  void feedback_callback(const char * buffer, size_t bytes_received)
+  void feedback_callback(const uint8_t * buffer, size_t bytes_received)
   {
     RobotControlResponse feedback_proto;
     if (!feedback_proto.ParseFromArray(buffer, bytes_received - 1)) {

--- a/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
+++ b/ateam_ssl_simulation_radio_bridge/src/ssl_simulation_radio_bridge_node.cpp
@@ -73,7 +73,7 @@ public:
     std::vector<uint8_t> buffer;
     buffer.resize(robots_control.ByteSizeLong());
     if (robots_control.SerializeToArray(buffer.data(), buffer.size())) {
-      udp_.send(static_cast<uint8_t*>(buffer.data()), buffer.size());
+      udp_.send(static_cast<uint8_t *>(buffer.data()), buffer.size());
     }
   }
 

--- a/ateam_ssl_vision_bridge/src/ssl_vision_bridge_node.cpp
+++ b/ateam_ssl_vision_bridge/src/ssl_vision_bridge_node.cpp
@@ -42,7 +42,7 @@ public:
   : rclcpp::Node("ssl_vision_bridge", options),
     multicast_receiver_("224.5.23.2",
       10020,
-      [this](auto * buffer, size_t bytes_received) {
+      [this](const std::string &, const uint16_t, auto * buffer, size_t bytes_received) {
         SSL_WrapperPacket vision_proto;
 
         // Note: "- 1" is needed due to some weird bug where if the entire buffer


### PR DESCRIPTION
While working on the radio bridge, I ended up adding some features to & tweaking the UDP utilities.

These changes include:
- Changing buffer types to `uint8_t` (instead of `char`)
- Adding functions to `BiDirectionalUDP` for getting the local and remote endpoint info
- Adding a `SendTo` function to `MulticastReceiver` so it can send replies to multicast messages