### PR TITLE
Fixes math for default planning obstacles.

### DIFF
--- a/ateam_kenobi/src/path_planning/path_planner.cpp
+++ b/ateam_kenobi/src/path_planning/path_planner.cpp
@@ -214,7 +214,7 @@ void PathPlanner::addDefaultObstacles(
     ateam_geometry::Rectangle(
       ateam_geometry::Point(-world.field.field_length / 2, world.field.goal_width),
       ateam_geometry::Point(
-        -1 * (world.field.field_length / 2) + world.field.goal_width,
+        -1 * (world.field.field_length / 2) + world.field.goal_depth,
         -world.field.goal_width)
   ));
   // their goalie box
@@ -222,7 +222,7 @@ void PathPlanner::addDefaultObstacles(
     ateam_geometry::Rectangle(
       ateam_geometry::Point((world.field.field_length / 2), world.field.goal_width),
       ateam_geometry::Point(
-        (world.field.field_length / 2) + world.field.goal_width,
+        (world.field.field_length / 2) - world.field.goal_depth,
         -world.field.goal_width)
   ));
 }


### PR DESCRIPTION
Math is hard.

![math](https://media4.giphy.com/media/BmmfETghGOPrW/giphy.gif?cid=ecf05e47be1ixz0mqq6l8453a95qj73o2sw1f4o34nk10q77&ep=v1_gifs_search&rid=giphy.gif&ct=g)



Previous bad math was putting the default obstacles for the defense areas in the wrong place and making them the wrong size. This fixes that.