### PR TITLE
Changes simulator radio bridge to use local velocities.

### DIFF
--- a/ateam_bringup/launch/bringup_simulation.launch.py
+++ b/ateam_bringup/launch/bringup_simulation.launch.py
@@ -67,7 +67,6 @@ def generate_launch_description():
                                               "autonomy.launch.xml")),
             launch_arguments={
                 "ssl_vision_interface_address": "",
-                "use_world_velocities": "true",
                 "ssl_vision_port": "10020"
             }.items()
         ),

--- a/ateam_ssl_simulation_radio_bridge/src/message_conversions.cpp
+++ b/ateam_ssl_simulation_radio_bridge/src/message_conversions.cpp
@@ -54,12 +54,11 @@ RobotControl fromMsg(const ateam_msgs::msg::RobotMotionCommand & ros_msg, int ro
   }
 
   RobotMoveCommand * robot_move_command = proto_robot_command->mutable_move_command();
-  MoveGlobalVelocity * global_velocity_command =
-    robot_move_command->mutable_global_velocity();
+  MoveLocalVelocity * local_velocity_command = robot_move_command->mutable_local_velocity();
 
-  global_velocity_command->set_x(ros_msg.twist.linear.x);
-  global_velocity_command->set_y(ros_msg.twist.linear.y);
-  global_velocity_command->set_angular(ros_msg.twist.angular.z);
+  local_velocity_command->set_forward(ros_msg.twist.linear.x);
+  local_velocity_command->set_left(ros_msg.twist.linear.y);
+  local_velocity_command->set_angular(ros_msg.twist.angular.z);
 
   return robots_control;
 }


### PR DESCRIPTION
Our simulator radio bridge has been using global velocities. This had the side effect of breaking our code when running as the yellow team in sim. Our gameplay code uses our conventions for the global frame, which is inverted from the sim/vision frame when we're playing as yellow in sim. This caused the robots to drive in the opposite direction than what our gameplay code was trying to request.

Turns out the sim protocol lets you control using either wheel velocities, local velocities, or global velocities. So, I just flipped it over to using local velocities like our physical radio bridge does, and now we can play as either team without issue.