### PR TITLE
Bug fixes and clean ups in field geometry pipeline.

### DIFF
--- a/ateam_msgs/msg/FieldInfo.msg
+++ b/ateam_msgs/msg/FieldInfo.msg
@@ -1,4 +1,3 @@
-bool valid
 float32 field_length
 float32 field_width
 float32 goal_width

--- a/ateam_ssl_vision_bridge/src/message_conversions.cpp
+++ b/ateam_ssl_vision_bridge/src/message_conversions.cpp
@@ -170,8 +170,12 @@ ssl_league_msgs::msg::VisionGeometryData fromProto(const SSL_GeometryData & prot
 ssl_league_msgs::msg::VisionWrapper fromProto(const SSL_WrapperPacket & proto_msg)
 {
   ssl_league_msgs::msg::VisionWrapper ros_msg;
-  ros_msg.detection = fromProto(proto_msg.detection());
-  ros_msg.geometry = fromProto(proto_msg.geometry());
+  if (proto_msg.has_detection()) {
+    ros_msg.detection.push_back(fromProto(proto_msg.detection()));
+  }
+  if (proto_msg.has_geometry()) {
+    ros_msg.geometry.push_back(fromProto(proto_msg.geometry()));
+  }
 
   return ros_msg;
 }

--- a/ateam_vision_filter/src/ateam_vision_filter_node.cpp
+++ b/ateam_vision_filter/src/ateam_vision_filter_node.cpp
@@ -85,9 +85,10 @@ public:
   void vision_callback(
     const ssl_league_msgs::msg::VisionWrapper::SharedPtr vision_wrapper_msg)
   {
+    const auto team_side = game_controller_listener_.GetTeamSide();
     if (!vision_wrapper_msg->detection.empty()) {
       const auto camera_measurement = message_conversions::fromMsg(
-        vision_wrapper_msg->detection.front());
+        vision_wrapper_msg->detection.front(), team_side);
       const auto camera_id = vision_wrapper_msg->detection.front().camera_id;
       {
         const std::lock_guard<std::mutex> lock(world_mutex_);
@@ -97,9 +98,7 @@ public:
 
     if (!vision_wrapper_msg->geometry.empty()) {
       field_publisher_->publish(
-        message_conversions::fromMsg(
-          vision_wrapper_msg->geometry.front(),
-          game_controller_listener_.GetTeamSide()));
+        message_conversions::fromMsg(vision_wrapper_msg->geometry.front(), team_side));
     }
   }
 

--- a/ateam_vision_filter/src/message_conversions.cpp
+++ b/ateam_vision_filter/src/message_conversions.cpp
@@ -23,6 +23,7 @@
 #include <tf2/utils.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <string>
+#include <vector>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
@@ -70,144 +71,6 @@ ateam_msgs::msg::RobotState toMsg(const std::optional<Robot> & maybe_robot)
   return robot_state_msg;
 }
 
-CameraMeasurement getCameraMeasurement(const ssl_league_msgs::msg::VisionWrapper & ros_msg)
-{
-  return fromMsg(ros_msg.detection);
-}
-
-ateam_msgs::msg::FieldInfo getFieldGeometry(const ssl_league_msgs::msg::VisionWrapper & ros_msg)
-{
-  return fromMsg(ros_msg.geometry);
-}
-
-// note left and right can be different according to Joe
-ateam_msgs::msg::FieldInfo fromMsg(
-  const ssl_league_msgs::msg::VisionGeometryData & vision_wrapper_msg)
-{
-  // calibration left out but should be included in field info message if needed
-  const ssl_league_msgs::msg::VisionGeometryFieldSize & ros_msg =
-    vision_wrapper_msg.field;
-
-  ateam_msgs::msg::FieldInfo field_info {};
-  // check for if invalid since we cant see the original optional and this
-  // is a rough estimate of the smallest field
-  if (ros_msg.field_length < 1.0 || ros_msg.field_width < 1.0) {
-    field_info.valid = false;
-    return field_info;
-  } else {
-    field_info.valid = true;
-  }
-
-  field_info.field_length = ros_msg.field_length;
-  field_info.field_width = ros_msg.field_width;
-  field_info.goal_width = ros_msg.goal_width;
-  field_info.goal_depth = ros_msg.goal_depth;
-  field_info.boundary_width = ros_msg.boundary_width;
-
-  auto check_field_line_name =
-    [](auto line_msg, std::string target_name) -> bool {
-      return line_msg.name == target_name;
-    };
-
-
-  // did just realize I could have done this as a std transform
-  auto lines_to_points = [&](auto & name_array, auto & target_array) {
-      target_array.resize(name_array.size() * 2);
-      for (size_t i = 0; i < name_array.size(); i++) {
-        auto & name = name_array.at(i);
-        auto itr = std::find_if(
-          ros_msg.field_lines.begin(), ros_msg.field_lines.end(),
-          std::bind(check_field_line_name, std::placeholders::_1, name));
-        if (itr != ros_msg.field_lines.end()) {
-          target_array.at(i).x = itr->p1.x;
-          target_array.at(i).y = itr->p1.y;
-          target_array.at(2 * i + 1).x = itr->p2.x;
-          target_array.at(2 * i + 1).y = itr->p2.y;
-        }
-      }
-    };
-
-  std::array<std::string, 2> field_bound_names = {"TopTouchLine", "BottomTouchLine"};
-  lines_to_points(field_bound_names, field_info.field_corners.points);
-
-
-  ateam_msgs::msg::FieldSidedInfo left_side_info {};
-  left_side_info.goal_corners.points.resize(4);
-  left_side_info.goal_corners.points.at(0).x = -field_info.field_length / 2.0;
-  left_side_info.goal_corners.points.at(0).y = field_info.goal_width / 2.0;
-
-  left_side_info.goal_corners.points.at(1).x = -field_info.field_length / 2.0;
-  left_side_info.goal_corners.points.at(1).y = -field_info.goal_width / 2.0;
-
-  left_side_info.goal_corners.points.at(2).x = -field_info.field_length / 2.0 -
-    field_info.goal_depth;
-  left_side_info.goal_corners.points.at(2).y = -field_info.goal_width / 2.0;
-
-  left_side_info.goal_corners.points.at(3).x = -field_info.field_length / 2.0 -
-    field_info.goal_depth;
-  left_side_info.goal_corners.points.at(3).y = field_info.goal_width / 2.0;
-
-
-  std::array<std::string,
-    2> left_penalty_names = {"LeftFieldLeftPenaltyStretch", "LeftFieldRightPenaltyStretch"};
-  lines_to_points(left_penalty_names, left_side_info.defense_area_corners.points);
-
-  // TODO(Collin) VISION GOAL ESTIMATES
-  ateam_msgs::msg::FieldSidedInfo right_side_info {};
-  right_side_info.goal_corners.points.resize(4);
-  right_side_info.goal_corners.points.at(0).x = field_info.field_length / 2.0;
-  right_side_info.goal_corners.points.at(0).y = field_info.goal_width / 2.0;
-
-  right_side_info.goal_corners.points.at(1).x = field_info.field_length / 2.0;
-  right_side_info.goal_corners.points.at(1).y = -field_info.goal_width / 2.0;
-
-  right_side_info.goal_corners.points.at(2).x = field_info.field_length / 2.0 +
-    field_info.goal_depth;
-  right_side_info.goal_corners.points.at(2).y = -field_info.goal_width / 2.0;
-
-  right_side_info.goal_corners.points.at(3).x = field_info.field_length / 2.0 +
-    field_info.goal_depth;
-  right_side_info.goal_corners.points.at(3).y = field_info.goal_width / 2.0;
-
-
-  std::array<std::string,
-    2> right_penalty_names = {"RightFieldLeftPenaltyStretch", "RightFieldRightPenaltyStretch"};
-  lines_to_points(right_penalty_names, right_side_info.defense_area_corners.points);
-
-  auto itr = std::find_if(
-    ros_msg.field_arcs.begin(), ros_msg.field_arcs.end(),
-    std::bind(check_field_line_name, std::placeholders::_1, "CenterCircle"));
-  if (itr != ros_msg.field_arcs.end()) {
-    field_info.center_circle = itr->center;
-    field_info.center_circle_radius = itr->radius;
-  }
-
-  // note left and right can be different according to Joe
-  // Temporary stupid assignment working under the assumption we are on left side
-  // This gets inverted later if side is not right
-  field_info.ours = left_side_info;
-  field_info.theirs = right_side_info;
-  return field_info;
-}
-
-// I hate all my code...
-// because we really dont have access to the structs of the ros message just did it here
-void invert_field_info(ateam_msgs::msg::FieldInfo & info)
-{
-  auto invert_point_array = [&](auto & target_array) {
-      for (auto & point : target_array) {
-        point.x *= -1.0;
-        point.y *= -1.0;
-      }
-    };
-
-  invert_point_array(info.field_corners.points);
-  invert_point_array(info.ours.defense_area_corners.points);
-  invert_point_array(info.ours.goal_corners.points);
-  invert_point_array(info.theirs.defense_area_corners.points);
-  invert_point_array(info.theirs.goal_corners.points);
-}
-
 CameraMeasurement fromMsg(const ssl_league_msgs::msg::VisionDetectionFrame & ros_msg)
 {
   CameraMeasurement cameraFrame;
@@ -245,6 +108,148 @@ BallMeasurement fromMsg(const ssl_league_msgs::msg::VisionDetectionBall & ros_ms
   ballDetection.position.x() = ros_msg.pos.x;
   ballDetection.position.y() = ros_msg.pos.y;
   return ballDetection;
+}
+
+ateam_msgs::msg::FieldInfo fromMsg(
+  const ssl_league_msgs::msg::VisionGeometryData & vision_wrapper_msg,
+  const ateam_common::TeamSide & team_side)
+{
+  const ssl_league_msgs::msg::VisionGeometryFieldSize & ros_msg =
+    vision_wrapper_msg.field;
+
+  ateam_msgs::msg::FieldInfo field_info;
+
+  field_info.field_length = ros_msg.field_length;
+  field_info.field_width = ros_msg.field_width;
+  field_info.goal_width = ros_msg.goal_width;
+  field_info.goal_depth = ros_msg.goal_depth;
+  field_info.boundary_width = ros_msg.boundary_width;
+
+  field_info.field_corners.points = getPointsFromLines(
+    ros_msg.field_lines,
+    {"TopTouchLine", "BottomTouchLine"});
+
+  auto Point32Builder = [] {return geometry_msgs::build<geometry_msgs::msg::Point32>();};
+
+  ateam_msgs::msg::FieldSidedInfo left_side_info;
+
+  left_side_info.goal_corners.points = {
+    Point32Builder()
+    .x(-field_info.field_length / 2)
+    .y(field_info.goal_width / 2)
+    .z(0),
+    Point32Builder()
+    .x(-field_info.field_length / 2)
+    .y(-field_info.goal_width / 2)
+    .z(0),
+    Point32Builder()
+    .x((-field_info.field_length / 2) - field_info.goal_depth)
+    .y(-field_info.goal_width / 2)
+    .z(0),
+    Point32Builder()
+    .x((-field_info.field_length / 2) - field_info.goal_depth)
+    .y(field_info.goal_width / 2)
+    .z(0)
+  };
+
+  left_side_info.defense_area_corners.points = getPointsFromLines(
+    ros_msg.field_lines,
+    {"LeftFieldLeftPenaltyStretch", "LeftFieldRightPenaltyStretch"});
+
+  ateam_msgs::msg::FieldSidedInfo right_side_info;
+  right_side_info.goal_corners.points = {
+    Point32Builder()
+    .x(field_info.field_length / 2)
+    .y(field_info.goal_width / 2)
+    .z(0),
+    Point32Builder()
+    .x(field_info.field_length / 2)
+    .y(-field_info.goal_width / 2)
+    .z(0),
+    Point32Builder()
+    .x((field_info.field_length / 2) + field_info.goal_depth)
+    .y(-field_info.goal_width / 2)
+    .z(0),
+    Point32Builder()
+    .x((field_info.field_length / 2) + field_info.goal_depth)
+    .y(field_info.goal_width / 2)
+    .z(0),
+  };
+
+  right_side_info.defense_area_corners.points = getPointsFromLines(
+    ros_msg.field_lines,
+    {"RightFieldLeftPenaltyStretch", "RightFieldRightPenaltyStretch"});
+
+  const auto circle_iter = std::ranges::find_if(
+    ros_msg.field_arcs, [](const auto & line) {
+      return line.name == "CenterCircle";
+    });
+
+  if (circle_iter != ros_msg.field_arcs.end()) {
+    field_info.center_circle = circle_iter->center;
+    field_info.center_circle_radius = circle_iter->radius;
+  }
+
+  // Assign sides and invert to our coordinate convention if needed.
+  switch (team_side) {
+    case ateam_common::TeamSide::NegativeHalf:
+    case ateam_common::TeamSide::Unknown:
+      field_info.ours = left_side_info;
+      field_info.theirs = right_side_info;
+      break;
+    case ateam_common::TeamSide::PositiveHalf:
+      field_info.ours = right_side_info;
+      field_info.theirs = left_side_info;
+      invertFieldInfo(field_info);
+      break;
+  }
+
+  return field_info;
+}
+
+void invertFieldInfo(ateam_msgs::msg::FieldInfo & info)
+{
+  auto invert_point_array = [&](auto & target_array) {
+      for (auto & point : target_array) {
+        point.x *= -1.0;
+        point.y *= -1.0;
+      }
+    };
+
+  invert_point_array(info.field_corners.points);
+  invert_point_array(info.ours.defense_area_corners.points);
+  invert_point_array(info.ours.goal_corners.points);
+  invert_point_array(info.theirs.defense_area_corners.points);
+  invert_point_array(info.theirs.goal_corners.points);
+}
+
+std::vector<geometry_msgs::msg::Point32> getPointsFromLines(
+  const std::vector<ssl_league_msgs::msg::VisionFieldLineSegment> & lines,
+  const std::vector<std::string> & line_names)
+{
+  std::vector<geometry_msgs::msg::Point32> points;
+  points.reserve(line_names.size() * 2);
+  for (const auto & name : line_names) {
+    const auto line_iter = std::ranges::find_if(
+      lines, [&name](const auto & line) {
+        return line.name == name;
+      });
+
+    if (line_iter == lines.end()) {
+      // TODO(barulicm) Log missing line?
+      continue;
+    }
+
+    geometry_msgs::msg::Point32 p1;
+    p1.x = line_iter->p1.x;
+    p1.y = line_iter->p1.y;
+    points.push_back(p1);
+    geometry_msgs::msg::Point32 p2;
+    p2.x = line_iter->p2.x;
+    p2.y = line_iter->p2.y;
+    points.push_back(p2);
+  }
+  return points;
 }
 
 }  // namespace ateam_vision_filter::message_conversions

--- a/ateam_vision_filter/src/message_conversions.cpp
+++ b/ateam_vision_filter/src/message_conversions.cpp
@@ -71,7 +71,9 @@ ateam_msgs::msg::RobotState toMsg(const std::optional<Robot> & maybe_robot)
   return robot_state_msg;
 }
 
-CameraMeasurement fromMsg(const ssl_league_msgs::msg::VisionDetectionFrame & ros_msg)
+CameraMeasurement fromMsg(
+  const ssl_league_msgs::msg::VisionDetectionFrame & ros_msg,
+  const ateam_common::TeamSide & team_side)
 {
   CameraMeasurement cameraFrame;
   for (const auto & ball_detection : ros_msg.balls) {
@@ -86,6 +88,10 @@ CameraMeasurement fromMsg(const ssl_league_msgs::msg::VisionDetectionFrame & ros
   for (const auto & blue_robot_detection : ros_msg.robots_blue) {
     std::size_t robot_id = blue_robot_detection.robot_id;
     cameraFrame.blue_robots.at(robot_id).push_back(fromMsg(blue_robot_detection));
+  }
+
+  if(team_side == ateam_common::TeamSide::PositiveHalf) {
+    cameraFrame.invert();
   }
 
   return cameraFrame;

--- a/ateam_vision_filter/src/message_conversions.cpp
+++ b/ateam_vision_filter/src/message_conversions.cpp
@@ -90,7 +90,7 @@ CameraMeasurement fromMsg(
     cameraFrame.blue_robots.at(robot_id).push_back(fromMsg(blue_robot_detection));
   }
 
-  if(team_side == ateam_common::TeamSide::PositiveHalf) {
+  if (team_side == ateam_common::TeamSide::PositiveHalf) {
     cameraFrame.invert();
   }
 

--- a/ateam_vision_filter/src/message_conversions.hpp
+++ b/ateam_vision_filter/src/message_conversions.hpp
@@ -46,7 +46,9 @@ namespace ateam_vision_filter::message_conversions
 ateam_msgs::msg::BallState toMsg(const std::optional<Ball> & maybe_ball);
 ateam_msgs::msg::RobotState toMsg(const std::optional<Robot> & maybe_robot);
 
-CameraMeasurement fromMsg(const ssl_league_msgs::msg::VisionDetectionFrame & ros_msg);
+CameraMeasurement fromMsg(
+  const ssl_league_msgs::msg::VisionDetectionFrame & ros_msg,
+  const ateam_common::TeamSide & team_side);
 RobotMeasurement fromMsg(const ssl_league_msgs::msg::VisionDetectionRobot & ros_msg);
 BallMeasurement fromMsg(const ssl_league_msgs::msg::VisionDetectionBall & ros_msg);
 

--- a/ateam_vision_filter/src/message_conversions.hpp
+++ b/ateam_vision_filter/src/message_conversions.hpp
@@ -22,10 +22,13 @@
 #define MESSAGE_CONVERSIONS_HPP_
 
 #include <optional>
+#include <string>
+#include <vector>
 #include <ateam_msgs/msg/ball_state.hpp>
 #include <ateam_msgs/msg/robot_state.hpp>
 #include <ateam_msgs/msg/field_info.hpp>
 #include <ateam_msgs/msg/field_sided_info.hpp>
+#include <ateam_common/game_controller_listener.hpp>
 #include <ssl_league_msgs/msg/vision_detection_ball.hpp>
 #include <ssl_league_msgs/msg/vision_detection_robot.hpp>
 #include <ssl_league_msgs/msg/vision_detection_frame.hpp>
@@ -43,15 +46,17 @@ namespace ateam_vision_filter::message_conversions
 ateam_msgs::msg::BallState toMsg(const std::optional<Ball> & maybe_ball);
 ateam_msgs::msg::RobotState toMsg(const std::optional<Robot> & maybe_robot);
 
-CameraMeasurement getCameraMeasurement(const ssl_league_msgs::msg::VisionWrapper & ros_msg);
 CameraMeasurement fromMsg(const ssl_league_msgs::msg::VisionDetectionFrame & ros_msg);
 RobotMeasurement fromMsg(const ssl_league_msgs::msg::VisionDetectionRobot & ros_msg);
 BallMeasurement fromMsg(const ssl_league_msgs::msg::VisionDetectionBall & ros_msg);
 
-void invert_field_info(ateam_msgs::msg::FieldInfo & info);
-
-ateam_msgs::msg::FieldInfo getFieldGeometry(const ssl_league_msgs::msg::VisionWrapper & ros_msg);
-ateam_msgs::msg::FieldInfo fromMsg(const ssl_league_msgs::msg::VisionGeometryData & ros_msg);
+ateam_msgs::msg::FieldInfo fromMsg(
+  const ssl_league_msgs::msg::VisionGeometryData & ros_msg,
+  const ateam_common::TeamSide & team_side);
+void invertFieldInfo(ateam_msgs::msg::FieldInfo & info);
+std::vector<geometry_msgs::msg::Point32> getPointsFromLines(
+  const std::vector<ssl_league_msgs::msg::VisionFieldLineSegment> & lines,
+  const std::vector<std::string> & line_names);
 
 }  // namespace ateam_vision_filter::message_conversions
 

--- a/ssl_league_msgs/msg/vision/VisionWrapper.msg
+++ b/ssl_league_msgs/msg/vision/VisionWrapper.msg
@@ -1,2 +1,2 @@
-ssl_league_msgs/VisionDetectionFrame detection
-ssl_league_msgs/VisionGeometryData geometry
+ssl_league_msgs/VisionDetectionFrame[<=1] detection
+ssl_league_msgs/VisionGeometryData[<=1] geometry


### PR DESCRIPTION
We found a bug in some of the new field geometry code so I cracked it open to fix it and ended up cleaning some other stuff while I was there.

The bug was in the `lines_to_points` lambda. The translation of indices from the names vector to the points vector was incorrect. The intended points layout was {line 1 point 1, line 1 point 2, line 2 point 1, line 2 point 2}. Unfortunately, the implementation actually resulted in {line 1 point 1, line 2 point 1, unassigned, line 2 point 1}. The solution to this bug was to modify the implementation of that helper to use `push_back` and avoid handling indices altogether.

While I was in the neighborhood, I took the opportunity to clean up a couple other things in this corner of the code.

The detections and geometry fields of ssl_league_msgs/msg/VisionWrapper are now optional (implemented as arrays of 0 or 1 size) to reflect the optionals in the protobuf messages. This allowed for some of the vision filter code to more explicitly check if these fields were available instead of making assumptions based on other values.

Converted the `lines_to_points` lambda to a full function since it's kinda long for a lambda.

Removed the `get______()` functions in message conversions that just forwarded to one of the `fromMsg()` functions.

Moved the team side check into the field message's `fromMsg` function so we make sure to assign the field side infos to the correct members. (I don't think this will ever really matter in practice since I'm pretty sure vision always publishes symmetric fields even though the protobuf supports asymmetric fields, but if it ever does, we're ready.)

I converted some of the point initialization functions to use the builder API. Personally, I think this makes it a little easier to read these sections, but I'm open to suggestions. This builder API is relatively new, and I'm still deciding where I like using it.