### PR TITLE
Fixing InPlayEval

### DIFF
--- a/ateam_kenobi/CMakeLists.txt
+++ b/ateam_kenobi/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(control_toolbox REQUIRED)
 find_package(ompl REQUIRED)
 
 add_library(kenobi_node_component SHARED
+  src/in_play_eval.cpp
   src/kenobi_node.cpp
   src/play_selector.cpp
   src/path_planning/path_planner.cpp

--- a/ateam_kenobi/src/in_play_eval.cpp
+++ b/ateam_kenobi/src/in_play_eval.cpp
@@ -1,0 +1,109 @@
+// Copyright 2024 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "in_play_eval.hpp"
+
+#include <cmath>
+#include <CGAL/squared_distance_2.h>
+
+namespace ateam_kenobi
+{
+
+void InPlayEval::Update(World & world)
+{
+  // Force start always puts the ball in play
+  if (world.referee_info.running_command == ateam_common::GameCommand::ForceStart) {
+    in_play_ = true;
+  }
+  // Stop puts the ball out of play
+  else if (world.referee_info.running_command == ateam_common::GameCommand::Stop) {
+    in_play_ = false;
+    ball_start_pos_.reset();
+  }
+  // If game's not stopped, we're going to have to pay attention to in play conditions
+  else if (world.referee_info.running_command != ateam_common::GameCommand::Stop &&
+    world.referee_info.running_command != ateam_common::GameCommand::Halt)
+  {
+    // If this is our first frame out of stop, establish starting conditions
+    if (!ball_start_pos_) {
+      ball_start_pos_ = world.ball.pos;
+      SetTimeout(world);
+      SetDistanceThreshold(world);
+    }
+
+    // If timeout passed, ball's in play
+    if (timeout_time_.time_since_epoch().count() != 0 &&
+      std::chrono::steady_clock::now() > timeout_time_)
+    {
+      in_play_ = true;
+    }
+
+    // If ball moved far enough, it's in play
+    if (ball_start_pos_ &&
+      std::sqrt(
+        CGAL::squared_distance(
+          world.ball.pos,
+          ball_start_pos_.value())) > ball_moved_threshold_)
+    {
+      in_play_ = true;
+    }
+  }
+
+  prev_game_command_ = world.referee_info.running_command;
+}
+
+void InPlayEval::SetTimeout(const World & world)
+{
+  switch (world.referee_info.running_command) {
+    case ateam_common::GameCommand::PrepareKickoffOurs:
+    case ateam_common::GameCommand::PrepareKickoffTheirs:
+      timeout_time_ = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+      break;
+    case ateam_common::GameCommand::DirectFreeOurs:
+    case ateam_common::GameCommand::DirectFreeTheirs:
+      // Division A
+      // timeout_time_ = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+      // Division B
+      timeout_time_ = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+      break;
+    default:
+      timeout_time_ = {}; // No timeout
+      break;
+  }
+}
+
+void InPlayEval::SetDistanceThreshold(const World & world)
+{
+  switch (world.referee_info.running_command) {
+    case ateam_common::GameCommand::PrepareKickoffOurs:
+    case ateam_common::GameCommand::PrepareKickoffTheirs:
+    case ateam_common::GameCommand::DirectFreeOurs:
+    case ateam_common::GameCommand::DirectFreeTheirs:
+    case ateam_common::GameCommand::PreparePenaltyOurs:
+    case ateam_common::GameCommand::PreparePenaltyTheirs:
+      ball_moved_threshold_ = 0.05;
+      break;
+    default:
+      ball_moved_threshold_ = std::numeric_limits<double>::infinity();
+      break;
+  }
+}
+
+}  // namespace ateam_kenobi

--- a/ateam_kenobi/src/in_play_eval.hpp
+++ b/ateam_kenobi/src/in_play_eval.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 A Team
+// Copyright 2024 A Team
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,110 +22,34 @@
 #ifndef IN_PLAY_EVAL_HPP_
 #define IN_PLAY_EVAL_HPP_
 
-#include <math.h>
-#include <CGAL/squared_distance_2.h>
-#include <Eigen/Dense>
 #include <chrono>
 #include <optional>
-#include "types/world.hpp"
 #include <ateam_geometry/types.hpp>
 #include <ateam_common/game_controller_listener.hpp>
+#include "types/world.hpp"
 
+namespace ateam_kenobi
+{
 
-/**
- *  Small class to be "ticked" with the world output_state and keep track of if we enter a kickoff and then when we exit (ball has moved 0.05 after normal_start is issued, 10 seconds pass, force start is issued)
- *
-*/
 class InPlayEval
 {
 public:
-  // Ctors
-  InPlayEval() {}
 
-  // Vars
-  bool in_play {};
-  bool our_penalty {};
-  bool their_penalty {};
-  ateam_common::GameCommand cur_state {ateam_common::GameCommand::Stop};
-  // optional in case ball cant be seen
-  std::optional<ateam_geometry::Point> maybe_kickoff_position {};
+  void Update(World & world);
 
-  static constexpr double DIST_THRESHOLD {0.05};
+private:
+  bool in_play_ = false;
+  std::optional<ateam_geometry::Point> ball_start_pos_;
+  ateam_common::GameCommand prev_game_command_;
+  std::chrono::steady_clock::time_point timeout_time_ = {};
+  double ball_moved_threshold_ = 0;
 
-  // only 3 things enter us into play according to the appendix B state machine
-  void update(ateam_kenobi::World & world)
-  {
-    // edge triggered
-    // we just need an edge on commands to know not to do in_play = false in the same normal_play
-    ateam_common::GameCommand next_command = world.referee_info.running_command;
-    if (cur_state != next_command) {
-      switch (next_command) {
-        // all of these are not in play technically but not for this purpose
-        case ateam_common::GameCommand::Halt:
-        case ateam_common::GameCommand::Stop:
-        case ateam_common::GameCommand::TimeoutTheirs:
+  void SetTimeout(const World & world);
 
-        case ateam_common::GameCommand::PrepareKickoffOurs:
-        case ateam_common::GameCommand::PrepareKickoffTheirs:
-        case ateam_common::GameCommand::DirectFreeOurs:
-        case ateam_common::GameCommand::DirectFreeTheirs:
-        case ateam_common::GameCommand::BallPlacementOurs:
-        case ateam_common::GameCommand::BallPlacementTheirs:
-        case ateam_common::GameCommand::NormalStart:
-          // reset in_play in any of these state
-          world.in_play = false;
-          break;
+  void SetDistanceThreshold(const World & world);
 
-        case ateam_common::GameCommand::PreparePenaltyOurs:
-          world.in_play = false;
-          world.our_penalty = true;
-          world.their_penalty = false;
-          break;
-        case ateam_common::GameCommand::PreparePenaltyTheirs:
-          world.in_play = false;
-          world.their_penalty = true;
-          world.our_penalty = false;
-          break;
-
-        // force play really play acts the same as play
-        case ateam_common::GameCommand::ForceStart:
-          world.in_play = true;
-          world.their_penalty = false;
-          world.our_penalty = false;
-          break;
-        default:
-          world.in_play = true;
-          world.their_penalty = false;
-          world.our_penalty = false;
-      }
-    }
-
-    cur_state = next_command;
-
-    // level
-    if (in_play == false) {
-      auto ball_current = world.ball;
-      if (maybe_kickoff_position.has_value()) {
-        // if we are tracking a start position and a current ball and its further away than
-        // dist we are in play
-        if (sqrt(CGAL::squared_distance(ball_current.pos, maybe_kickoff_position.value())) >
-          DIST_THRESHOLD)
-        {
-          world.in_play = true;
-          // so if you read this and its any of the states in the above you are basically
-          // playing under restrictions
-        }
-      } else {
-        // set the ball position if we dont have one yet during this kickoff
-        maybe_kickoff_position = ball_current.pos;
-      }
-    } else {
-      // note we may not have a view of the ball the frame we enter kickoff thats
-      // why this is seperate
-      maybe_kickoff_position = std::nullopt;
-    }
-    return;
-  }
 };
+
+}  // namespace ateam_kenobi
 
 #endif  // IN_PLAY_EVAL_HPP_

--- a/ateam_kenobi/src/in_play_eval.hpp
+++ b/ateam_kenobi/src/in_play_eval.hpp
@@ -48,6 +48,8 @@ private:
 
   void SetDistanceThreshold(const World & world);
 
+  bool IsGameResuming(const World & world);
+
 };
 
 }  // namespace ateam_kenobi

--- a/ateam_kenobi/src/in_play_eval.hpp
+++ b/ateam_kenobi/src/in_play_eval.hpp
@@ -48,8 +48,15 @@ private:
 
   void SetDistanceThreshold(const World & world);
 
+  bool IsGameStopped(const World & world);
+
+  bool IsStopCommandEnding(const World & world);
+
   bool IsGameResuming(const World & world);
 
+  bool HasBallMoved(const World & world);
+
+  bool HasTimeoutExpired();
 };
 
 }  // namespace ateam_kenobi

--- a/ateam_kenobi/src/in_play_eval.hpp
+++ b/ateam_kenobi/src/in_play_eval.hpp
@@ -34,14 +34,14 @@ namespace ateam_kenobi
 class InPlayEval
 {
 public:
-
   void Update(World & world);
 
 private:
   bool in_play_ = false;
   std::optional<ateam_geometry::Point> ball_start_pos_;
   ateam_common::GameCommand prev_game_command_;
-  std::chrono::steady_clock::time_point timeout_time_ = {};
+  std::optional<std::chrono::steady_clock::duration> timeout_duration_;
+  std::chrono::steady_clock::time_point timeout_start_;
   double ball_moved_threshold_ = 0;
 
   void SetTimeout(const World & world);

--- a/ateam_kenobi/src/kenobi_node.cpp
+++ b/ateam_kenobi/src/kenobi_node.cpp
@@ -210,7 +210,7 @@ private:
     if (game_controller_listener_.GetOurGoalieID().has_value()) {
       world_.referee_info.our_goalie_id = game_controller_listener_.GetOurGoalieID().value();
     }
-    in_play_eval_.update(world_);
+    in_play_eval_.Update(world_);
     if (game_controller_listener_.GetTeamColor() == ateam_common::TeamColor::Unknown) {
       auto & clk = *this->get_clock();
       RCLCPP_WARN_THROTTLE(


### PR DESCRIPTION
I'm pretty sure the reason we were seeing Kenobi get confused about when the ball was in play this weekend was because `InPlayEval` was capturing the ball's starting position at the wrong time. So, if you entered the kickoff prep command then moved the ball more than 0.5m before issuing normal start, the ball would immediately be considered in play.

This PR rewrites `InPlayEval` to hopefully follow the rules correctly. Eventually we should add real tests, but based on my informal testing in simulation, this works correctly and doesn't get tripped up by things like the ball moving during prep commands.