### PR TITLE
Changes default team color to blue.

### DIFF
--- a/ateam_common/src/team_info_listener.cpp
+++ b/ateam_common/src/team_info_listener.cpp
@@ -32,7 +32,7 @@ TeamInfoListener::TeamInfoListener(
   side_callback_(side_callback)
 {
   const auto default_team_color =
-    node.declare_parameter<std::string>("default_team_color", "yellow");
+    node.declare_parameter<std::string>("default_team_color", "blue");
   if (default_team_color == "yellow") {
     team_color_ = TeamColor::Yellow;
   } else if (default_team_color == "blue") {

--- a/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
+++ b/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
@@ -26,7 +26,10 @@ def generate_test_description():
                 launch_ros.actions.Node(
                     package="ateam_radio_bridge",
                     executable="radio_bridge_node",
-                    parameters=[{"discovery_address": discovery_address}],
+                    parameters=[
+                        {"discovery_address": discovery_address},
+                        {"default_team_color": "yellow"}
+                        ],
                 ),
                 # Had to add this delay when upgraded to Humble. Without this,
                 # the test fails b/c the bridge never seems to receive the


### PR DESCRIPTION
This changes the default team color in the `TeamInfoListener` to blue to be consitent with our new convention of always defaulting blue.