### PR TITLE
Adds radio bridge

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: src/ateam_software
+          submodules: true
       - name: Install Dependencies
         shell: bash
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ateam_radio_bridge/software-communication"]
+	path = ateam_radio_bridge/software-communication
+	url = https://github.com/SSL-A-Team/software-communication.git

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
    cd ateam_ws
    mkdir src
    cd src
-   git clone git@github.com:SSL-A-Team/software.git
+   git clone --recursive git@github.com:SSL-A-Team/software.git
    ```
 
 1. Install our ROS dependencies

--- a/ateam_radio_bridge/CMakeLists.txt
+++ b/ateam_radio_bridge/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.8)
+project(ateam_radio_bridge)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(ateam_msgs REQUIRED)
+find_package(ateam_common REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED
+  src/conversion.cpp
+  src/ip_address_helpers.cpp
+  src/radio_bridge_node.cpp
+  src/rnp_packet_helpers.cpp
+)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
+target_include_directories(${PROJECT_NAME} PUBLIC software-communication/ateam-common-packets/include)
+target_include_directories(${PROJECT_NAME} PUBLIC src)
+ament_target_dependencies(${PROJECT_NAME}
+  rclcpp
+  rclcpp_components
+  ateam_msgs
+  ateam_common
+)
+rclcpp_components_register_node(
+  ${PROJECT_NAME}
+  PLUGIN "ateam_radio_bridge::RadioBridgeNode"
+  EXECUTABLE radio_bridge_node
+)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+
+if(BUILD_TESTING)
+  # list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_cpplint)
+  # find_package(ament_lint_auto REQUIRED)
+  # Disable auto finding of cpplint so we can customize its arguments
+  # set(ament_cmake_cpplint_FOUND TRUE)
+  # ament_lint_auto_find_test_dependencies()
+
+  # set(ament_cmake_cpplint_FOUND FALSE)
+  # find_package(ament_cmake_cpplint)
+  # ament_cpplint(EXCLUDE software-communication)
+
+  add_subdirectory(test)
+endif()
+
+ament_package()

--- a/ateam_radio_bridge/CMakeLists.txt
+++ b/ateam_radio_bridge/CMakeLists.txt
@@ -35,15 +35,9 @@ rclcpp_components_register_node(
 install(TARGETS ${PROJECT_NAME} DESTINATION lib)
 
 if(BUILD_TESTING)
-  # list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_cpplint)
-  # find_package(ament_lint_auto REQUIRED)
-  # Disable auto finding of cpplint so we can customize its arguments
-  # set(ament_cmake_cpplint_FOUND TRUE)
-  # ament_lint_auto_find_test_dependencies()
-
-  # set(ament_cmake_cpplint_FOUND FALSE)
-  # find_package(ament_cmake_cpplint)
-  # ament_cpplint(EXCLUDE software-communication)
+  # TODO(barulicm) Linters are omitted from this package because the software-communication repo
+  # doesn't respect our style rules and setting exclusion rules for ament linters doesn't seem
+  # to actually work in Humble
 
   add_subdirectory(test)
 endif()

--- a/ateam_radio_bridge/package.xml
+++ b/ateam_radio_bridge/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ateam_radio_bridge</name>
+  <version>0.0.0</version>
+  <description>Provides a node which bridges radio packets to and from the robots into ROS</description>
+  <maintainer email="matthew.barulic@gmail.com">Matthew Barulic</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>ateam_msgs</depend>
+  <depend>ateam_common</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ateam_radio_bridge/src/conversion.cpp
+++ b/ateam_radio_bridge/src/conversion.cpp
@@ -1,0 +1,46 @@
+#include "conversion.hpp"
+
+namespace ateam_radio_bridge
+{
+
+ateam_msgs::msg::RobotFeedback Convert(const BasicTelemetry & basic_telemetry)
+{
+  ateam_msgs::msg::RobotFeedback robot_feedback;
+
+  robot_feedback.sequence_number = basic_telemetry.sequence_number;
+  robot_feedback.robot_revision_major = basic_telemetry.robot_revision_major;
+  robot_feedback.robot_revision_minor = basic_telemetry.robot_revision_minor;
+  robot_feedback.battery_level = basic_telemetry.battery_level;
+  robot_feedback.battery_temperature = basic_telemetry.battery_temperature;
+  robot_feedback.power_error = basic_telemetry.power_error;
+  robot_feedback.tipped_error = basic_telemetry.tipped_error;
+  robot_feedback.breakbeam_error = basic_telemetry.breakbeam_error;
+  robot_feedback.breakbeam_ball_detected = basic_telemetry.breakbeam_ball_detected;
+  robot_feedback.accelerometer_0_error = basic_telemetry.accelerometer_0_error;
+  robot_feedback.accelerometer_1_error = basic_telemetry.accelerometer_1_error;
+  robot_feedback.gyroscope_0_error = basic_telemetry.gyroscope_0_error;
+  robot_feedback.gyroscope_1_error = basic_telemetry.gyroscope_1_error;
+  robot_feedback.motor_0_general_error = basic_telemetry.motor_0_general_error;
+  robot_feedback.motor_0_hall_error = basic_telemetry.motor_0_hall_error;
+  robot_feedback.motor_1_general_error = basic_telemetry.motor_1_general_error;
+  robot_feedback.motor_1_hall_error = basic_telemetry.motor_1_hall_error;
+  robot_feedback.motor_2_general_error = basic_telemetry.motor_2_general_error;
+  robot_feedback.motor_2_hall_error = basic_telemetry.motor_2_hall_error;
+  robot_feedback.motor_3_general_error = basic_telemetry.motor_3_general_error;
+  robot_feedback.motor_3_hall_error = basic_telemetry.motor_3_hall_error;
+  robot_feedback.motor_4_general_error = basic_telemetry.motor_4_general_error;
+  robot_feedback.motor_4_hall_error = basic_telemetry.motor_4_hall_error;
+  robot_feedback.chipper_available = basic_telemetry.chipper_available;
+  robot_feedback.kicker_available = basic_telemetry.kicker_available;
+  robot_feedback.motor_0_temperature = basic_telemetry.motor_0_temperature;
+  robot_feedback.motor_1_temperature = basic_telemetry.motor_1_temperature;
+  robot_feedback.motor_2_temperature = basic_telemetry.motor_2_temperature;
+  robot_feedback.motor_3_temperature = basic_telemetry.motor_3_temperature;
+  robot_feedback.motor_4_temperature = basic_telemetry.motor_4_temperature;
+  robot_feedback.kicker_charge_level = basic_telemetry.kicker_charge_level;
+
+
+  return robot_feedback;
+}
+
+}  // namespace ateam_radio_bridge

--- a/ateam_radio_bridge/src/conversion.hpp
+++ b/ateam_radio_bridge/src/conversion.hpp
@@ -1,0 +1,18 @@
+#ifndef CONVERSION_HPP_
+#define CONVERSION_HPP_
+
+#include <ateam_msgs/msg/robot_feedback.hpp>
+#include <ateam_msgs/msg/robot_motion_command.hpp>
+#include <basic_control.h>
+#include <basic_telemetry.h>
+#include <hello_data.h>
+
+namespace ateam_radio_bridge
+{
+
+ateam_msgs::msg::RobotFeedback Convert(const BasicTelemetry & basic_telemetry);
+
+
+}
+
+#endif  // CONVERSION_HPP_

--- a/ateam_radio_bridge/src/ip_address_helpers.cpp
+++ b/ateam_radio_bridge/src/ip_address_helpers.cpp
@@ -1,0 +1,58 @@
+#include "ip_address_helpers.hpp"
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <algorithm>
+
+std::vector<std::string> GetIpAddresses()
+{
+  std::vector<std::string> addresses;
+  ifaddrs * iface_info = nullptr;
+  getifaddrs(&iface_info);
+  auto iface_info_current = iface_info;
+  while (iface_info_current != nullptr) {
+    if (!iface_info_current->ifa_addr) {
+      continue;
+    }
+
+    if (iface_info_current->ifa_addr->sa_family == AF_INET) {
+      // IPv4 address
+      void * net_address =
+        &(reinterpret_cast<sockaddr_in *>(iface_info_current->ifa_addr)->sin_addr);
+      char buffer[INET_ADDRSTRLEN];
+      inet_ntop(AF_INET, net_address, buffer, INET_ADDRSTRLEN);
+      addresses.emplace_back(buffer);
+    } else if (iface_info_current->ifa_addr->sa_family == AF_INET6) {
+      // IPv6 address
+      void * net_address =
+        &(reinterpret_cast<sockaddr_in *>(iface_info_current->ifa_addr)->sin_addr);
+      char buffer[INET6_ADDRSTRLEN];
+      inet_ntop(AF_INET6, net_address, buffer, INET6_ADDRSTRLEN);
+      addresses.emplace_back(buffer);
+    }
+
+    iface_info_current = iface_info_current->ifa_next;
+  }
+  if (iface_info != nullptr) {
+    freeifaddrs(iface_info);
+  }
+  return addresses;
+}
+
+const std::string & GetClosestIpAddress(
+  const std::vector<std::string> & addresses,
+  const std::string & target)
+{
+  std::vector<std::size_t> address_overlaps;
+  std::transform(
+    addresses.begin(), addresses.end(), std::back_inserter(address_overlaps),
+    [&target](const auto & address) {
+      return std::distance(
+        target.begin(),
+        std::mismatch(target.begin(), target.end(), address.begin(), address.end()).first);
+    });
+  return addresses.at(
+    std::distance(
+      address_overlaps.begin(),
+      std::max_element(address_overlaps.begin(), address_overlaps.end())));
+}

--- a/ateam_radio_bridge/src/ip_address_helpers.hpp
+++ b/ateam_radio_bridge/src/ip_address_helpers.hpp
@@ -6,20 +6,22 @@
 
 /**
  * @brief Get all IP addresses for the local machine
- * 
+ *
  * @return std::vector<std::string> IP addresses in dot decimal notation
  */
 std::vector<std::string> GetIpAddresses();
 
 /**
  * @brief Get the IP address from @c addresses with the largest common prefix with @c target .
- * 
+ *
  * The intent is to get the address that shares the most specific subnet with the target address.
- * 
+ *
  * @param addresses IP addresses to search, in dot decimal notation
  * @param target IP address to match against, in dot decimal notation
  * @return std::string& reference to closest address
  */
-const std::string & GetClosestIpAddress(const std::vector<std::string> & addresses, const std::string & target);
+const std::string & GetClosestIpAddress(
+  const std::vector<std::string> & addresses,
+  const std::string & target);
 
 #endif  // GET_IP_ADDRESSES_HPP__

--- a/ateam_radio_bridge/src/ip_address_helpers.hpp
+++ b/ateam_radio_bridge/src/ip_address_helpers.hpp
@@ -1,0 +1,25 @@
+#ifndef GET_IP_ADDRESSES_HPP__
+#define GET_IP_ADDRESSES_HPP__
+
+#include <vector>
+#include <string>
+
+/**
+ * @brief Get all IP addresses for the local machine
+ * 
+ * @return std::vector<std::string> IP addresses in dot decimal notation
+ */
+std::vector<std::string> GetIpAddresses();
+
+/**
+ * @brief Get the IP address from @c addresses with the largest common prefix with @c target .
+ * 
+ * The intent is to get the address that shares the most specific subnet with the target address.
+ * 
+ * @param addresses IP addresses to search, in dot decimal notation
+ * @param target IP address to match against, in dot decimal notation
+ * @return std::string& reference to closest address
+ */
+const std::string & GetClosestIpAddress(const std::vector<std::string> & addresses, const std::string & target);
+
+#endif  // GET_IP_ADDRESSES_HPP__

--- a/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -46,12 +46,14 @@ public:
 
     connection_check_timer_ =
       create_wall_timer(
-        std::chrono::duration<double>(1.0/declare_parameter<double>("connection_check_frequency", 10.0)),
+      std::chrono::duration<double>(
+        1.0 /
+        declare_parameter<double>("connection_check_frequency", 10.0)),
       std::bind(&RadioBridgeNode::ConnectionCheckCallback, this));
 
     command_send_timer_ =
       create_wall_timer(
-        std::chrono::duration<double>(1.0/declare_parameter<double>("command_frequency", 60.0)),
+      std::chrono::duration<double>(1.0 / declare_parameter<double>("command_frequency", 60.0)),
       std::bind(&RadioBridgeNode::SendCommandsCallback, this));
 
     RCLCPP_INFO(get_logger(), "Radio bridge node ready.");

--- a/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -46,12 +46,12 @@ public:
 
     connection_check_timer_ =
       create_wall_timer(
-        std::chrono::milliseconds(1000/declare_parameter<double>("connection_check_frequency", 10.0)),
+        std::chrono::duration<double>(1.0/declare_parameter<double>("connection_check_frequency", 10.0)),
       std::bind(&RadioBridgeNode::ConnectionCheckCallback, this));
 
     command_send_timer_ =
       create_wall_timer(
-        std::chrono::milliseconds(1000/declare_parameter<double>("command_frequency", 100.0))
+        std::chrono::duration<double>(1.0/declare_parameter<double>("command_frequency", 100.0)),
       std::bind(&RadioBridgeNode::SendCommandsCallback, this));
 
     RCLCPP_INFO(get_logger(), "Radio bridge node ready.");

--- a/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -1,0 +1,281 @@
+#include <array>
+#include <chrono>
+#include <numeric>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+#include <ateam_msgs/msg/robot_motion_command.hpp>
+#include <ateam_msgs/msg/robot_feedback.hpp>
+#include <ateam_common/indexed_topic_helpers.hpp>
+#include <ateam_common/multicast_receiver.hpp>
+#include <ateam_common/bi_directional_udp.hpp>
+#include <ateam_common/team_color_listener.hpp>
+
+#include "rnp_packet_helpers.hpp"
+#include "conversion.hpp"
+#include "ip_address_helpers.hpp"
+
+// TODO(barulicm) add warning if we see another instance of this running via multicast
+
+namespace ateam_radio_bridge
+{
+
+class RadioBridgeNode : public rclcpp::Node
+{
+public:
+  RadioBridgeNode(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("radio_bridge", options),
+    timeout_threshold_(declare_parameter("timeout_ms", 250)),
+    color_listener_(*this),
+    discovery_receiver_(declare_parameter<std::string>("discovery_address", "224.4.20.69"),
+      declare_parameter<uint16_t>("discovery_port", 42069),
+      std::bind(&RadioBridgeNode::DiscoveryMessageCallback, this, std::placeholders::_1,
+      std::placeholders::_2, std::placeholders::_3, std::placeholders::_4))
+  {
+    ateam_common::indexed_topic_helpers::create_indexed_subscribers<ateam_msgs::msg::RobotMotionCommand>(
+      motion_command_subscriptions_,
+      "~/robot_motion_commands/robot",
+      rclcpp::SystemDefaultsQoS(),
+      &RadioBridgeNode::motion_command_callback,
+      this);
+
+    ateam_common::indexed_topic_helpers::create_indexed_publishers<ateam_msgs::msg::RobotFeedback>(
+      feedback_publishers_,
+      "~/robot_feedback/robot",
+      rclcpp::SystemDefaultsQoS(),
+      this);
+
+    connection_check_timer_ =
+      create_wall_timer(
+        std::chrono::milliseconds(1000/declare_parameter<double>("connection_check_frequency", 10.0)),
+      std::bind(&RadioBridgeNode::ConnectionCheckCallback, this));
+
+    command_send_timer_ =
+      create_wall_timer(
+        std::chrono::milliseconds(1000/declare_parameter<double>("command_frequency", 100.0))
+      std::bind(&RadioBridgeNode::SendCommandsCallback, this));
+
+    RCLCPP_INFO(get_logger(), "Radio bridge node ready.");
+  }
+
+private:
+  const std::chrono::milliseconds timeout_threshold_;
+  std::array<ateam_msgs::msg::RobotMotionCommand, 16> motion_commands_;
+  ateam_common::TeamColorListener color_listener_;
+  std::array<rclcpp::Subscription<ateam_msgs::msg::RobotMotionCommand>::SharedPtr,
+    16> motion_command_subscriptions_;
+  std::array<rclcpp::Publisher<ateam_msgs::msg::RobotFeedback>::SharedPtr, 16> feedback_publishers_;
+  ateam_common::MulticastReceiver discovery_receiver_;
+  std::array<std::unique_ptr<ateam_common::BiDirectionalUDP>, 16> connections_;
+  std::array<std::chrono::steady_clock::time_point, 16> last_heartbeat_timestamp_;
+  std::array<bool, 16> first_message_received_;
+  rclcpp::TimerBase::SharedPtr connection_check_timer_;
+  rclcpp::TimerBase::SharedPtr command_send_timer_;
+
+  void motion_command_callback(
+    const ateam_msgs::msg::RobotMotionCommand::SharedPtr command_msg,
+    int robot_id)
+  {
+    motion_commands_[robot_id] = *command_msg;
+  }
+
+  void CloseConnection(const std::size_t & connection_index)
+  {
+    auto & connection = connections_.at(connection_index);
+    RCLCPP_INFO(
+      get_logger(), "Closing connection to robot %ld (%s:%d)", connection_index,
+      connection->GetRemoteIPAddress().c_str(), connection->GetRemotePort());
+    const auto packet = CreateEmptyPacket(CC_GOODBYE);
+    connection->send(
+      reinterpret_cast<const uint8_t *>(&packet),
+      GetPacketSize(packet.command_code));
+    // Give some time for the message to actually send before closing the connection
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    connection.reset();
+  }
+
+  void ConnectionCheckCallback()
+  {
+    // Close any connections whose last heartbeat time is too old
+    for (auto i = 0ul; i < connections_.size(); ++i) {
+      if (!connections_[i]) {
+        continue;
+      }
+      const auto & last_heartbeat_time = last_heartbeat_timestamp_[i];
+      const auto time_since_heartbeat = std::chrono::steady_clock::now() - last_heartbeat_time;
+      if (time_since_heartbeat > timeout_threshold_) {
+        RCLCPP_WARN(get_logger(), "Connection to robot %ld timed out.", i);
+        CloseConnection(i);
+      }
+    }
+  }
+
+  void SendCommandsCallback()
+  {
+    for (auto id = 0; id < 16; ++id) {
+      if (connections_[id] == nullptr) {
+        continue;
+      }
+      if (!first_message_received_[id]) {
+        continue;
+      }
+      BasicControl control_msg;
+      control_msg.vel_x_linear = motion_commands_[id].twist.linear.x;
+      control_msg.vel_y_linear = motion_commands_[id].twist.linear.y;
+      control_msg.vel_z_angular = motion_commands_[id].twist.angular.z;
+      control_msg.kick_vel = 0.0f;
+      control_msg.dribbler_speed = motion_commands_[id].dribbler_speed;
+      if (motion_commands_[id].kick) {
+        control_msg.kick_request = KR_KICK_NOW;
+      } else {
+        control_msg.kick_request = KR_ARM;
+      }
+      const auto control_packet = CreatePacket(CC_CONTROL, control_msg);
+      connections_[id]->send(
+        reinterpret_cast<const uint8_t *>(&control_packet),
+        GetPacketSize(control_packet.command_code));
+    }
+  }
+
+  void DiscoveryMessageCallback(
+    const std::string & sender_address, const uint16_t sender_port,
+    uint8_t * udp_packet_data, size_t udp_packet_size)
+  {
+    RCLCPP_INFO(get_logger(), "Multicast packet received!");
+    std::string parsing_error;
+    RadioPacket packet = ParsePacket(udp_packet_data, udp_packet_size, parsing_error);
+    if (!parsing_error.empty()) {
+      RCLCPP_WARN(get_logger(), "Ignoring discovery packet. %s", parsing_error.c_str());
+      return;
+    }
+
+    if (packet.command_code != CC_HELLO_REQ) {
+      RCLCPP_WARN(
+        get_logger(), "Ignoring discovery packet. Unexpected command code: %d",
+        packet.command_code);
+      return;
+    }
+
+    auto data_variant = ExtractData(packet, parsing_error);
+    if (!parsing_error.empty()) {
+      RCLCPP_WARN(get_logger(), "Ignoring discovery packet. %s", parsing_error.c_str());
+      return;
+    }
+
+    if (!std::holds_alternative<HelloRequest>(data_variant)) {
+      RCLCPP_WARN(get_logger(), "Ignoring discovery packet. Unexpected data type.");
+      return;
+    }
+
+    HelloRequest hello_data = std::get<HelloRequest>(data_variant);
+
+    if (!(color_listener_.GetTeamColor() == ateam_common::TeamColorListener::TeamColor::Blue &&
+      hello_data.color == TC_BLUE) &&
+      !(color_listener_.GetTeamColor() == ateam_common::TeamColorListener::TeamColor::Yellow &&
+      hello_data.color == TC_YELLOW))
+    {
+      RCLCPP_WARN(get_logger(), "Ignoring discovery packet. Wrong team.");
+      // Quietly ignore discovery packets for the other team
+      return;
+    }
+
+    const auto robot_id = hello_data.robot_id;
+
+    if (robot_id > connections_.size()) {
+      // invalid robot ID requested
+      const auto reply_packet = CreateEmptyPacket(CC_NACK);
+      discovery_receiver_.SendTo(
+        sender_address, sender_port,
+        reinterpret_cast<const char *>(&reply_packet), GetPacketSize(reply_packet.command_code));
+      return;
+    }
+
+    if (connections_[robot_id] != nullptr &&
+      sender_address != connections_[robot_id]->GetRemoteIPAddress())
+    {
+      // a connection for this robot ID already exists with a different robot
+      const auto reply_packet = CreateEmptyPacket(CC_NACK);
+      discovery_receiver_.SendTo(
+        sender_address, sender_port,
+        reinterpret_cast<const char *>(&reply_packet), GetPacketSize(reply_packet.command_code));
+      return;
+    }
+
+    RCLCPP_INFO(
+      get_logger(), "Creating connection for robot %d (%s:%d)", robot_id,
+      sender_address.c_str(), sender_port);
+
+    first_message_received_[robot_id] = false;
+    last_heartbeat_timestamp_[robot_id] = std::chrono::steady_clock::now();
+    connections_[hello_data.robot_id] = std::make_unique<ateam_common::BiDirectionalUDP>(
+      sender_address, sender_port,
+      std::bind(
+        &RadioBridgeNode::RobotIncomingPacketCallback, this, hello_data.robot_id,
+        std::placeholders::_1, std::placeholders::_2));
+
+    HelloResponse response;
+    response.port = connections_[hello_data.robot_id]->GetLocalPort();
+    const auto local_ip_address = GetClosestIpAddress(GetIpAddresses(), sender_address);
+    const auto local_address_bytes =
+      boost::asio::ip::make_address(local_ip_address).to_v4().to_bytes();
+    std::copy_n(local_address_bytes.begin(), 4, response.ipv4);
+
+    const auto reply_packet = CreatePacket(CC_HELLO_RESP, response);
+    discovery_receiver_.SendTo(
+      sender_address, sender_port,
+      reinterpret_cast<const char *>(&reply_packet), GetPacketSize(reply_packet.command_code));
+  }
+
+  void RobotIncomingPacketCallback(
+    const uint8_t robot_id, const uint8_t * udp_packet_data,
+    const std::size_t udp_packet_size)
+  {
+    std::string error;
+    const auto packet = ParsePacket(udp_packet_data, udp_packet_size, error);
+    if (!error.empty()) {
+      RCLCPP_WARN(get_logger(), "Ignoring telemetry message. %s", error.c_str());
+      return;
+    }
+
+    switch (packet.command_code) {
+      case CC_GOODBYE:
+        // close connection. No need to send our own goodbye
+        connections_[robot_id].reset();
+        break;
+      case CC_TELEMETRY:
+        {
+          last_heartbeat_timestamp_[robot_id] = std::chrono::steady_clock::now();
+          const auto data_var = ExtractData(packet, error);
+          if (!error.empty()) {
+            RCLCPP_WARN(get_logger(), "Ignoring telemetry message. %s", error.c_str());
+            return;
+          }
+          if (std::holds_alternative<BasicTelemetry>(data_var)) {
+            feedback_publishers_[robot_id]->publish(Convert(std::get<BasicTelemetry>(data_var)));
+          }
+          break;
+        }
+      case CC_KEEPALIVE:
+        last_heartbeat_timestamp_[robot_id] = std::chrono::steady_clock::now();
+        break;
+      default:
+        RCLCPP_WARN(
+          get_logger(), "Ignoring telemetry message. Unsupported command code: %d",
+          packet.command_code);
+        return;
+    }
+
+    first_message_received_[robot_id] = true;
+  }
+
+  void TeamColorChangeCallback(const ateam_common::TeamColorListener::TeamColor)
+  {
+    for (auto i = 0ul; i < connections_.size(); ++i) {
+      CloseConnection(i);
+    }
+  }
+
+};
+
+}  // namespace ateam_radio_bridge
+
+RCLCPP_COMPONENTS_REGISTER_NODE(ateam_radio_bridge::RadioBridgeNode)

--- a/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -51,7 +51,7 @@ public:
 
     command_send_timer_ =
       create_wall_timer(
-        std::chrono::duration<double>(1.0/declare_parameter<double>("command_frequency", 100.0)),
+        std::chrono::duration<double>(1.0/declare_parameter<double>("command_frequency", 60.0)),
       std::bind(&RadioBridgeNode::SendCommandsCallback, this));
 
     RCLCPP_INFO(get_logger(), "Radio bridge node ready.");

--- a/ateam_radio_bridge/src/rnp_packet_helpers.cpp
+++ b/ateam_radio_bridge/src/rnp_packet_helpers.cpp
@@ -88,8 +88,6 @@ RadioPacket ParsePacket(const uint8_t * data, const std::size_t data_length, std
     return {};
   }
 
-  std::copy_n(data+kPacketHeaderSize, packet_size - kPacketHeaderSize, reinterpret_cast<uint8_t*>(&packet.data));
-
   if (packet.major_version != kProtocolVersionMajor ||
     packet.minor_version != kProtocolVersionMinor)
   {
@@ -97,6 +95,8 @@ RadioPacket ParsePacket(const uint8_t * data, const std::size_t data_length, std
     error = "Protocol versions do not match.";
     return {};
   }
+  
+  std::copy_n(data+kPacketHeaderSize, packet_size - kPacketHeaderSize, reinterpret_cast<uint8_t*>(&packet.data));
 
   // TODO(barulicm) Firmware doesn't implement CRCs yet
   // if(!HasCorrectCRC(packet)) {

--- a/ateam_radio_bridge/src/rnp_packet_helpers.cpp
+++ b/ateam_radio_bridge/src/rnp_packet_helpers.cpp
@@ -10,8 +10,7 @@ namespace ateam_radio_bridge
 std::size_t GetPacketSize(const CommandCode & command_code)
 {
   // For now, packet size only depends on command code
-  switch(command_code)
-  {
+  switch (command_code) {
     case CC_ACK:
       return kPacketHeaderSize;
       break;
@@ -46,7 +45,9 @@ void SetCRC(RadioPacket & packet)
   const auto crc_size = sizeof(packet.crc32);
   const auto packet_size = GetPacketSize(packet.command_code);
   boost::crc_32_type crc;
-  crc.process_bytes(reinterpret_cast<void*>(reinterpret_cast<uint8_t*>(&packet)+crc_size), packet_size-crc_size);
+  crc.process_bytes(
+    reinterpret_cast<void *>(reinterpret_cast<uint8_t *>(&packet) + crc_size),
+    packet_size - crc_size);
   packet.crc32 = crc.checksum();
 }
 
@@ -55,7 +56,9 @@ bool HasCorrectCRC(const RadioPacket & packet)
   const auto crc_size = sizeof(packet.crc32);
   const auto packet_size = GetPacketSize(packet.command_code);
   boost::crc_32_type crc;
-  crc.process_bytes(reinterpret_cast<const void*>(reinterpret_cast<const uint8_t*>(&packet)+crc_size), packet_size-crc_size);
+  crc.process_bytes(
+    reinterpret_cast<const void *>(reinterpret_cast<const uint8_t *>(&packet) +
+    crc_size), packet_size - crc_size);
   return packet.crc32 == crc.checksum();
 }
 
@@ -83,8 +86,9 @@ RadioPacket ParsePacket(const uint8_t * data, const std::size_t data_length, std
 
   const auto packet_size = GetPacketSize(packet.command_code);
 
-  if(data_length != packet_size) {
-    error = "Wrong number of bytes. Expected " + std::to_string(packet_size) + " but got " + std::to_string(data_length) + ".";
+  if (data_length != packet_size) {
+    error = "Wrong number of bytes. Expected " + std::to_string(packet_size) + " but got " +
+      std::to_string(data_length) + ".";
     return {};
   }
 
@@ -95,8 +99,10 @@ RadioPacket ParsePacket(const uint8_t * data, const std::size_t data_length, std
     error = "Protocol versions do not match.";
     return {};
   }
-  
-  std::copy_n(data+kPacketHeaderSize, packet_size - kPacketHeaderSize, reinterpret_cast<uint8_t*>(&packet.data));
+
+  std::copy_n(
+    data + kPacketHeaderSize, packet_size - kPacketHeaderSize,
+    reinterpret_cast<uint8_t *>(&packet.data));
 
   // TODO(barulicm) Firmware doesn't implement CRCs yet
   // if(!HasCorrectCRC(packet)) {
@@ -139,9 +145,9 @@ PacketDataVariant ExtractData(const RadioPacket & packet, std::string & error)
         var = packet.data.control;
         break;
       }
-      default:
-        // No data payload associated with given command code
-        break;
+    default:
+      // No data payload associated with given command code
+      break;
   }
 
   return var;

--- a/ateam_radio_bridge/src/rnp_packet_helpers.cpp
+++ b/ateam_radio_bridge/src/rnp_packet_helpers.cpp
@@ -1,0 +1,150 @@
+#include "rnp_packet_helpers.hpp"
+
+#include <iostream>
+
+#include <boost/crc.hpp>
+
+namespace ateam_radio_bridge
+{
+
+std::size_t GetPacketSize(const CommandCode & command_code)
+{
+  // For now, packet size only depends on command code
+  switch(command_code)
+  {
+    case CC_ACK:
+      return kPacketHeaderSize;
+      break;
+    case CC_NACK:
+      return kPacketHeaderSize;
+      break;
+    case CC_GOODBYE:
+      return kPacketHeaderSize;
+      break;
+    case CC_KEEPALIVE:
+      return kPacketHeaderSize;
+      break;
+    case CC_HELLO_REQ:
+      return kPacketHeaderSize + sizeof(HelloRequest);
+      break;
+    case CC_TELEMETRY:
+      return kPacketHeaderSize + sizeof(BasicTelemetry);
+      break;
+    case CC_CONTROL:
+      return kPacketHeaderSize + sizeof(BasicControl);
+      break;
+    case CC_HELLO_RESP:
+      return kPacketHeaderSize + sizeof(HelloResponse);
+      break;
+    default:
+      throw std::invalid_argument("Unrecognized command code.");
+  }
+}
+
+void SetCRC(RadioPacket & packet)
+{
+  const auto crc_size = sizeof(packet.crc32);
+  const auto packet_size = GetPacketSize(packet.command_code);
+  boost::crc_32_type crc;
+  crc.process_bytes(reinterpret_cast<void*>(reinterpret_cast<uint8_t*>(&packet)+crc_size), packet_size-crc_size);
+  packet.crc32 = crc.checksum();
+}
+
+bool HasCorrectCRC(const RadioPacket & packet)
+{
+  const auto crc_size = sizeof(packet.crc32);
+  const auto packet_size = GetPacketSize(packet.command_code);
+  boost::crc_32_type crc;
+  crc.process_bytes(reinterpret_cast<const void*>(reinterpret_cast<const uint8_t*>(&packet)+crc_size), packet_size-crc_size);
+  return packet.crc32 == crc.checksum();
+}
+
+RadioPacket CreateEmptyPacket(const CommandCode command_code)
+{
+  RadioPacket packet{
+    0,
+    kProtocolVersionMajor,
+    kProtocolVersionMinor,
+    command_code,
+    0,
+    {}
+  };
+
+  SetCRC(packet);
+
+  return packet;
+}
+
+RadioPacket ParsePacket(const uint8_t * data, const std::size_t data_length, std::string & error)
+{
+  RadioPacket packet;
+
+  std::copy_n(data, kPacketHeaderSize, reinterpret_cast<uint8_t *>(&packet));
+
+  const auto packet_size = GetPacketSize(packet.command_code);
+
+  if(data_length != packet_size) {
+    error = "Wrong number of bytes. Expected " + std::to_string(packet_size) + " but got " + std::to_string(data_length) + ".";
+    return {};
+  }
+
+  std::copy_n(data+kPacketHeaderSize, packet_size - kPacketHeaderSize, reinterpret_cast<uint8_t*>(&packet.data));
+
+  if (packet.major_version != kProtocolVersionMajor ||
+    packet.minor_version != kProtocolVersionMinor)
+  {
+    // TODO(barulicm) What should our version compatability rules actually be? This assumes they must match.
+    error = "Protocol versions do not match.";
+    return {};
+  }
+
+  // TODO(barulicm) Firmware doesn't implement CRCs yet
+  // if(!HasCorrectCRC(packet)) {
+  //   error = "CRC value incorrect.";
+  //   return {};
+  // }
+
+  return packet;
+}
+
+PacketDataVariant ExtractData(const RadioPacket & packet, std::string & error)
+{
+  PacketDataVariant var;
+
+  switch (packet.command_code) {
+    case CC_HELLO_REQ:
+      {
+        if (packet.data_length != sizeof(HelloRequest)) {
+          error = "Incorrect data length for HelloData type.";
+          break;
+        }
+        var = packet.data.hello_request;
+        break;
+      }
+    case CC_TELEMETRY:
+      {
+        if (packet.data_length != sizeof(BasicTelemetry)) {
+          error = "Incorrect data length for BasicTelemetry type.";
+          break;
+        }
+        var = packet.data.telemetry;
+        break;
+      }
+    case CC_CONTROL:
+      {
+        if (packet.data_length != sizeof(BasicControl)) {
+          error = "Incorrect data length for BasicControl type.";
+          break;
+        }
+        var = packet.data.control;
+        break;
+      }
+      default:
+        // No data payload associated with given command code
+        break;
+  }
+
+  return var;
+}
+
+}  // namespace ateam_radio_bridge

--- a/ateam_radio_bridge/src/rnp_packet_helpers.hpp
+++ b/ateam_radio_bridge/src/rnp_packet_helpers.hpp
@@ -1,0 +1,64 @@
+#ifndef RNP_PACKET_HELPERS_HPP_
+#define RNP_PACKET_HELPERS_HPP_
+
+#include <algorithm>
+#include <map>
+#include <string>
+#include <typeindex>
+#include <typeinfo>
+#include <variant>
+#include <radio.h>
+#include <hello_data.h>
+#include <basic_control.h>
+#include <basic_telemetry.h>
+
+namespace ateam_radio_bridge
+{
+
+std::size_t GetPacketSize(const CommandCode & packet);
+
+constexpr std::size_t kPacketHeaderSize = 12;
+
+void SetCRC(RadioPacket & packet);
+
+bool HasCorrectCRC(const RadioPacket & packet);
+
+template<typename DataTypeType>
+void SetDataPayload(RadioPacket & packet, const DataTypeType & payload)
+{
+  packet.data_length = sizeof(DataTypeType);
+  auto payload_ptr = reinterpret_cast<const uint8_t *>(&payload);
+  std::copy_n(payload_ptr, packet.data_length, reinterpret_cast<uint8_t *>(&packet.data));
+}
+
+template<typename DataTypeType>
+RadioPacket CreatePacket(const CommandCode command_code, const DataTypeType & data)
+{
+  RadioPacket packet{
+    0,
+    kProtocolVersionMajor,
+    kProtocolVersionMinor,
+    command_code,
+    0,
+    {}
+  };
+
+  SetDataPayload(packet, data);
+
+  SetCRC(packet);
+
+  return packet;
+}
+
+RadioPacket CreateEmptyPacket(const CommandCode command_code);
+
+RadioPacket ParsePacket(const uint8_t * data, const std::size_t data_length, std::string & error);
+
+using PacketDataVariant = std::variant<std::monostate, HelloRequest, BasicTelemetry,
+    BasicControl>;
+
+PacketDataVariant ExtractData(const RadioPacket & packet, std::string & error);
+
+}  // ateam_radio_bridge
+
+#endif  // RNP_PACKET_HELPERS_HPP_

--- a/ateam_radio_bridge/test/CMakeLists.txt
+++ b/ateam_radio_bridge/test/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(launch_tests)
+add_subdirectory(unit_tests)

--- a/ateam_radio_bridge/test/launch_tests/CMakeLists.txt
+++ b/ateam_radio_bridge/test/launch_tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+find_package(launch_testing_ament_cmake REQUIRED)
+add_launch_test(radio_discovery_test.py
+  APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/test
+  TIMEOUT 10
+)

--- a/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
+++ b/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
@@ -112,10 +112,10 @@ class TestRadioBridgeNode(unittest.TestCase):
   def test_2_commandMessage(self):
     data = self.sock.recv(508)
     expected_data = bytearray(b'\x00') * 36
-    expected_data[0:4] = [57, 152, 86, 229] # CRC
+    expected_data[0:4] = [92, 255, 234, 93] # CRC
     expected_data[8] = 201 # Command code: CC_CONTROL
     expected_data[9:11] = [0,24] # Data length
-    expected_data[32] = 1 # Kicker request: KR_DISABLE
+    expected_data[32] = 0 # Kicker request: KR_ARM
     self.assertEqual(len(data), len(expected_data), "Radio bridge node sent the wrong number of bytes for a command packet")
     for i in range(min(len(data), len(expected_data))):
       if data[i] != expected_data[i]:

--- a/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
+++ b/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
@@ -1,0 +1,127 @@
+import unittest
+import rclpy
+import launch
+from launch.actions import TimerAction
+import launch_ros.actions
+import launch_testing
+import launch_testing_ros
+import pytest
+import socket
+import struct
+import ateam_msgs.msg
+import time
+
+discovery_address = '224.4.20.70'
+discovery_port = 42069
+discovery_endpoint = (discovery_address, discovery_port)
+
+bridge_endpoint = ('', 0)
+
+@pytest.mark.rostest
+def generate_test_description():
+  return launch.LaunchDescription([
+    launch_ros.actions.Node(
+      package='ateam_radio_bridge',
+      executable='radio_bridge_node',
+      parameters=[{
+        "discovery_address": discovery_address
+      }]
+    ),
+    # Had to add this delay when upgraded to Humble. Without this, the test fails b/c the bridge never seems to receive the discovery message
+    TimerAction(
+      period=0.1,
+      actions=[
+        launch_testing.actions.ReadyToTest()
+      ]
+    )
+  ]), locals()
+
+class TestRadioBridgeNode(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    cls.context = rclpy.Context()
+    rclpy.init(context=cls.context)
+    cls.node = rclpy.create_node('test_radio_bridge_node', context=cls.context, allow_undeclared_parameters=True, automatically_declare_parameters_from_overrides=True)
+    cls.message_pump = launch_testing_ros.MessagePump(cls.node, context=cls.context)
+    cls.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    cls.sock.settimeout(1.0)
+    cls.message_pump.start()
+
+  @classmethod
+  def tearDownClass(cls):
+    cls.message_pump.stop()
+    cls.node.destroy_node()
+    cls.sock.close()
+    rclpy.shutdown(context=cls.context)
+
+  def setUp(self):
+    self.feedback_sub = self.node.create_subscription(ateam_msgs.msg.RobotFeedback, '/radio_bridge/robot_feedback/robot0', self.feedback_callback_0, 1)
+    self.received_feedback_msg_0 = None
+
+  def test_0_discoveryResponse(self):
+    self.sock.sendto(struct.pack("IHHBHBB", 653411691, 0, 0, 101, 2, 0, 0), discovery_endpoint)
+    data, sender = self.sock.recvfrom(52)
+    global bridge_endpoint
+    self.assertEqual(data[8], 202, "Radio bridge sent wrong command code. Expected CC_HELLO_RESP (202).")
+    self.assertEqual(data[9:11], bytearray([0,6]), "Radio bridge sent wrong size for reply data. Expected 6 (size of HelloResponse).")
+    # Note: This test does not check full packet contents as they are dynamic and unpredictable from the client
+    self.assertNotEqual(data[12:16], bytearray([0,0,0,0]), "Hello response should not hold IP 0.0.0.0")
+    self.assertNotEqual(data[16:18], bytearray([0,0]), "Hello response should not hold port 0")
+    server_port = (data[17]<<8) | data[16]
+    server_ip = ".".join([str(x) for x in data[12:16]])
+    bridge_endpoint = (server_ip, server_port)  # Save so we can send things back to the bridge
+
+  def test_1_telemetryMessage(self):
+    telemetry_msg_data = struct.pack("IHHBHHBBffIffffff", 1112834395, 0, 0, 102, 40, 1, 2, 3, 4.0, 5.0, 349525, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0)
+    global bridge_endpoint
+    self.sock.sendto(telemetry_msg_data, bridge_endpoint)
+    while self.received_feedback_msg_0 is None:
+      time.sleep(0.1)
+    self.assertEqual(self.received_feedback_msg_0.sequence_number, 1)
+    self.assertEqual(self.received_feedback_msg_0.robot_revision_major, 2)
+    self.assertEqual(self.received_feedback_msg_0.robot_revision_minor, 3)
+    self.assertAlmostEqual(self.received_feedback_msg_0.battery_level, 4.0)
+    self.assertAlmostEqual(self.received_feedback_msg_0.battery_temperature, 5.0)
+    self.assertTrue(self.received_feedback_msg_0.power_error)
+    self.assertFalse(self.received_feedback_msg_0.tipped_error)
+    self.assertTrue(self.received_feedback_msg_0.breakbeam_error)
+    self.assertFalse(self.received_feedback_msg_0.breakbeam_ball_detected)
+    self.assertTrue(self.received_feedback_msg_0.accelerometer_0_error)
+    self.assertFalse(self.received_feedback_msg_0.accelerometer_1_error)
+    self.assertTrue(self.received_feedback_msg_0.gyroscope_0_error)
+    self.assertFalse(self.received_feedback_msg_0.gyroscope_1_error)
+    self.assertTrue(self.received_feedback_msg_0.motor_0_general_error)
+    self.assertFalse(self.received_feedback_msg_0.motor_0_hall_error)
+    self.assertTrue(self.received_feedback_msg_0.motor_1_general_error)
+    self.assertFalse(self.received_feedback_msg_0.motor_1_hall_error)
+    self.assertTrue(self.received_feedback_msg_0.motor_2_general_error)
+    self.assertFalse(self.received_feedback_msg_0.motor_2_hall_error)
+    self.assertTrue(self.received_feedback_msg_0.motor_3_general_error)
+    self.assertFalse(self.received_feedback_msg_0.motor_3_hall_error)
+    self.assertTrue(self.received_feedback_msg_0.motor_4_general_error)
+    self.assertFalse(self.received_feedback_msg_0.motor_4_hall_error)
+    self.assertTrue(self.received_feedback_msg_0.chipper_available)
+    self.assertFalse(self.received_feedback_msg_0.kicker_available)
+    self.assertAlmostEqual(self.received_feedback_msg_0.motor_0_temperature, 6.0)
+    self.assertAlmostEqual(self.received_feedback_msg_0.motor_1_temperature, 7.0)
+    self.assertAlmostEqual(self.received_feedback_msg_0.motor_2_temperature, 8.0)
+    self.assertAlmostEqual(self.received_feedback_msg_0.motor_3_temperature, 9.0)
+    self.assertAlmostEqual(self.received_feedback_msg_0.motor_4_temperature, 10.0)
+    self.assertAlmostEqual(self.received_feedback_msg_0.kicker_charge_level, 11.0)
+
+  def test_2_commandMessage(self):
+    data = self.sock.recv(508)
+    expected_data = bytearray(b'\x00') * 36
+    expected_data[0:4] = [57, 152, 86, 229] # CRC
+    expected_data[8] = 201 # Command code: CC_CONTROL
+    expected_data[9:11] = [0,24] # Data length
+    expected_data[32] = 1 # Kicker request: KR_DISABLE
+    self.assertEqual(len(data), len(expected_data), "Radio bridge node sent the wrong number of bytes for a command packet")
+    for i in range(min(len(data), len(expected_data))):
+      if data[i] != expected_data[i]:
+        print(f"@ {i}: {data[i]} != {expected_data[i]}")
+    self.assertEqual(data, expected_data, "Radio bridge node sent an unexpected command packet")
+
+  def feedback_callback_0(self, msg):
+    self.received_feedback_msg_0 = ateam_msgs.msg.RobotFeedback()
+    self.received_feedback_msg_0 = msg

--- a/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
+++ b/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
@@ -11,117 +11,190 @@ import struct
 import ateam_msgs.msg
 import time
 
-discovery_address = '224.4.20.70'
+discovery_address = "224.4.20.70"
 discovery_port = 42069
 discovery_endpoint = (discovery_address, discovery_port)
 
-bridge_endpoint = ('', 0)
+bridge_endpoint = ("", 0)
+
 
 @pytest.mark.rostest
 def generate_test_description():
-  return launch.LaunchDescription([
-    launch_ros.actions.Node(
-      package='ateam_radio_bridge',
-      executable='radio_bridge_node',
-      parameters=[{
-        "discovery_address": discovery_address
-      }]
-    ),
-    # Had to add this delay when upgraded to Humble. Without this, the test fails b/c the bridge never seems to receive the discovery message
-    TimerAction(
-      period=0.1,
-      actions=[
-        launch_testing.actions.ReadyToTest()
-      ]
+    return (
+        launch.LaunchDescription(
+            [
+                launch_ros.actions.Node(
+                    package="ateam_radio_bridge",
+                    executable="radio_bridge_node",
+                    parameters=[{"discovery_address": discovery_address}],
+                ),
+                # Had to add this delay when upgraded to Humble. Without this,
+                # the test fails b/c the bridge never seems to receive the
+                # discovery message
+                TimerAction(period=0.1, actions=[
+                    launch_testing.actions.ReadyToTest()]),
+            ]
+        ),
+        locals(),
     )
-  ]), locals()
+
 
 class TestRadioBridgeNode(unittest.TestCase):
-  @classmethod
-  def setUpClass(cls):
-    cls.context = rclpy.Context()
-    rclpy.init(context=cls.context)
-    cls.node = rclpy.create_node('test_radio_bridge_node', context=cls.context, allow_undeclared_parameters=True, automatically_declare_parameters_from_overrides=True)
-    cls.message_pump = launch_testing_ros.MessagePump(cls.node, context=cls.context)
-    cls.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
-    cls.sock.settimeout(1.0)
-    cls.message_pump.start()
+    @classmethod
+    def setUpClass(cls):
+        cls.context = rclpy.Context()
+        rclpy.init(context=cls.context)
+        cls.node = rclpy.create_node(
+            "test_radio_bridge_node",
+            context=cls.context,
+            allow_undeclared_parameters=True,
+            automatically_declare_parameters_from_overrides=True,
+        )
+        cls.message_pump = launch_testing_ros.MessagePump(
+            cls.node, context=cls.context)
+        cls.sock = socket.socket(
+            socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        cls.sock.settimeout(1.0)
+        cls.message_pump.start()
 
-  @classmethod
-  def tearDownClass(cls):
-    cls.message_pump.stop()
-    cls.node.destroy_node()
-    cls.sock.close()
-    rclpy.shutdown(context=cls.context)
+    @classmethod
+    def tearDownClass(cls):
+        cls.message_pump.stop()
+        cls.node.destroy_node()
+        cls.sock.close()
+        rclpy.shutdown(context=cls.context)
 
-  def setUp(self):
-    self.feedback_sub = self.node.create_subscription(ateam_msgs.msg.RobotFeedback, '/radio_bridge/robot_feedback/robot0', self.feedback_callback_0, 1)
-    self.received_feedback_msg_0 = None
+    def setUp(self):
+        self.feedback_sub = self.node.create_subscription(
+            ateam_msgs.msg.RobotFeedback,
+            "/radio_bridge/robot_feedback/robot0",
+            self.feedback_callback_0,
+            1,
+        )
+        self.received_feedback_msg_0 = None
 
-  def test_0_discoveryResponse(self):
-    self.sock.sendto(struct.pack("IHHBHBB", 653411691, 0, 0, 101, 2, 0, 0), discovery_endpoint)
-    data, sender = self.sock.recvfrom(52)
-    global bridge_endpoint
-    self.assertEqual(data[8], 202, "Radio bridge sent wrong command code. Expected CC_HELLO_RESP (202).")
-    self.assertEqual(data[9:11], bytearray([0,6]), "Radio bridge sent wrong size for reply data. Expected 6 (size of HelloResponse).")
-    # Note: This test does not check full packet contents as they are dynamic and unpredictable from the client
-    self.assertNotEqual(data[12:16], bytearray([0,0,0,0]), "Hello response should not hold IP 0.0.0.0")
-    self.assertNotEqual(data[16:18], bytearray([0,0]), "Hello response should not hold port 0")
-    server_port = (data[17]<<8) | data[16]
-    server_ip = ".".join([str(x) for x in data[12:16]])
-    bridge_endpoint = (server_ip, server_port)  # Save so we can send things back to the bridge
+    def test_0_discoveryResponse(self):
+        self.sock.sendto(
+            struct.pack("IHHBHBB", 653411691, 0, 0, 101, 2, 0, 0),
+            discovery_endpoint
+        )
+        data, sender = self.sock.recvfrom(52)
+        global bridge_endpoint
+        self.assertEqual(
+            data[8],
+            202,
+            "Radio bridge sent wrong command code. Expected CC_HELLO_RESP \
+                (202).",
+        )
+        self.assertEqual(
+            data[9:11],
+            bytearray([0, 6]),
+            "Radio bridge sent wrong size for reply data. \
+                Expected 6 (size of HelloResponse).",
+        )
+        # Note: This test does not check full packet contents as they are
+        # dynamic and unpredictable from the client
+        self.assertNotEqual(
+            data[12:16],
+            bytearray([0, 0, 0, 0]),
+            "Hello response should not hold IP 0.0.0.0",
+        )
+        self.assertNotEqual(
+            data[16:18], bytearray([0, 0]), "Hello response should not hold \
+                port 0"
+        )
+        server_port = (data[17] << 8) | data[16]
+        server_ip = ".".join([str(x) for x in data[12:16]])
+        bridge_endpoint = (
+            server_ip,
+            server_port,
+        )  # Save so we can send things back to the bridge
 
-  def test_1_telemetryMessage(self):
-    telemetry_msg_data = struct.pack("IHHBHHBBffIffffff", 1112834395, 0, 0, 102, 40, 1, 2, 3, 4.0, 5.0, 349525, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0)
-    global bridge_endpoint
-    self.sock.sendto(telemetry_msg_data, bridge_endpoint)
-    while self.received_feedback_msg_0 is None:
-      time.sleep(0.1)
-    self.assertEqual(self.received_feedback_msg_0.sequence_number, 1)
-    self.assertEqual(self.received_feedback_msg_0.robot_revision_major, 2)
-    self.assertEqual(self.received_feedback_msg_0.robot_revision_minor, 3)
-    self.assertAlmostEqual(self.received_feedback_msg_0.battery_level, 4.0)
-    self.assertAlmostEqual(self.received_feedback_msg_0.battery_temperature, 5.0)
-    self.assertTrue(self.received_feedback_msg_0.power_error)
-    self.assertFalse(self.received_feedback_msg_0.tipped_error)
-    self.assertTrue(self.received_feedback_msg_0.breakbeam_error)
-    self.assertFalse(self.received_feedback_msg_0.breakbeam_ball_detected)
-    self.assertTrue(self.received_feedback_msg_0.accelerometer_0_error)
-    self.assertFalse(self.received_feedback_msg_0.accelerometer_1_error)
-    self.assertTrue(self.received_feedback_msg_0.gyroscope_0_error)
-    self.assertFalse(self.received_feedback_msg_0.gyroscope_1_error)
-    self.assertTrue(self.received_feedback_msg_0.motor_0_general_error)
-    self.assertFalse(self.received_feedback_msg_0.motor_0_hall_error)
-    self.assertTrue(self.received_feedback_msg_0.motor_1_general_error)
-    self.assertFalse(self.received_feedback_msg_0.motor_1_hall_error)
-    self.assertTrue(self.received_feedback_msg_0.motor_2_general_error)
-    self.assertFalse(self.received_feedback_msg_0.motor_2_hall_error)
-    self.assertTrue(self.received_feedback_msg_0.motor_3_general_error)
-    self.assertFalse(self.received_feedback_msg_0.motor_3_hall_error)
-    self.assertTrue(self.received_feedback_msg_0.motor_4_general_error)
-    self.assertFalse(self.received_feedback_msg_0.motor_4_hall_error)
-    self.assertTrue(self.received_feedback_msg_0.chipper_available)
-    self.assertFalse(self.received_feedback_msg_0.kicker_available)
-    self.assertAlmostEqual(self.received_feedback_msg_0.motor_0_temperature, 6.0)
-    self.assertAlmostEqual(self.received_feedback_msg_0.motor_1_temperature, 7.0)
-    self.assertAlmostEqual(self.received_feedback_msg_0.motor_2_temperature, 8.0)
-    self.assertAlmostEqual(self.received_feedback_msg_0.motor_3_temperature, 9.0)
-    self.assertAlmostEqual(self.received_feedback_msg_0.motor_4_temperature, 10.0)
-    self.assertAlmostEqual(self.received_feedback_msg_0.kicker_charge_level, 11.0)
+    def test_1_telemetryMessage(self):
+        telemetry_msg_data = struct.pack(
+            "IHHBHHBBffIffffff",
+            1112834395,
+            0,
+            0,
+            102,
+            40,
+            1,
+            2,
+            3,
+            4.0,
+            5.0,
+            349525,
+            6.0,
+            7.0,
+            8.0,
+            9.0,
+            10.0,
+            11.0,
+        )
+        global bridge_endpoint
+        self.sock.sendto(telemetry_msg_data, bridge_endpoint)
+        while self.received_feedback_msg_0 is None:
+            time.sleep(0.1)
+        self.assertEqual(self.received_feedback_msg_0.sequence_number, 1)
+        self.assertEqual(self.received_feedback_msg_0.robot_revision_major, 2)
+        self.assertEqual(self.received_feedback_msg_0.robot_revision_minor, 3)
+        self.assertAlmostEqual(self.received_feedback_msg_0.battery_level, 4.0)
+        self.assertAlmostEqual(
+            self.received_feedback_msg_0.battery_temperature, 5.0)
+        self.assertTrue(self.received_feedback_msg_0.power_error)
+        self.assertFalse(self.received_feedback_msg_0.tipped_error)
+        self.assertTrue(self.received_feedback_msg_0.breakbeam_error)
+        self.assertFalse(self.received_feedback_msg_0.breakbeam_ball_detected)
+        self.assertTrue(self.received_feedback_msg_0.accelerometer_0_error)
+        self.assertFalse(self.received_feedback_msg_0.accelerometer_1_error)
+        self.assertTrue(self.received_feedback_msg_0.gyroscope_0_error)
+        self.assertFalse(self.received_feedback_msg_0.gyroscope_1_error)
+        self.assertTrue(self.received_feedback_msg_0.motor_0_general_error)
+        self.assertFalse(self.received_feedback_msg_0.motor_0_hall_error)
+        self.assertTrue(self.received_feedback_msg_0.motor_1_general_error)
+        self.assertFalse(self.received_feedback_msg_0.motor_1_hall_error)
+        self.assertTrue(self.received_feedback_msg_0.motor_2_general_error)
+        self.assertFalse(self.received_feedback_msg_0.motor_2_hall_error)
+        self.assertTrue(self.received_feedback_msg_0.motor_3_general_error)
+        self.assertFalse(self.received_feedback_msg_0.motor_3_hall_error)
+        self.assertTrue(self.received_feedback_msg_0.motor_4_general_error)
+        self.assertFalse(self.received_feedback_msg_0.motor_4_hall_error)
+        self.assertTrue(self.received_feedback_msg_0.chipper_available)
+        self.assertFalse(self.received_feedback_msg_0.kicker_available)
+        self.assertAlmostEqual(
+            self.received_feedback_msg_0.motor_0_temperature, 6.0)
+        self.assertAlmostEqual(
+            self.received_feedback_msg_0.motor_1_temperature, 7.0)
+        self.assertAlmostEqual(
+            self.received_feedback_msg_0.motor_2_temperature, 8.0)
+        self.assertAlmostEqual(
+            self.received_feedback_msg_0.motor_3_temperature, 9.0)
+        self.assertAlmostEqual(
+            self.received_feedback_msg_0.motor_4_temperature, 10.0)
+        self.assertAlmostEqual(
+            self.received_feedback_msg_0.kicker_charge_level, 11.0)
 
-  def test_2_commandMessage(self):
-    data = self.sock.recv(508)
-    expected_data = bytearray(b'\x00') * 36
-    expected_data[0:4] = [92, 255, 234, 93] # CRC
-    expected_data[8] = 201 # Command code: CC_CONTROL
-    expected_data[9:11] = [0,24] # Data length
-    expected_data[32] = 0 # Kicker request: KR_ARM
-    self.assertEqual(len(data), len(expected_data), "Radio bridge node sent the wrong number of bytes for a command packet")
-    for i in range(min(len(data), len(expected_data))):
-      if data[i] != expected_data[i]:
-        print(f"@ {i}: {data[i]} != {expected_data[i]}")
-    self.assertEqual(data, expected_data, "Radio bridge node sent an unexpected command packet")
+    def test_2_commandMessage(self):
+        data = self.sock.recv(508)
+        expected_data = bytearray(b"\x00") * 36
+        expected_data[0:4] = [92, 255, 234, 93]  # CRC
+        expected_data[8] = 201  # Command code: CC_CONTROL
+        expected_data[9:11] = [0, 24]  # Data length
+        expected_data[32] = 0  # Kicker request: KR_ARM
+        self.assertEqual(
+            len(data),
+            len(expected_data),
+            "Radio bridge node sent the wrong number of bytes for a command \
+                packet",
+        )
+        for i in range(min(len(data), len(expected_data))):
+            if data[i] != expected_data[i]:
+                print(f"@ {i}: {data[i]} != {expected_data[i]}")
+        self.assertEqual(
+            data, expected_data, "Radio bridge node sent an unexpected command\
+                  packet"
+        )
 
-  def feedback_callback_0(self, msg):
-    self.received_feedback_msg_0 = ateam_msgs.msg.RobotFeedback()
-    self.received_feedback_msg_0 = msg
+    def feedback_callback_0(self, msg):
+        self.received_feedback_msg_0 = ateam_msgs.msg.RobotFeedback()
+        self.received_feedback_msg_0 = msg

--- a/ateam_radio_bridge/test/unit_tests/CMakeLists.txt
+++ b/ateam_radio_bridge/test/unit_tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+find_package(ament_cmake_gtest REQUIRED)
+ament_add_gtest(unit_tests
+  conversion_tests.cpp
+  rnp_packet_helpers_tests.cpp
+)
+target_link_libraries(unit_tests ${PROJECT_NAME})

--- a/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
+++ b/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+#include "conversion.hpp"
+
+TEST(Convert, BasicTelemmetry)
+{
+  BasicTelemetry telemetry {
+    0,
+    1,
+    2,
+    3.4,
+    5.6,
+    0,
+    1,
+    0,
+    1,
+    0,
+    0,
+    1,
+    1,
+    0,
+    1,
+    1,
+    0,
+    1,
+    1,
+    0,
+    1,
+    0,
+    0,
+    1,
+    0,
+    0,
+    1.2,
+    3.4,
+    5.6,
+    7.8,
+    9.0,
+    1.2
+  };
+  const auto feedback_msg = ateam_radio_bridge::Convert(telemetry);
+  EXPECT_EQ(feedback_msg.sequence_number, 0);
+  EXPECT_EQ(feedback_msg.robot_revision_major, 1);
+  EXPECT_EQ(feedback_msg.robot_revision_minor, 2);
+  EXPECT_FLOAT_EQ(feedback_msg.battery_level, 3.4);
+  EXPECT_FLOAT_EQ(feedback_msg.battery_temperature, 5.6);
+  EXPECT_EQ(feedback_msg.power_error, 0);
+  EXPECT_EQ(feedback_msg.tipped_error, 1);
+  EXPECT_EQ(feedback_msg.breakbeam_error, 0);
+  EXPECT_EQ(feedback_msg.breakbeam_ball_detected, 1);
+  EXPECT_EQ(feedback_msg.accelerometer_0_error, 0);
+  EXPECT_EQ(feedback_msg.accelerometer_1_error, 0);
+  EXPECT_EQ(feedback_msg.gyroscope_0_error, 1);
+  EXPECT_EQ(feedback_msg.gyroscope_1_error, 1);
+  EXPECT_EQ(feedback_msg.motor_0_general_error, 0);
+  EXPECT_EQ(feedback_msg.motor_0_hall_error, 1);
+  EXPECT_EQ(feedback_msg.motor_1_general_error, 1);
+  EXPECT_EQ(feedback_msg.motor_1_hall_error, 0);
+  EXPECT_EQ(feedback_msg.motor_2_general_error, 1);
+  EXPECT_EQ(feedback_msg.motor_2_hall_error, 1);
+  EXPECT_EQ(feedback_msg.motor_3_general_error, 0);
+  EXPECT_EQ(feedback_msg.motor_3_hall_error, 1);
+  EXPECT_EQ(feedback_msg.motor_4_general_error, 0);
+  EXPECT_EQ(feedback_msg.motor_4_hall_error, 0);
+  EXPECT_EQ(feedback_msg.chipper_available, 1);
+  EXPECT_EQ(feedback_msg.kicker_available, 0);
+  EXPECT_FLOAT_EQ(feedback_msg.motor_0_temperature, 1.2);
+  EXPECT_FLOAT_EQ(feedback_msg.motor_1_temperature, 3.4);
+  EXPECT_FLOAT_EQ(feedback_msg.motor_2_temperature, 5.6);
+  EXPECT_FLOAT_EQ(feedback_msg.motor_3_temperature, 7.8);
+  EXPECT_FLOAT_EQ(feedback_msg.motor_4_temperature, 9.0);
+  EXPECT_FLOAT_EQ(feedback_msg.kicker_charge_level, 1.2);
+}

--- a/ateam_radio_bridge/test/unit_tests/rnp_packet_helpers_tests.cpp
+++ b/ateam_radio_bridge/test/unit_tests/rnp_packet_helpers_tests.cpp
@@ -37,25 +37,88 @@ TEST(HasCorrectCRC, BasicTest)
 
 TEST(SetDataPayload, HelloRequest)
 {
-
+  RadioPacket packet;
+  HelloRequest payload{
+    8,
+    TC_BLUE
+  };
+  ateam_radio_bridge::SetDataPayload(packet, payload);
+  EXPECT_EQ(packet.data_length, 2);
+  EXPECT_EQ(packet.data.hello_request.robot_id, 8);
+  EXPECT_EQ(packet.data.hello_request.color, TC_BLUE);
 }
 
 TEST(CreatePacket, HelloRequest)
 {
-
+  HelloRequest payload{
+    12,
+    TC_YELLOW
+  };
+  RadioPacket packet = ateam_radio_bridge::CreatePacket(CC_HELLO_REQ, payload);
+  EXPECT_EQ(packet.crc32, 3171905816u);
+  EXPECT_EQ(packet.major_version, kProtocolVersionMajor);
+  EXPECT_EQ(packet.minor_version, kProtocolVersionMinor);
+  EXPECT_EQ(packet.command_code, CC_HELLO_REQ);
+  EXPECT_EQ(packet.data_length, 2);
+  EXPECT_EQ(packet.data.hello_request.robot_id, 12);
+  EXPECT_EQ(packet.data.hello_request.color, TC_YELLOW);
 }
 
 TEST(CreateEmptyPacket, Ack)
 {
-
+  RadioPacket packet = ateam_radio_bridge::CreateEmptyPacket(CC_ACK);
+  EXPECT_EQ(packet.crc32, 3718166540u);
+  EXPECT_EQ(packet.major_version, kProtocolVersionMajor);
+  EXPECT_EQ(packet.minor_version, kProtocolVersionMinor);
+  EXPECT_EQ(packet.command_code, CC_ACK);
+  EXPECT_EQ(packet.data_length, 0);
 }
 
 TEST(ParsePacket, HelloRequest)
 {
-
+  std::array<uint8_t, 14> data = {
+    0,
+    0,
+    0,
+    0,
+    kProtocolVersionMajor & 0xFF,
+    kProtocolVersionMajor >> 8,
+    kProtocolVersionMinor & 0xFF,
+    kProtocolVersionMinor >> 8,
+    CC_HELLO_REQ,
+    0,
+    2,
+    0,
+    15,
+    1
+  };
+  std::string error_msg;
+  RadioPacket packet = ateam_radio_bridge::ParsePacket(data.data(), data.size(), error_msg);
+  EXPECT_TRUE(error_msg.empty()) << "Unexpected error message: " << error_msg;
+  EXPECT_EQ(packet.crc32, 0u);
+  EXPECT_EQ(packet.major_version, kProtocolVersionMajor);
+  EXPECT_EQ(packet.minor_version, kProtocolVersionMinor);
+  EXPECT_EQ(packet.command_code, CC_HELLO_REQ);
+  EXPECT_EQ(packet.data_length, 2);
+  EXPECT_EQ(packet.data.hello_request.robot_id, 15);
+  EXPECT_EQ(packet.data.hello_request.color, TC_BLUE);
 }
 
 TEST(ExtractData, HelloRequest)
 {
-  
+  RadioPacket packet{
+    0,
+    0,
+    0,
+    CC_HELLO_REQ,
+    2,
+    HelloRequest{4,TC_BLUE}
+  };
+  std::string error_msg;
+  ateam_radio_bridge::PacketDataVariant data_var = ateam_radio_bridge::ExtractData(packet, error_msg);
+  EXPECT_TRUE(error_msg.empty()) << "Unexpected error message: " << error_msg;
+  ASSERT_TRUE(std::holds_alternative<HelloRequest>(data_var));
+  HelloRequest data = std::get<HelloRequest>(data_var);
+  EXPECT_EQ(data.robot_id, 4);
+  EXPECT_EQ(data.color, TC_BLUE);
 }

--- a/ateam_radio_bridge/test/unit_tests/rnp_packet_helpers_tests.cpp
+++ b/ateam_radio_bridge/test/unit_tests/rnp_packet_helpers_tests.cpp
@@ -2,14 +2,37 @@
 
 #include <rnp_packet_helpers.hpp>
 
+// TODO(barulicm) expand test coverage
+
 TEST(SetCRC, BasicTest)
 {
-
+  RadioPacket packet{
+    0,
+    1,
+    2,
+    CC_ACK,
+    0,
+    {}
+  };
+  ateam_radio_bridge::SetCRC(packet);
+  EXPECT_EQ(packet.crc32, 1560025497u);
 }
 
 TEST(HasCorrectCRC, BasicTest)
 {
+  RadioPacket packet{
+    1560025497,
+    1,
+    2,
+    CC_ACK,
+    0,
+    {}
+  };
+  EXPECT_TRUE(ateam_radio_bridge::HasCorrectCRC(packet));
 
+  
+  packet.crc32 = 12; // arbitrary bad CRC value
+  EXPECT_FALSE(ateam_radio_bridge::HasCorrectCRC(packet));
 }
 
 TEST(SetDataPayload, HelloRequest)

--- a/ateam_radio_bridge/test/unit_tests/rnp_packet_helpers_tests.cpp
+++ b/ateam_radio_bridge/test/unit_tests/rnp_packet_helpers_tests.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include <rnp_packet_helpers.hpp>
+
+TEST(SetCRC, BasicTest)
+{
+
+}
+
+TEST(HasCorrectCRC, BasicTest)
+{
+
+}
+
+TEST(SetDataPayload, HelloRequest)
+{
+
+}
+
+TEST(CreatePacket, HelloRequest)
+{
+
+}
+
+TEST(CreateEmptyPacket, Ack)
+{
+
+}
+
+TEST(ParsePacket, HelloRequest)
+{
+
+}
+
+TEST(ExtractData, HelloRequest)
+{
+  
+}

--- a/ateam_radio_bridge/test/unit_tests/rnp_packet_helpers_tests.cpp
+++ b/ateam_radio_bridge/test/unit_tests/rnp_packet_helpers_tests.cpp
@@ -30,7 +30,7 @@ TEST(HasCorrectCRC, BasicTest)
   };
   EXPECT_TRUE(ateam_radio_bridge::HasCorrectCRC(packet));
 
-  
+
   packet.crc32 = 12; // arbitrary bad CRC value
   EXPECT_FALSE(ateam_radio_bridge::HasCorrectCRC(packet));
 }
@@ -112,10 +112,11 @@ TEST(ExtractData, HelloRequest)
     0,
     CC_HELLO_REQ,
     2,
-    HelloRequest{4,TC_BLUE}
+    HelloRequest{4, TC_BLUE}
   };
   std::string error_msg;
-  ateam_radio_bridge::PacketDataVariant data_var = ateam_radio_bridge::ExtractData(packet, error_msg);
+  ateam_radio_bridge::PacketDataVariant data_var =
+    ateam_radio_bridge::ExtractData(packet, error_msg);
   EXPECT_TRUE(error_msg.empty()) << "Unexpected error message: " << error_msg;
   ASSERT_TRUE(std::holds_alternative<HelloRequest>(data_var));
   HelloRequest data = std::get<HelloRequest>(data_var);


### PR DESCRIPTION
It's finally here!

This PR adds the `ateam_radio_bridge` package. This package provides a node to connect our robot radio network to ROS.

This package also includes a submodule for the [software-communication repo](https://github.com/SSL-A-Team/software-communication), which holds the shared definitions of our radio packets.