### PR TITLE
Add Control Debug Telemetry Data Pipeline

### DIFF
--- a/ateam_msgs/CMakeLists.txt
+++ b/ateam_msgs/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(ssl_league_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
@@ -44,6 +45,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   builtin_interfaces
   std_msgs
   geometry_msgs
+  sensor_msgs
   ssl_league_msgs
   ADD_LINTER_TESTS
 )

--- a/ateam_msgs/CMakeLists.txt
+++ b/ateam_msgs/CMakeLists.txt
@@ -17,6 +17,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/RefereeInfo.msg
   msg/RobotFeedback.msg
   msg/RobotMotionCommand.msg
+  msg/RobotMotionFeedback.msg
+  msg/RobotMotorFeedback.msg
   msg/RobotState.msg
   msg/Sample3d.msg
   msg/TeamClientConnectionStatus.msg

--- a/ateam_msgs/msg/RobotMotionFeedback.msg
+++ b/ateam_msgs/msg/RobotMotionFeedback.msg
@@ -5,6 +5,8 @@ uint8 BACK_LEFT_MOTOR = 3
 
 ateam_msgs/RobotMotorFeedback[4] motors
 
+sensor_msgs/Imu imu
+
 geometry_msgs/Twist body_velocity_setpoint
 geometry_msgs/Twist clamped_body_velocity_setpoint
 geometry_msgs/Twist body_velocity_state_estimate

--- a/ateam_msgs/msg/RobotMotionFeedback.msg
+++ b/ateam_msgs/msg/RobotMotionFeedback.msg
@@ -1,0 +1,14 @@
+uint8 FRONT_LEFT_MOTOR = 0
+uint8 FRONT_RIGHT_MOTOR = 1
+uint8 BACK_RIGHT_MOTOR = 2
+uint8 BACK_LEFT_MOTOR = 3
+
+ateam_msgs/RobotMotorFeedback[4] motors
+
+geometry_msgs/Twist body_velocity_setpoint
+geometry_msgs/Twist clamped_body_velocity_setpoint
+geometry_msgs/Twist body_velocity_state_estimate
+geometry_msgs/Twist body_velocity_control_variable
+
+float32[4] wheel_velocity_control_variable
+float32[4] clamped_wheel_velocity_control_variable

--- a/ateam_msgs/msg/RobotMotorFeedback.msg
+++ b/ateam_msgs/msg/RobotMotorFeedback.msg
@@ -1,0 +1,3 @@
+float32 setpoint
+float32 velocity
+float32 torque

--- a/ateam_radio_bridge/package.xml
+++ b/ateam_radio_bridge/package.xml
@@ -11,6 +11,7 @@
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
   <depend>ateam_msgs</depend>
   <depend>ateam_common</depend>
 

--- a/ateam_radio_bridge/src/conversion.cpp
+++ b/ateam_radio_bridge/src/conversion.cpp
@@ -64,6 +64,20 @@ ateam_msgs::msg::RobotFeedback ConvertBasicTelemetry(const BasicTelemetry & basi
   return robot_feedback;
 }
 
+void ConvertFloatArrayToVec3(const float (&float_arr_3)[3], geometry_msgs::msg::Vector3 & vec) {
+  vec.x = float_arr_3[0];
+  vec.y = float_arr_3[1];
+  vec.z = float_arr_3[2];
+}
+
+geometry_msgs::msg::Vector3 ConvertFloatArrayToVec3(const float (&float_arr_3)[3]) {
+  geometry_msgs::msg::Vector3 vec;
+
+  ConvertFloatArrayToVec3(float_arr_3, vec);
+
+  return vec;
+}
+
 void ConvertFloatArrayToTwist(const float (&fw_state_space_array)[3], geometry_msgs::msg::Twist & twist) {
   twist.linear.x = fw_state_space_array[0];
   twist.linear.y = fw_state_space_array[1];
@@ -102,6 +116,10 @@ ateam_msgs::msg::RobotMotionFeedback ConvertControlDebugTelemetry(const ControlD
   robot_motion_feedback.motors[robot_motion_feedback.FRONT_RIGHT_MOTOR] = ConvertMotorDebugTelemetry(control_debug_telemetry.motor_fr);
   robot_motion_feedback.motors[robot_motion_feedback.BACK_RIGHT_MOTOR] = ConvertMotorDebugTelemetry(control_debug_telemetry.motor_br);
   robot_motion_feedback.motors[robot_motion_feedback.BACK_LEFT_MOTOR] = ConvertMotorDebugTelemetry(control_debug_telemetry.motor_bl);
+
+  robot_motion_feedback.imu.orientation_covariance[0] = -1.0;  // ROS2 docs say if a sensor doesn't provide a data point, then set element '0' of it's covariance to
+  robot_motion_feedback.imu.angular_velocity = ConvertFloatArrayToVec3(control_debug_telemetry.imu_gyro);
+  robot_motion_feedback.imu.linear_acceleration = ConvertFloatArrayToVec3(control_debug_telemetry.imu_accel);
 
   robot_motion_feedback.body_velocity_setpoint = ConvertFloatArrayToTwist(control_debug_telemetry.commanded_body_velocity);
   robot_motion_feedback.clamped_body_velocity_setpoint = ConvertFloatArrayToTwist(control_debug_telemetry.clamped_commanded_body_velocity);

--- a/ateam_radio_bridge/src/conversion.cpp
+++ b/ateam_radio_bridge/src/conversion.cpp
@@ -117,7 +117,7 @@ ateam_msgs::msg::RobotMotionFeedback ConvertControlDebugTelemetry(const ControlD
   robot_motion_feedback.motors[robot_motion_feedback.BACK_RIGHT_MOTOR] = ConvertMotorDebugTelemetry(control_debug_telemetry.motor_br);
   robot_motion_feedback.motors[robot_motion_feedback.BACK_LEFT_MOTOR] = ConvertMotorDebugTelemetry(control_debug_telemetry.motor_bl);
 
-  robot_motion_feedback.imu.orientation_covariance[0] = -1.0;  // ROS2 docs say if a sensor doesn't provide a data point, then set element '0' of it's covariance to
+  robot_motion_feedback.imu.orientation_covariance[0] = -1.0;  // ROS2 docs say if a sensor doesn't provide a data point, then set element '0' of it's covariance to -1
   robot_motion_feedback.imu.angular_velocity = ConvertFloatArrayToVec3(control_debug_telemetry.imu_gyro);
   robot_motion_feedback.imu.linear_acceleration = ConvertFloatArrayToVec3(control_debug_telemetry.imu_accel);
 

--- a/ateam_radio_bridge/src/conversion.cpp
+++ b/ateam_radio_bridge/src/conversion.cpp
@@ -24,7 +24,7 @@
 namespace ateam_radio_bridge
 {
 
-ateam_msgs::msg::RobotFeedback Convert(const BasicTelemetry & basic_telemetry)
+ateam_msgs::msg::RobotFeedback ConvertBasicTelemetry(const BasicTelemetry & basic_telemetry)
 {
   ateam_msgs::msg::RobotFeedback robot_feedback;
 
@@ -62,6 +62,10 @@ ateam_msgs::msg::RobotFeedback Convert(const BasicTelemetry & basic_telemetry)
 
 
   return robot_feedback;
+}
+
+ateam_msgs::msg::RobotMotionFeedback ConvertControlDebugTelemetry(const ControlDebugTelemetry & control_debug_telemetry) {
+  
 }
 
 }  // namespace ateam_radio_bridge

--- a/ateam_radio_bridge/src/conversion.cpp
+++ b/ateam_radio_bridge/src/conversion.cpp
@@ -21,10 +21,12 @@
 
 #include "conversion.hpp"
 
+#include <span>
+
 namespace ateam_radio_bridge
 {
 
-ateam_msgs::msg::RobotFeedback ConvertBasicTelemetry(const BasicTelemetry & basic_telemetry)
+ateam_msgs::msg::RobotFeedback Convert(const BasicTelemetry & basic_telemetry)
 {
   ateam_msgs::msg::RobotFeedback robot_feedback;
 
@@ -64,58 +66,46 @@ ateam_msgs::msg::RobotFeedback ConvertBasicTelemetry(const BasicTelemetry & basi
   return robot_feedback;
 }
 
-void ConvertFloatArrayToVec3(const float (&float_arr_3)[3], geometry_msgs::msg::Vector3 & vec) {
-  vec.x = float_arr_3[0];
-  vec.y = float_arr_3[1];
-  vec.z = float_arr_3[2];
-}
-
 geometry_msgs::msg::Vector3 ConvertFloatArrayToVec3(const float (&float_arr_3)[3]) {
   geometry_msgs::msg::Vector3 vec;
 
-  ConvertFloatArrayToVec3(float_arr_3, vec);
+  vec.x = float_arr_3[0];
+  vec.y = float_arr_3[1];
+  vec.z = float_arr_3[2];
 
   return vec;
 }
 
-void ConvertFloatArrayToTwist(const float (&fw_state_space_array)[3], geometry_msgs::msg::Twist & twist) {
+geometry_msgs::msg::Twist ConvertFloatArrayToTwist(const float (&fw_state_space_array)[3]) {
+  geometry_msgs::msg::Twist twist;
+
   twist.linear.x = fw_state_space_array[0];
   twist.linear.y = fw_state_space_array[1];
   twist.linear.z = 0.0;
   twist.angular.x = 0.0;
   twist.angular.y = 0.0;
   twist.angular.z = fw_state_space_array[2];
-}
-
-geometry_msgs::msg::Twist ConvertFloatArrayToTwist(const float (&fw_state_space_array)[3]) {
-  geometry_msgs::msg::Twist twist;
-
-  ConvertFloatArrayToTwist(fw_state_space_array, twist);
 
   return twist;
 }
 
-void ConvertMotorDebugTelemetry(const MotorDebugTelemetry & motor_debug_telemetry, ateam_msgs::msg::RobotMotorFeedback & ateam_motor_feedback) {
-  ateam_motor_feedback.setpoint = motor_debug_telemetry.wheel_setpoint;
-  ateam_motor_feedback.velocity = motor_debug_telemetry.wheel_velocity;
-  ateam_motor_feedback.torque = motor_debug_telemetry.wheel_torque;
-}
-
-ateam_msgs::msg::RobotMotorFeedback ConvertMotorDebugTelemetry(const MotorDebugTelemetry & motor_debug_telemetry) {
+ateam_msgs::msg::RobotMotorFeedback Convert(const MotorDebugTelemetry & motor_debug_telemetry) {
   ateam_msgs::msg::RobotMotorFeedback robot_motor_feedback;
 
-  ConvertMotorDebugTelemetry(motor_debug_telemetry, robot_motor_feedback);
+  robot_motor_feedback.setpoint = motor_debug_telemetry.wheel_setpoint;
+  robot_motor_feedback.velocity = motor_debug_telemetry.wheel_velocity;
+  robot_motor_feedback.torque = motor_debug_telemetry.wheel_torque;
 
   return robot_motor_feedback;
 }
 
-ateam_msgs::msg::RobotMotionFeedback ConvertControlDebugTelemetry(const ControlDebugTelemetry & control_debug_telemetry) {
+ateam_msgs::msg::RobotMotionFeedback Convert(const ControlDebugTelemetry & control_debug_telemetry) {
   ateam_msgs::msg::RobotMotionFeedback robot_motion_feedback;
 
-  robot_motion_feedback.motors[robot_motion_feedback.FRONT_LEFT_MOTOR] = ConvertMotorDebugTelemetry(control_debug_telemetry.motor_fl);
-  robot_motion_feedback.motors[robot_motion_feedback.FRONT_RIGHT_MOTOR] = ConvertMotorDebugTelemetry(control_debug_telemetry.motor_fr);
-  robot_motion_feedback.motors[robot_motion_feedback.BACK_RIGHT_MOTOR] = ConvertMotorDebugTelemetry(control_debug_telemetry.motor_br);
-  robot_motion_feedback.motors[robot_motion_feedback.BACK_LEFT_MOTOR] = ConvertMotorDebugTelemetry(control_debug_telemetry.motor_bl);
+  robot_motion_feedback.motors[robot_motion_feedback.FRONT_LEFT_MOTOR] = Convert(control_debug_telemetry.motor_fl);
+  robot_motion_feedback.motors[robot_motion_feedback.FRONT_RIGHT_MOTOR] = Convert(control_debug_telemetry.motor_fr);
+  robot_motion_feedback.motors[robot_motion_feedback.BACK_RIGHT_MOTOR] = Convert(control_debug_telemetry.motor_br);
+  robot_motion_feedback.motors[robot_motion_feedback.BACK_LEFT_MOTOR] = Convert(control_debug_telemetry.motor_bl);
 
   robot_motion_feedback.imu.orientation_covariance[0] = -1.0;  // ROS2 docs say if a sensor doesn't provide a data point, then set element '0' of it's covariance to -1
   robot_motion_feedback.imu.angular_velocity = ConvertFloatArrayToVec3(control_debug_telemetry.imu_gyro);

--- a/ateam_radio_bridge/src/conversion.cpp
+++ b/ateam_radio_bridge/src/conversion.cpp
@@ -126,11 +126,13 @@ ateam_msgs::msg::RobotMotionFeedback ConvertControlDebugTelemetry(const ControlD
   robot_motion_feedback.body_velocity_state_estimate = ConvertFloatArrayToTwist(control_debug_telemetry.cgkf_body_velocity_state_estimate);
   robot_motion_feedback.body_velocity_control_variable = ConvertFloatArrayToTwist(control_debug_telemetry.body_velocity_u);
 
-  // copying from some C arrays here, not a struct so add some sanity checks
-  assert((sizeof(control_debug_telemetry.wheel_velocity_u) / sizeof(control_debug_telemetry.wheel_velocity_u[0]) <= robot_motion_feedback.wheel_velocity_control_variable.size()));
-  assert((sizeof(control_debug_telemetry.wheel_velocity_clamped_u) / sizeof(control_debug_telemetry.wheel_velocity_clamped_u[0]) <= robot_motion_feedback.clamped_wheel_velocity_control_variable.size()));
-  std::copy(std::begin(control_debug_telemetry.wheel_velocity_u), std::end(control_debug_telemetry.wheel_velocity_u), std::begin(robot_motion_feedback.wheel_velocity_control_variable));
-  std::copy(std::begin(control_debug_telemetry.wheel_velocity_clamped_u), std::end(control_debug_telemetry.wheel_velocity_clamped_u), std::begin(robot_motion_feedback.clamped_wheel_velocity_control_variable));
+  std::span wheel_velocity_u_span{control_debug_telemetry.wheel_velocity_u};
+  static_assert(wheel_velocity_u_span.size() == robot_motion_feedback.wheel_velocity_control_variable.size());
+  std::ranges::copy(wheel_velocity_u_span, robot_motion_feedback.wheel_velocity_control_variable.begin());
+
+  std::span wheel_velocity_clamped_u_span{control_debug_telemetry.wheel_velocity_clamped_u};
+  static_assert(wheel_velocity_clamped_u_span.size() == robot_motion_feedback.clamped_wheel_velocity_control_variable.size());
+  std::ranges::copy(wheel_velocity_clamped_u_span, robot_motion_feedback.clamped_wheel_velocity_control_variable.begin());
 
   return robot_motion_feedback;
 }

--- a/ateam_radio_bridge/src/conversion.hpp
+++ b/ateam_radio_bridge/src/conversion.hpp
@@ -34,6 +34,7 @@ namespace ateam_radio_bridge
 {
 
 ateam_msgs::msg::RobotFeedback Convert(const BasicTelemetry & basic_telemetry);
+ateam_msgs::msg::RobotMotorFeedback Convert(const MotorDebugTelemetry & motor_debug_telemetry);
 ateam_msgs::msg::RobotMotionFeedback Convert(const ControlDebugTelemetry & control_debug_telemetry);
 
 }

--- a/ateam_radio_bridge/src/conversion.hpp
+++ b/ateam_radio_bridge/src/conversion.hpp
@@ -33,8 +33,8 @@
 namespace ateam_radio_bridge
 {
 
-ateam_msgs::msg::RobotFeedback ConvertBasicTelemetry(const BasicTelemetry & basic_telemetry);
-ateam_msgs::msg::RobotMotionFeedback ConvertControlDebugTelemetry(const ControlDebugTelemetry & control_debug_telemetry);
+ateam_msgs::msg::RobotFeedback Convert(const BasicTelemetry & basic_telemetry);
+ateam_msgs::msg::RobotMotionFeedback Convert(const ControlDebugTelemetry & control_debug_telemetry);
 
 }
 

--- a/ateam_radio_bridge/src/conversion.hpp
+++ b/ateam_radio_bridge/src/conversion.hpp
@@ -24,15 +24,17 @@
 
 #include <ateam_msgs/msg/robot_feedback.hpp>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
+#include <ateam_msgs/msg/robot_motion_feedback.hpp>
 #include <basic_control.h>
 #include <basic_telemetry.h>
+#include <control_debug_telemetry.h>
 #include <hello_data.h>
 
 namespace ateam_radio_bridge
 {
 
-ateam_msgs::msg::RobotFeedback Convert(const BasicTelemetry & basic_telemetry);
-
+ateam_msgs::msg::RobotFeedback ConvertBasicTelemetry(const BasicTelemetry & basic_telemetry);
+ateam_msgs::msg::RobotMotionFeedback ConvertControlDebugTelemetry(const ControlDebugTelemetry & control_debug_telemetry);
 
 }
 

--- a/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -290,7 +290,7 @@ private:
             return;
           }
           if (std::holds_alternative<BasicTelemetry>(data_var)) {
-            auto msg = ConvertBasicTelemetry(std::get<BasicTelemetry>(data_var));
+            auto msg = Convert(std::get<BasicTelemetry>(data_var));
             msg.radio_connected = true;
             feedback_publishers_[robot_id]->publish(msg);
           }
@@ -305,7 +305,7 @@ private:
           }
 
           if (std::holds_alternative<ControlDebugTelemetry>(data_var)) {
-            auto msg = ConvertControlDebugTelemetry(std::get<ControlDebugTelemetry>(data_var));
+            auto msg = Convert(std::get<ControlDebugTelemetry>(data_var));
             motion_feedback_publishers_[robot_id]->publish(msg);
           }
           break;

--- a/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -70,7 +70,7 @@ public:
     ateam_common::indexed_topic_helpers::create_indexed_publishers<ateam_msgs::msg::RobotMotionFeedback>(
       motion_feedback_publishers_,
       "~/robot_motion_feedback/robot",
-      rclcpp::SystemDefaultQoS(),
+      rclcpp::SystemDefaultsQoS(),
       this);
 
     connection_check_timer_ =
@@ -308,6 +308,7 @@ private:
             auto msg = ConvertControlDebugTelemetry(std::get<ControlDebugTelemetry>(data_var));
             motion_feedback_publishers_[robot_id]->publish(msg);
           }
+          break;
         }
       case CC_KEEPALIVE:
         last_heartbeat_timestamp_[robot_id] = std::chrono::steady_clock::now();

--- a/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -67,6 +67,12 @@ public:
       rclcpp::SystemDefaultsQoS(),
       this);
 
+    ateam_common::indexed_topic_helpers::create_indexed_publishers<ateam_msgs::msg::RobotMotionFeedback>(
+      motion_feedback_publishers_,
+      "~/robot_motion_feedback/robot",
+      rclcpp::SystemDefaultQoS(),
+      this);
+
     connection_check_timer_ =
       create_wall_timer(
       std::chrono::duration<double>(
@@ -91,6 +97,7 @@ private:
   std::array<rclcpp::Subscription<ateam_msgs::msg::RobotMotionCommand>::SharedPtr,
     16> motion_command_subscriptions_;
   std::array<rclcpp::Publisher<ateam_msgs::msg::RobotFeedback>::SharedPtr, 16> feedback_publishers_;
+  std::array<rclcpp::Publisher<ateam_msgs::msg::RobotMotionFeedback>::SharedPtr, 16> motion_feedback_publishers_;
   ateam_common::MulticastReceiver discovery_receiver_;
   std::array<std::unique_ptr<ateam_common::BiDirectionalUDP>, 16> connections_;
   std::array<std::chrono::steady_clock::time_point, 16> last_heartbeat_timestamp_;
@@ -283,11 +290,24 @@ private:
             return;
           }
           if (std::holds_alternative<BasicTelemetry>(data_var)) {
-            auto msg = Convert(std::get<BasicTelemetry>(data_var));
+            auto msg = ConvertBasicTelemetry(std::get<BasicTelemetry>(data_var));
             msg.radio_connected = true;
             feedback_publishers_[robot_id]->publish(msg);
           }
           break;
+        }
+      case CC_CONTROL_DEBUG_TELEMETRY:
+        {
+          const auto data_var = ExtractData(packet, error);
+          if (!error.empty()) {
+            RCLCPP_WARN(get_logger(), "Ignoring control debug message. %s", error.c_str());
+            return;
+          }
+
+          if (std::holds_alternative<ControlDebugTelemetry>(data_var)) {
+            auto msg = ConvertControlDebugTelemetry(std::get<ControlDebugTelemetry>(data_var));
+            motion_feedback_publishers_[robot_id]->publish(msg);
+          }
         }
       case CC_KEEPALIVE:
         last_heartbeat_timestamp_[robot_id] = std::chrono::steady_clock::now();

--- a/ateam_radio_bridge/src/rnp_packet_helpers.cpp
+++ b/ateam_radio_bridge/src/rnp_packet_helpers.cpp
@@ -223,6 +223,15 @@ PacketDataVariant ExtractData(const RadioPacket & packet, std::string & error)
         var = packet.data.telemetry;
         break;
       }
+    case CC_CONTROL_DEBUG_TELEMETRY:
+      {
+        if (packet.data_length != sizeof(ControlDebugTelemetry)) {
+          error = "Incorrect data length for ControlDebugTelemetry type.";
+          break;
+        }
+        var = packet.data.control_debug_telemetry;
+        break;
+      }
     case CC_CONTROL:
       {
         if (packet.data_length != sizeof(BasicControl)) {

--- a/ateam_radio_bridge/src/rnp_packet_helpers.hpp
+++ b/ateam_radio_bridge/src/rnp_packet_helpers.hpp
@@ -76,7 +76,7 @@ RadioPacket CreateEmptyPacket(const CommandCode command_code);
 RadioPacket ParsePacket(const uint8_t * data, const std::size_t data_length, std::string & error);
 
 using PacketDataVariant = std::variant<std::monostate, HelloRequest, BasicTelemetry,
-    BasicControl>;
+    BasicControl, ControlDebugTelemetry>;
 
 PacketDataVariant ExtractData(const RadioPacket & packet, std::string & error);
 

--- a/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
+++ b/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
@@ -153,9 +153,9 @@ TEST(ConvertControlDebugTelemetry, PacketConversions) {
   EXPECT_FLOAT_EQ(motion_feedback_msg.imu.angular_velocity.y, 20.0);
   EXPECT_FLOAT_EQ(motion_feedback_msg.imu.angular_velocity.z, 30.0);
 
-  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.angular_velocity.x, 100.0);
-  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.angular_velocity.x, 200.0);
-  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.angular_velocity.x, 300.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.linear_acceleration.x, 100.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.linear_acceleration.y, 200.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.linear_acceleration.z, 300.0);
 
   EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_setpoint.linear.x, 1.6);
   EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_setpoint.linear.y, 1.7);

--- a/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
+++ b/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
@@ -118,6 +118,9 @@ TEST(ConvertControlDebugTelemetry, PacketConversions) {
       1.0
     },
 
+    {10.0, 20.0, 30.0},
+    {100.0, 200.0, 300.0},
+
     {1.6, 1.7, 6.28},
     {1.5, 1.4, 6.00},
     {1.2, 1.1, 5.00},
@@ -143,6 +146,16 @@ TEST(ConvertControlDebugTelemetry, PacketConversions) {
   EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_LEFT_MOTOR].setpoint, 3.14);
   EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_LEFT_MOTOR].velocity, 3.20);
   EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_LEFT_MOTOR].torque, 1.0);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.orientation_covariance[0], -1.0);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.angular_velocity.x, 10.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.angular_velocity.y, 20.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.angular_velocity.z, 30.0);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.angular_velocity.x, 100.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.angular_velocity.x, 200.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.imu.angular_velocity.x, 300.0);
 
   EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_setpoint.linear.x, 1.6);
   EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_setpoint.linear.y, 1.7);

--- a/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
+++ b/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
@@ -58,7 +58,7 @@ TEST(ConvertBasicTelemmetry, PacketConversions)
     9.0,
     1.2
   };
-  const auto feedback_msg = ateam_radio_bridge::ConvertBasicTelemetry(telemetry);
+  const auto feedback_msg = ateam_radio_bridge::Convert(telemetry);
   EXPECT_EQ(feedback_msg.sequence_number, 0);
   EXPECT_EQ(feedback_msg.robot_revision_major, 1);
   EXPECT_EQ(feedback_msg.robot_revision_minor, 2);
@@ -130,7 +130,7 @@ TEST(ConvertControlDebugTelemetry, PacketConversions) {
     {1.0, 2.0, 3.0, 4.0}
   };
 
-  const auto motion_feedback_msg = ateam_radio_bridge::ConvertControlDebugTelemetry(control_debug_telemetry);
+  const auto motion_feedback_msg = ateam_radio_bridge::Convert(control_debug_telemetry);
   EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_LEFT_MOTOR].setpoint, 3.14);
   EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_LEFT_MOTOR].velocity, 3.12);
   EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_LEFT_MOTOR].torque, 2.0);

--- a/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
+++ b/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
@@ -22,7 +22,7 @@
 #include <gtest/gtest.h>
 #include "conversion.hpp"
 
-TEST(ConvertBasicTelemetry, BasicTelemmetry)
+TEST(ConvertBasicTelemmetry, PacketConversions)
 {
   BasicTelemetry telemetry {
     0,
@@ -90,4 +90,83 @@ TEST(ConvertBasicTelemetry, BasicTelemmetry)
   EXPECT_FLOAT_EQ(feedback_msg.motor_3_temperature, 7.8);
   EXPECT_FLOAT_EQ(feedback_msg.motor_4_temperature, 9.0);
   EXPECT_FLOAT_EQ(feedback_msg.kicker_charge_level, 1.2);
+}
+
+TEST(ConvertControlDebugTelemetry, PacketConversions) {
+  ControlDebugTelemetry control_debug_telemetry {
+    MotorDebugTelemetry {
+      3.14,
+      3.12,
+      2.0
+    },
+
+    MotorDebugTelemetry {
+      3.14,
+      3.14,
+      3.0
+    },
+
+    MotorDebugTelemetry {
+      3.14,
+      3.15,
+      2.0
+    },
+
+    MotorDebugTelemetry {
+      3.14,
+      3.20,
+      1.0
+    },
+
+    {1.6, 1.7, 6.28},
+    {1.5, 1.4, 6.00},
+    {1.2, 1.1, 5.00},
+    {1.8, 1.9, 7.00},
+
+    {4.0, 5.0, 6.0, 7.0},
+    {1.0, 2.0, 3.0, 4.0}
+  };
+
+  const auto motion_feedback_msg = ateam_radio_bridge::ConvertControlDebugTelemetry(control_debug_telemetry);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_LEFT_MOTOR].setpoint, 3.14);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_LEFT_MOTOR].velocity, 3.12);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_LEFT_MOTOR].torque, 2.0);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_RIGHT_MOTOR].setpoint, 3.14);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_RIGHT_MOTOR].velocity, 3.14);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_RIGHT_MOTOR].torque, 3.0);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_RIGHT_MOTOR].setpoint, 3.14);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_RIGHT_MOTOR].velocity, 3.15);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_RIGHT_MOTOR].torque, 2.0);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_LEFT_MOTOR].setpoint, 3.14);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_LEFT_MOTOR].velocity, 3.20);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_LEFT_MOTOR].torque, 1.0);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_setpoint.linear.x, 1.6);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_setpoint.linear.y, 1.7);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_setpoint.angular.z, 6.28);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.clamped_body_velocity_setpoint.linear.x, 1.5);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.clamped_body_velocity_setpoint.linear.y, 1.4);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.clamped_body_velocity_setpoint.angular.z, 6.0);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_state_estimate.linear.x, 1.2);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_state_estimate.linear.y, 1.1);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_state_estimate.angular.z, 5.0);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_control_variable.linear.x, 1.8);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_control_variable.linear.y, 1.9);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.body_velocity_control_variable.angular.z, 7.0);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.wheel_velocity_control_variable[motion_feedback_msg.FRONT_LEFT_MOTOR], 4.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.wheel_velocity_control_variable[motion_feedback_msg.FRONT_RIGHT_MOTOR], 5.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.wheel_velocity_control_variable[motion_feedback_msg.BACK_RIGHT_MOTOR], 6.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.wheel_velocity_control_variable[motion_feedback_msg.BACK_LEFT_MOTOR], 7.0);
+
+  EXPECT_FLOAT_EQ(motion_feedback_msg.clamped_wheel_velocity_control_variable[motion_feedback_msg.FRONT_LEFT_MOTOR], 1.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.clamped_wheel_velocity_control_variable[motion_feedback_msg.FRONT_RIGHT_MOTOR], 2.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.clamped_wheel_velocity_control_variable[motion_feedback_msg.BACK_RIGHT_MOTOR], 3.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.clamped_wheel_velocity_control_variable[motion_feedback_msg.BACK_LEFT_MOTOR], 4.0);
 }

--- a/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
+++ b/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
@@ -22,7 +22,7 @@
 #include <gtest/gtest.h>
 #include "conversion.hpp"
 
-TEST(Convert, BasicTelemmetry)
+TEST(ConvertBasicTelemetry, BasicTelemmetry)
 {
   BasicTelemetry telemetry {
     0,
@@ -58,7 +58,7 @@ TEST(Convert, BasicTelemmetry)
     9.0,
     1.2
   };
-  const auto feedback_msg = ateam_radio_bridge::Convert(telemetry);
+  const auto feedback_msg = ateam_radio_bridge::ConvertBasicTelemetry(telemetry);
   EXPECT_EQ(feedback_msg.sequence_number, 0);
   EXPECT_EQ(feedback_msg.robot_revision_major, 1);
   EXPECT_EQ(feedback_msg.robot_revision_minor, 2);


### PR DESCRIPTION
This is the software side of the initial prototype to get motion control debug data into the ROS ecosystem in real time for logging and analysis purposes.