### PR TITLE
Adds team name override.

### DIFF
--- a/ateam_bringup/launch/autonomy.launch.xml
+++ b/ateam_bringup/launch/autonomy.launch.xml
@@ -3,14 +3,19 @@
   <arg name="ssl_vision_port" default="10006"/>
   <arg name="ssl_vision_interface_address" default="10.193.15.132"/>
   <arg name="use_world_velocities" default="false"/>
+  <arg name="team_name" default="A-Team"/>
 
   <node name="ssl_vision_bridge" pkg="ateam_ssl_vision_bridge" exec="ssl_vision_bridge_node" respawn="True">
     <param name="ssl_vision_ip" value="$(var ssl_vision_ip)"/>
     <param name="ssl_vision_port" value="$(var ssl_vision_port)"/>
     <param name="net_interface_address" value="$(var ssl_vision_interface_address)"/>
+    <param name="gc_team_name" value="$(var team_name)"/>
   </node>
-  <node name="vision_filter" pkg="ateam_vision_filter" exec="ateam_vision_filter_node" respawn="True"/>
+  <node name="vision_filter" pkg="ateam_vision_filter" exec="ateam_vision_filter_node" respawn="True">
+    <param name="gc_team_name" value="$(var team_name)"/>
+  </node>
   <node name="kenobi_node" pkg="ateam_kenobi" exec="ateam_kenobi_node" respawn="True">
     <param name="use_world_velocities" value="$(var use_world_velocities)"/>
+    <param name="gc_team_name" value="$(var team_name)"/>
   </node>
 </launch>

--- a/ateam_bringup/launch/bringup_simulation.launch.py
+++ b/ateam_bringup/launch/bringup_simulation.launch.py
@@ -33,6 +33,7 @@ def generate_launch_description():
         DeclareLaunchArgument("start_gc", default_value="True"),
         DeclareLaunchArgument("headless_sim", default_value="True"),
         DeclareLaunchArgument("sim_radio_ip", default_value="127.0.0.1"),
+        DeclareLaunchArgument("team_name", default_value="A-Team"),
 
         IncludeLaunchDescription(
             FrontendLaunchDescriptionSource(
@@ -57,7 +58,8 @@ def generate_launch_description():
                                               "game_controller_nodes.launch.xml")),
             launch_arguments={
                 "net_interface_address": "",
-                "gc_ip_address": "127.0.0.1"
+                "gc_ip_address": "127.0.0.1",
+                "team_name": LaunchConfiguration("team_name")
             }.items()
         ),
 
@@ -68,7 +70,8 @@ def generate_launch_description():
             launch_arguments={
                 "ssl_vision_interface_address": "",
                 "use_world_velocities": "true",
-                "ssl_vision_port": "10020"
+                "ssl_vision_port": "10020",
+                "team_name": LaunchConfiguration("team_name")
             }.items()
         ),
 
@@ -83,7 +86,8 @@ def generate_launch_description():
             executable="ssl_simulation_radio_bridge_node",
             name="radio_bridge",
             parameters=[{
-                "ssl_sim_radio_ip": LaunchConfiguration("sim_radio_ip")
+                "ssl_sim_radio_ip": LaunchConfiguration("sim_radio_ip"),
+                "gc_team_name": LaunchConfiguration("team_name")
             }]
         )
     ])

--- a/ateam_bringup/launch/game_controller_nodes.launch.xml
+++ b/ateam_bringup/launch/game_controller_nodes.launch.xml
@@ -1,10 +1,12 @@
 <launch>
   <arg name="gc_ip_address" default="10.193.12.10"/>
   <arg name="net_interface_address" default="10.193.15.132"/>
+  <arg name="team_name" default="A-Team"/>
   <node name="gc_multicast_bridge_node" pkg="ateam_game_controller_bridge" exec="gc_multicast_bridge_node" respawn="True">
     <param name="net_interface_address" value="$(var net_interface_address)"/>
   </node>
   <node name="team_client_node" pkg="ateam_game_controller_bridge" exec="team_client_node" respawn="True">
     <param name="gc_ip_address" value="$(var gc_ip_address)"/>
+    <param name="team_name" value="$(var team_name)"/>
   </node>
 </launch>

--- a/ateam_common/src/game_controller_listener.cpp
+++ b/ateam_common/src/game_controller_listener.cpp
@@ -34,6 +34,8 @@ GameControllerListener::GameControllerListener(
   color_callback_(color_callback),
   side_callback_(side_callback)
 {
+  auto logger = node.get_logger().get_child("GameControllerListener");
+  RCLCPP_INFO(logger, "Using team name: %s", team_name_.c_str());
   const auto default_team_color =
     node.declare_parameter<std::string>("default_team_color", "blue");
   if (default_team_color == "yellow") {
@@ -43,12 +45,12 @@ GameControllerListener::GameControllerListener(
   } else if (default_team_color == "unknown") {
     team_color_ = TeamColor::Unknown;
     RCLCPP_WARN(
-      node.get_logger(),
+      logger,
       "EXPLICIT UNKNOWN GIVEN FOR TEAM COLOR.");
   } else {
     team_color_ = TeamColor::Unknown;
     RCLCPP_WARN(
-      node.get_logger(),
+      logger,
       "Unrecognized value for param 'default_team_color'. Ignoring and defaulting to Unknown.");
   }
 
@@ -62,7 +64,7 @@ GameControllerListener::GameControllerListener(
     team_side_ = TeamSide::Unknown;
   } else {
     RCLCPP_WARN(
-      node.get_logger(),
+      logger,
       "Unrecognized value for param 'default_team_side'. Ignoring and defaulting to Unknown.");
   }
 


### PR DESCRIPTION
To scrimmage against ourselves, we need one instance of our stack to pretend to be another team, otherwise each stack won't be able to tell which "A-Team" from the GC it's supposed to use.

`GameControllerListener` already had a parameter for overriding the team name, so this PR just finishes plumbing that into the simulation bringup files.

It's worth noting that not all team names will work, because some teams use secure connections and have signatures registered with the league (including "Test Team"). Luckily, not all teams do this, so we can connect as one of the non-secure teams. "RoboJackets" is one such team that worked in my testing.