### PR TITLE
Adds competition branchs to CI on any push.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,9 @@
 name: CI
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - comp/**
   pull_request:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
While we aren't adding push proections on our competition branches, this will hopefully help identify any breaking changes we accidentally push.