### PR TITLE
Set individual PID gains

### DIFF
--- a/ateam_kenobi/src/motion/motion_controller.cpp
+++ b/ateam_kenobi/src/motion/motion_controller.cpp
@@ -193,3 +193,46 @@ void MotionController::reset()
   this->face_towards.reset();
   this->face_angle = 0;
 }
+
+void MotionController::set_pid_gain(PidType pid, GainType gain, double value){
+  control_toolbox::Gains current_gains;
+  switch (pid) {
+    case PidType::x:
+      gains = this->x_controller.getGains();
+    case PidType::y:
+      gains = this->y_controller.getGains();
+    case PidType::t:
+      gains = this->t_controller.getGains();
+  }
+  switch (gain) {
+    case GainType::p:
+      gains.p_ = value;
+    case GainType::i:
+      gains.i_ = value;
+    case GainType::d
+      gains.d_ = value;
+  }
+  switch (pid) {
+    case PidType::x:
+      this->x_controller.setGains(gains);
+    case PidType::y:
+      this->y_controller.setGains(gains);
+    case PidType::t:
+      this->t_controller.setGains(gains);
+  }
+};
+
+void MotionController::set_pid_gains(PidType pid, double p, double i, double d){
+  control_toolbox::Gains gains;
+  gains._p = p;
+  gains._i = i;
+  gains._d = d;
+  switch(pid){
+    case PidType::x:
+      this->x_controller.setGains(gains);
+    case PidType::y:
+      this->y_controller.setGains(gains);
+    case PidType::t:
+      this->t_controller.setGains(gains);
+  }
+};

--- a/ateam_kenobi/src/motion/motion_controller.cpp
+++ b/ateam_kenobi/src/motion/motion_controller.cpp
@@ -194,63 +194,63 @@ void MotionController::reset()
   this->face_angle = 0;
 }
 
-void MotionController::set_x_pid_gain(PidType pid, GainType gain, double value){
-  control_toolbox::Gains gains = this->x_controller.getGains();
+void MotionController::set_x_pid_gain(GainType gain, double value){
+  control_toolbox::Pid::Gains gains = this->x_controller.getGains();
   switch (gain) {
     case GainType::p:
       gains.p_gain_ = value;
     case GainType::i:
       gains.i_gain_ = value;
-    case GainType::d
+    case GainType::d:
       gains.d_gain_ = value;
   }
   this->x_controller.setGains(gains);
 };
 
-void MotionController::set_y_pid_gain(PidType pid, GainType gain, double value){
-  control_toolbox::Gains gains = this->y_controller.getGains();
+void MotionController::set_y_pid_gain(GainType gain, double value){
+  control_toolbox::Pid::Gains gains = this->y_controller.getGains();
   switch (gain) {
     case GainType::p:
       gains.p_gain_ = value;
     case GainType::i:
       gains.i_gain_ = value;
-    case GainType::d
+    case GainType::d:
       gains.d_gain_ = value;
   }
   this->y_controller.setGains(gains);
 };
 
-void MotionController::set_t_pid_gain(PidType pid, GainType gain, double value){
-  control_toolbox::Gains gains = this->t_controller.getGains();
+void MotionController::set_t_pid_gain(GainType gain, double value){
+  control_toolbox::Pid::Gains gains = this->t_controller.getGains();
   switch (gain) {
     case GainType::p:
       gains.p_gain_ = value;
     case GainType::i:
       gains.i_gain_ = value;
-    case GainType::d
+    case GainType::d:
       gains.d_gain_ = value;
   }
   this->t_controller.setGains(gains);
 };
 
-void MotionController::set_x_pid_gains(PidType pid, double p, double i, double d){
-  control_toolbox::Gains gains;
+void MotionController::set_x_pid_gains(double p, double i, double d){
+  control_toolbox::Pid::Gains gains;
   gains.p_gain_ = p;
   gains.i_gain_ = i;
   gains.d_gain_ = d;
   this->x_controller.setGains(gains);
 };
 
-void MotionController::set_y_pid_gains(PidType pid, double p, double i, double d){
-  control_toolbox::Gains gains;
+void MotionController::set_y_pid_gains(double p, double i, double d){
+  control_toolbox::Pid::Gains gains;
   gains.p_gain_ = p;
   gains.i_gain_ = i;
   gains.d_gain_ = d;
   this->y_controller.setGains(gains);
 };
 
-void MotionController::set_t_pid_gains(PidType pid, double p, double i, double d){
-  control_toolbox::Gains gains;
+void MotionController::set_t_pid_gains(double p, double i, double d){
+  control_toolbox::Pid::Gains gains;
   gains.p_gain_ = p;
   gains.i_gain_ = i;
   gains.d_gain_ = d;

--- a/ateam_kenobi/src/motion/motion_controller.cpp
+++ b/ateam_kenobi/src/motion/motion_controller.cpp
@@ -194,7 +194,8 @@ void MotionController::reset()
   this->face_angle = 0;
 }
 
-void MotionController::set_x_pid_gain(GainType gain, double value){
+void MotionController::set_x_pid_gain(GainType gain, double value)
+{
   control_toolbox::Pid::Gains gains = this->x_controller.getGains();
   switch (gain) {
     case GainType::p:
@@ -205,9 +206,10 @@ void MotionController::set_x_pid_gain(GainType gain, double value){
       gains.d_gain_ = value;
   }
   this->x_controller.setGains(gains);
-};
+}
 
-void MotionController::set_y_pid_gain(GainType gain, double value){
+void MotionController::set_y_pid_gain(GainType gain, double value)
+{
   control_toolbox::Pid::Gains gains = this->y_controller.getGains();
   switch (gain) {
     case GainType::p:
@@ -218,9 +220,10 @@ void MotionController::set_y_pid_gain(GainType gain, double value){
       gains.d_gain_ = value;
   }
   this->y_controller.setGains(gains);
-};
+}
 
-void MotionController::set_t_pid_gain(GainType gain, double value){
+void MotionController::set_t_pid_gain(GainType gain, double value)
+{
   control_toolbox::Pid::Gains gains = this->t_controller.getGains();
   switch (gain) {
     case GainType::p:
@@ -231,28 +234,31 @@ void MotionController::set_t_pid_gain(GainType gain, double value){
       gains.d_gain_ = value;
   }
   this->t_controller.setGains(gains);
-};
+}
 
-void MotionController::set_x_pid_gains(double p, double i, double d){
+void MotionController::set_x_pid_gains(double p, double i, double d)
+{
   control_toolbox::Pid::Gains gains;
   gains.p_gain_ = p;
   gains.i_gain_ = i;
   gains.d_gain_ = d;
   this->x_controller.setGains(gains);
-};
+}
 
-void MotionController::set_y_pid_gains(double p, double i, double d){
+void MotionController::set_y_pid_gains(double p, double i, double d)
+{
   control_toolbox::Pid::Gains gains;
   gains.p_gain_ = p;
   gains.i_gain_ = i;
   gains.d_gain_ = d;
   this->y_controller.setGains(gains);
-};
+}
 
-void MotionController::set_t_pid_gains(double p, double i, double d){
+void MotionController::set_t_pid_gains(double p, double i, double d)
+{
   control_toolbox::Pid::Gains gains;
   gains.p_gain_ = p;
   gains.i_gain_ = i;
   gains.d_gain_ = d;
   this->t_controller.setGains(gains);
-};
+}

--- a/ateam_kenobi/src/motion/motion_controller.cpp
+++ b/ateam_kenobi/src/motion/motion_controller.cpp
@@ -194,45 +194,65 @@ void MotionController::reset()
   this->face_angle = 0;
 }
 
-void MotionController::set_pid_gain(PidType pid, GainType gain, double value){
-  control_toolbox::Gains current_gains;
-  switch (pid) {
-    case PidType::x:
-      gains = this->x_controller.getGains();
-    case PidType::y:
-      gains = this->y_controller.getGains();
-    case PidType::t:
-      gains = this->t_controller.getGains();
-  }
+void MotionController::set_x_pid_gain(PidType pid, GainType gain, double value){
+  control_toolbox::Gains gains = this->x_controller.getGains();
   switch (gain) {
     case GainType::p:
-      gains.p_ = value;
+      gains.p_gain_ = value;
     case GainType::i:
-      gains.i_ = value;
+      gains.i_gain_ = value;
     case GainType::d
-      gains.d_ = value;
+      gains.d_gain_ = value;
   }
-  switch (pid) {
-    case PidType::x:
-      this->x_controller.setGains(gains);
-    case PidType::y:
-      this->y_controller.setGains(gains);
-    case PidType::t:
-      this->t_controller.setGains(gains);
-  }
+  this->x_controller.setGains(gains);
 };
 
-void MotionController::set_pid_gains(PidType pid, double p, double i, double d){
-  control_toolbox::Gains gains;
-  gains._p = p;
-  gains._i = i;
-  gains._d = d;
-  switch(pid){
-    case PidType::x:
-      this->x_controller.setGains(gains);
-    case PidType::y:
-      this->y_controller.setGains(gains);
-    case PidType::t:
-      this->t_controller.setGains(gains);
+void MotionController::set_y_pid_gain(PidType pid, GainType gain, double value){
+  control_toolbox::Gains gains = this->y_controller.getGains();
+  switch (gain) {
+    case GainType::p:
+      gains.p_gain_ = value;
+    case GainType::i:
+      gains.i_gain_ = value;
+    case GainType::d
+      gains.d_gain_ = value;
   }
+  this->y_controller.setGains(gains);
+};
+
+void MotionController::set_t_pid_gain(PidType pid, GainType gain, double value){
+  control_toolbox::Gains gains = this->t_controller.getGains();
+  switch (gain) {
+    case GainType::p:
+      gains.p_gain_ = value;
+    case GainType::i:
+      gains.i_gain_ = value;
+    case GainType::d
+      gains.d_gain_ = value;
+  }
+  this->t_controller.setGains(gains);
+};
+
+void MotionController::set_x_pid_gains(PidType pid, double p, double i, double d){
+  control_toolbox::Gains gains;
+  gains.p_gain_ = p;
+  gains.i_gain_ = i;
+  gains.d_gain_ = d;
+  this->x_controller.setGains(gains);
+};
+
+void MotionController::set_y_pid_gains(PidType pid, double p, double i, double d){
+  control_toolbox::Gains gains;
+  gains.p_gain_ = p;
+  gains.i_gain_ = i;
+  gains.d_gain_ = d;
+  this->y_controller.setGains(gains);
+};
+
+void MotionController::set_t_pid_gains(PidType pid, double p, double i, double d){
+  control_toolbox::Gains gains;
+  gains.p_gain_ = p;
+  gains.i_gain_ = i;
+  gains.d_gain_ = d;
+  this->t_controller.setGains(gains);
 };

--- a/ateam_kenobi/src/motion/motion_controller.hpp
+++ b/ateam_kenobi/src/motion/motion_controller.hpp
@@ -42,6 +42,20 @@ enum class AngleMode
   no_face
 };
 
+enum class PidType
+{
+  x,
+  y,
+  t
+};
+
+enum class GainType
+{
+  p,
+  i,
+  d
+}
+
 struct MotionOptions
 {
   /**
@@ -74,6 +88,10 @@ public:
 
   // Reset the PID controllers and remove previous time to recalculate dt
   void reset();
+
+  // Set gains for individual PID controllers
+  void set_pid_gain(PidType pid, GainType gain, double value);
+  void set_pid_gains(PidType pid, double p, double i, double d);
 
 // Velocity limits
   double v_max = 2;

--- a/ateam_kenobi/src/motion/motion_controller.hpp
+++ b/ateam_kenobi/src/motion/motion_controller.hpp
@@ -42,13 +42,6 @@ enum class AngleMode
   no_face
 };
 
-enum class PidType
-{
-  x,
-  y,
-  t
-};
-
 enum class GainType
 {
   p,
@@ -90,8 +83,12 @@ public:
   void reset();
 
   // Set gains for individual PID controllers
-  void set_pid_gain(PidType pid, GainType gain, double value);
-  void set_pid_gains(PidType pid, double p, double i, double d);
+  void set_x_pid_gain(GainType gain, double value);
+  void set_y_pid_gain(GainType gain, double value);
+  void set_t_pid_gain(GainType gain, double value);
+  void set_x_pid_gains(double p, double i, double d);
+  void set_y_pid_gains(double p, double i, double d);
+  void set_t_pid_gains(double p, double i, double d);
 
 // Velocity limits
   double v_max = 2;

--- a/ateam_kenobi/src/motion/motion_controller.hpp
+++ b/ateam_kenobi/src/motion/motion_controller.hpp
@@ -47,7 +47,7 @@ enum class GainType
   p,
   i,
   d
-}
+};
 
 struct MotionOptions
 {


### PR DESCRIPTION
Convenient functions to set all or individual gain values for our robots' PID controllers.

Added so we can set these values in individual plays/skills when needed.