### PR TITLE
Adds geometry testing utils.

### DIFF
--- a/ateam_geometry/CMakeLists.txt
+++ b/ateam_geometry/CMakeLists.txt
@@ -39,6 +39,22 @@ install(TARGETS ${PROJECT_NAME}
         INCLUDES DESTINATION include)
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gmock REQUIRED)
+  add_library(${PROJECT_NAME}_testing INTERFACE)
+  target_include_directories(${PROJECT_NAME}_testing INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  set_target_properties(${PROJECT_NAME}_testing PROPERTIES CXX_STANDARD 20)
+  target_link_libraries(${PROJECT_NAME}_testing INTERFACE ${PROJECT_NAME})
+  ament_export_targets(${PROJECT_NAME}_testing HAS_LIBRARY_TARGET)
+  install(TARGETS ${PROJECT_NAME}_testing
+          EXPORT ${PROJECT_NAME}_testing
+          LIBRARY DESTINATION lib
+          ARCHIVE DESTINATION lib
+          RUNTIME DESTINATION bin
+          INCLUDES DESTINATION include)
+
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
   add_subdirectory(test)

--- a/ateam_geometry/include/ateam_geometry_testing/testing_utils.hpp
+++ b/ateam_geometry/include/ateam_geometry_testing/testing_utils.hpp
@@ -1,0 +1,98 @@
+// Copyright 2024 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ATEAM_GEOMETRY_TESTING__TESTING_UTILS_HPP_
+#define ATEAM_GEOMETRY_TESTING__TESTING_UTILS_HPP_
+
+#include <gmock/gmock.h>
+#include <CGAL/squared_distance_2.h>
+#include <tuple>
+#include <ateam_geometry/types.hpp>
+
+class PointIsNearMatcher : public ::testing::MatcherInterface<ateam_geometry::Point>
+{
+public:
+  explicit PointIsNearMatcher(const ateam_geometry::Point target, double threshold = 0.01)
+  : target_(target), threshold_squared_(threshold * threshold) {}
+
+  bool MatchAndExplain(ateam_geometry::Point p, ::testing::MatchResultListener *) const override
+  {
+    return CGAL::squared_distance(p, target_) < threshold_squared_;
+  }
+
+  void DescribeTo(std::ostream * os) const override
+  {
+    *os << "is near (" << target_.x() << ", " << target_.y() << ")";
+  }
+
+  void DescribeNegationTo(std::ostream * os) const override
+  {
+    *os << "is not near (" << target_.x() << ", " << target_.y() << ")";
+  }
+
+private:
+  const ateam_geometry::Point target_;
+  const double threshold_squared_;
+};
+
+inline ::testing::Matcher<ateam_geometry::Point> PointIsNear(
+  const ateam_geometry::Point & target,
+  double threshold = 0.01)
+{
+  return ::testing::MakeMatcher(new PointIsNearMatcher(target, threshold));
+}
+
+class PointsAreNearMatcher : public ::testing::MatcherInterface<std::tuple<ateam_geometry::Point,
+    ateam_geometry::Point>>
+{
+public:
+  explicit PointsAreNearMatcher(double threshold = 0.01)
+  : threshold_squared_(threshold * threshold) {}
+
+  bool MatchAndExplain(
+    std::tuple<ateam_geometry::Point, ateam_geometry::Point> points,
+    ::testing::MatchResultListener *) const override
+  {
+    return CGAL::squared_distance(std::get<0>(points), std::get<1>(points)) < threshold_squared_;
+  }
+
+  void DescribeTo(std::ostream * os) const override
+  {
+    *os << "are near";
+  }
+
+  void DescribeNegationTo(std::ostream * os) const override
+  {
+    *os << "are not near";
+  }
+
+private:
+  const double threshold_squared_;
+};
+
+inline ::testing::Matcher<std::tuple<ateam_geometry::Point, ateam_geometry::Point>> PointsAreNear(
+  double threshold = 0.01)
+{
+  return ::testing::MakeMatcher<std::tuple<ateam_geometry::Point, ateam_geometry::Point>>(
+    new PointsAreNearMatcher(
+      threshold));
+}
+
+#endif  // ATEAM_GEOMETRY_TESTING__TESTING_UTILS_HPP_

--- a/ateam_geometry/test/CMakeLists.txt
+++ b/ateam_geometry/test/CMakeLists.txt
@@ -1,7 +1,7 @@
-find_package(ament_cmake_gmock REQUIRED)
 ament_add_gmock(ateam_geometry_tests
   nearest_points_test.cpp
   normalize_test.cpp
+  testing_utils_test.cpp
   variant_do_intersect_test.cpp
 )
-target_link_libraries(ateam_geometry_tests ${PROJECT_NAME})
+target_link_libraries(ateam_geometry_tests ${PROJECT_NAME} ${PROJECT_NAME}_testing)

--- a/ateam_geometry/test/testing_utils_test.cpp
+++ b/ateam_geometry/test/testing_utils_test.cpp
@@ -21,21 +21,43 @@
 #include <gtest/gtest.h>
 
 #include "ateam_geometry/types.hpp"
-#include "ateam_geometry/nearest_points.hpp"
 #include "ateam_geometry_testing/testing_utils.hpp"
 
-TEST(NearestPointOnSegment, PointOffSegment)
+using ateam_geometry::Point;
+
+TEST(PointIsNearTests, MatchNearPoints)
 {
-  ateam_geometry::Segment s(ateam_geometry::Point(0, 0), ateam_geometry::Point(10, 10));
-  ateam_geometry::Point p(10, 0);
-  auto nearest_point = ateam_geometry::NearestPointOnSegment(s, p);
-  EXPECT_THAT(nearest_point, PointIsNear(ateam_geometry::Point(5, 5)));
+  EXPECT_THAT(Point(1, 1), PointIsNear(Point(1, 1)));
+  EXPECT_THAT(Point(1, 1), PointIsNear(Point(1.005, 1.005)));
 }
 
-TEST(NearestPointOnSegment, PointOnSegment)
+TEST(PointIsNearTests, DontMatchFarPoints)
 {
-  ateam_geometry::Segment s(ateam_geometry::Point(0, 0), ateam_geometry::Point(10, 10));
-  ateam_geometry::Point p(1, 1);
-  auto nearest_point = ateam_geometry::NearestPointOnSegment(s, p);
-  EXPECT_THAT(nearest_point, PointIsNear(ateam_geometry::Point(1, 1)));
+  EXPECT_THAT(Point(0, 0), testing::Not(PointIsNear(Point(2, 2))));
+}
+
+TEST(PointIsNearTests, AllowChangingThreshold)
+{
+  EXPECT_THAT(Point(0, 0), PointIsNear(Point(2, 2), 3.0));
+  EXPECT_THAT(Point(0, 0), testing::Not(PointIsNear(Point(4, 4), 3.0)));
+}
+
+TEST(PointsAreNearTests, MatchNearPoints)
+{
+  std::vector<Point> points = {{0, 0}, {5, 5}};
+  EXPECT_THAT(points, testing::Pointwise(PointsAreNear(), points));
+}
+
+TEST(PointsAreNearTests, DontMatchFarPoints)
+{
+  std::vector<Point> p1 = {{1, 2}, {3, 4}};
+  std::vector<Point> p2 = {{5, 6}, {7, 8}};
+  EXPECT_THAT(p1, testing::Pointwise(testing::Not(PointsAreNear()), p2));
+}
+
+TEST(PointsAreNearTests, AllowChangingThreshold)
+{
+  std::vector<Point> p1 = {{1, 2}, {3, 4}};
+  std::vector<Point> p2 = {{5, 6}, {7, 8}};
+  EXPECT_THAT(p1, testing::Pointwise(PointsAreNear(10.0), p2));
 }


### PR DESCRIPTION
While working on path planning tests, I realized we're probably going to want to regularly test if two points are near each other (mostly to handle floating point equality comparisons).

This PR adds two gtest matchers that check if points are within some threshold distance of each other.

To check if one point is near a target:

```C++
EXPECT_THAT(p1, PointIsNear(target));
```

To check if a sequence of points (ie. a path) matches another:

```C++
EXPECT_THAT(path, testing::Pointwise(PointsAreNear(), expected_path));
```