### PR TITLE
Fixes bugs in UI goalie ID selector.

### DIFF
--- a/ateam_ui/src/src/components/GameStatusComponent.vue
+++ b/ateam_ui/src/src/components/GameStatusComponent.vue
@@ -2,7 +2,7 @@
     <v-row class="nowrap justify-space-between" align="center">
         <v-row align="center">
         <p>Goalie ID: {{this.state.getGoalie()}}</p>
-            <v-select label="set ID" class="flex-grow-0 align-end" :items="Array.from({length: 16}, (value, index) => index)" density="compact" variant="solo" @update:modelValue="this.state.setGoalie"/>
+            <v-select label="set ID" class="flex-grow-0 align-end" :items="Array.from({length: 16}, (value, index) => index)" density="compact" variant="solo" @update:modelValue="setGoalieId"/>
         </v-row>
         <v-spacer/>
     </v-row> 
@@ -29,6 +29,9 @@ export default {
     mounted() {
     },
     methods: {
+        setGoalieId(new_id) {
+            this.state.setGoalie(new_id);
+        }
     },
     computed: {
         getRefState: function() {

--- a/ateam_ui/src/src/state.ts
+++ b/ateam_ui/src/src/state.ts
@@ -57,8 +57,13 @@ export class AppState {
 
         this.services["setGoalie"].callService(request,
             function(result) {
-                // is there anything we need to do with this?
+                if(!result.success) {
+                    console.log("Failed to set goalie ID: ", result.reason);
+                } else {
+                    console.log("Goalie ID set!");
+                }
             });
+        console.log("Goalie ID set request sent.");
     }
 
     getGoalie(): string {
@@ -291,7 +296,7 @@ export class AppState {
         // Set up Goalie Service
         let goalieService = new ROSLIB.Service({
             ros: this.ros,
-            name: 'team_client_node/set_desired_keeper',
+            name: '/team_client_node/set_desired_keeper',
             serviceType: 'ateam_msgs/srv/SetDesiredKeeper'
         })
         this.services["setGoalie"] = goalieService;


### PR DESCRIPTION
The goalie ID drop down in the UI was not working. I found two bugs to fix.

1. The way the callback was being handled for the v-select value change event was losing the binding to the state object. So, in the state's `setGoalie` method, `this` was undefined. By adding an intermediate method in the Vue component, the method is called directly on the state object and the `this` binding is handled correcty.

1. A missing leading forward slash in the service name cause roslibjs to interpret it as a relative name, yielding "/ui/team_client_node/set_desired_keeper", which doesn't exist. Adding the leading slash fixes this.

I added some console logging to `setGoalie` for better feedback in the future. Is there a way for us to show an alert if the request fails?