### PR TITLE
Remove extra kick vel line in radio bridge.

### DIFF
--- a/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -174,7 +174,6 @@ private:
       control_msg.vel_x_linear = motion_commands_[id].twist.linear.x;
       control_msg.vel_y_linear = motion_commands_[id].twist.linear.y;
       control_msg.vel_z_angular = motion_commands_[id].twist.angular.z;
-      control_msg.kick_vel = 0.0f;
       control_msg.dribbler_speed = motion_commands_[id].dribbler_speed;
       control_msg.kick_request = static_cast<KickRequest>(motion_commands_[id].kick);
       control_msg.kick_vel = motion_commands_[id].kick_speed;


### PR DESCRIPTION
kick_vel is set to 0.0 on line 177 and then set to the actual commanded value on line 180. This PR removes line 177.