### PR TITLE
Fix radio bridge timeouts bug & unreliable test

### DIFF
--- a/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -319,8 +319,6 @@ private:
           packet.command_code);
         return;
     }
-
-    motion_command_timestamps_[robot_id] = std::chrono::steady_clock::now();
   }
 
   void TeamColorChangeCallback(const ateam_common::TeamColor)

--- a/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
+++ b/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
@@ -181,10 +181,10 @@ class TestRadioBridgeNode(unittest.TestCase):
     def test_2_commandMessage(self):
         data = self.sock.recv(508)
         expected_data = bytearray(b"\x00") * 36
-        expected_data[0:4] = [92, 255, 234, 93]  # CRC
+        expected_data[0:4] = [57, 152, 86, 229]  # CRC
         expected_data[8] = 201  # Command code: CC_CONTROL
         expected_data[9:11] = [0, 24]  # Data length
-        expected_data[32] = 0  # Kicker request: KR_ARM
+        expected_data[32] = 1  # Kicker request: KR_ARM
         self.assertEqual(
             len(data),
             len(expected_data),


### PR DESCRIPTION
`test_2_commandMessage` was failing intermittently because the timeout that disables motion and kicker was sometimes expired and sometimes not when that test was run. It should always be expired since no command messages are sent during the test. It was sometimes alive because of an erroneous line that reset the timeout on incoming messages from the robot. This PR removes that line and updates the test to reflect the disabled message the bridge should always be sending in this scenario.