### PR TITLE
Greedy Assignment

### DIFF
--- a/ateam_kenobi/CMakeLists.txt
+++ b/ateam_kenobi/CMakeLists.txt
@@ -66,6 +66,7 @@ install(TARGETS kenobi_node_component DESTINATION lib)
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  add_subdirectory(test)
 endif()
 
 ament_package()

--- a/ateam_kenobi/src/robot_assignment.hpp
+++ b/ateam_kenobi/src/robot_assignment.hpp
@@ -42,6 +42,35 @@ namespace ateam_kenobi::robot_assignment
 {
 
 // #define USE_HACKY_ASSIGNMENT
+#define USE_GREEDY_ASSIGNMENT
+
+inline std::unordered_map<size_t, size_t> greedyAssignment(const std::vector<Robot> & available_robots, const std::vector<ateam_geometry::Point> & goal_positions) {
+  std::unordered_map<size_t, size_t> assignments;
+
+  if(available_robots.empty() || goal_positions.empty()) {
+    return assignments;
+  }
+
+  Eigen::MatrixXd costs = Eigen::MatrixXd::Constant(
+    goal_positions.size(),
+    available_robots.size(), std::numeric_limits<double>::max());
+  for (size_t i = 0; i < goal_positions.size(); i++) {
+    for (size_t j = 0; j < available_robots.size(); j++) {
+      costs(i, j) = sqrt(CGAL::squared_distance(available_robots.at(j).pos, goal_positions.at(i)));
+    }
+  }
+
+  const auto num_assignments = std::min(available_robots.size(), goal_positions.size());
+
+  for(auto row = 0ul; row < num_assignments; ++row) {
+    Eigen::MatrixXd::Index min_index;
+    costs.row(row).minCoeff(&min_index);
+    assignments[available_robots[min_index].id] = row;
+    costs.col(min_index).fill(std::numeric_limits<double>::max());
+  }
+
+  return assignments;
+}
 
 inline std::unordered_map<size_t, size_t> assign(
   const std::vector<Robot> & available_robots,
@@ -58,6 +87,10 @@ inline std::unordered_map<size_t, size_t> assign(
     assignments[available_robots[index].id] = index;
   }
   return assignments;
+
+#elif defined(USE_GREEDY_ASSIGNMENT)
+
+  return greedyAssignment(available_robots, goal_positions);
 
 #else
 

--- a/ateam_kenobi/src/robot_assignment.hpp
+++ b/ateam_kenobi/src/robot_assignment.hpp
@@ -44,10 +44,13 @@ namespace ateam_kenobi::robot_assignment
 // #define USE_HACKY_ASSIGNMENT
 #define USE_GREEDY_ASSIGNMENT
 
-inline std::unordered_map<size_t, size_t> greedyAssignment(const std::vector<Robot> & available_robots, const std::vector<ateam_geometry::Point> & goal_positions) {
+inline std::unordered_map<size_t, size_t> greedyAssignment(
+  const std::vector<Robot> & available_robots,
+  const std::vector<ateam_geometry::Point> & goal_positions)
+{
   std::unordered_map<size_t, size_t> assignments;
 
-  if(available_robots.empty() || goal_positions.empty()) {
+  if (available_robots.empty() || goal_positions.empty()) {
     return assignments;
   }
 
@@ -62,7 +65,7 @@ inline std::unordered_map<size_t, size_t> greedyAssignment(const std::vector<Rob
 
   const auto num_assignments = std::min(available_robots.size(), goal_positions.size());
 
-  for(auto row = 0ul; row < num_assignments; ++row) {
+  for (auto row = 0ul; row < num_assignments; ++row) {
     Eigen::MatrixXd::Index min_index;
     costs.row(row).minCoeff(&min_index);
     assignments[available_robots[min_index].id] = row;

--- a/ateam_kenobi/test/CMakeLists.txt
+++ b/ateam_kenobi/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+find_package(ament_cmake_gmock REQUIRED)
+
+ament_add_gmock(ateam_kenobi_tests
+  greedy_assignment_test.cpp
+)
+
+target_include_directories(ateam_kenobi_tests PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src>
+)
+
+target_link_libraries(ateam_kenobi_tests
+  kenobi_node_component
+  ateam_geometry::ateam_geometry_testing
+)

--- a/ateam_kenobi/test/greedy_assignment_test.cpp
+++ b/ateam_kenobi/test/greedy_assignment_test.cpp
@@ -1,4 +1,22 @@
-
+// Copyright 2024 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
@@ -12,7 +30,7 @@ TEST(GreedyAssignmentTest, EmptyRobots)
 {
   std::vector<Robot> robots;
   std::vector<ateam_geometry::Point> goals = {
-    ateam_geometry::Point(0,0)
+    ateam_geometry::Point(0, 0)
   };
   const auto assignments = greedyAssignment(robots, goals);
   EXPECT_TRUE(assignments.empty());
@@ -31,52 +49,52 @@ TEST(GreedyAssignmentTest, EmptyGoals)
 TEST(GreedyAssignmentTest, OneRobotOneGoal)
 {
   std::vector<Robot> robots {
-    {1, ateam_geometry::Point(1,2)}
+    {1, ateam_geometry::Point(1, 2)}
   };
   std::vector<ateam_geometry::Point> goals = {
-    ateam_geometry::Point(3,4)
+    ateam_geometry::Point(3, 4)
   };
   const auto assignments = greedyAssignment(robots, goals);
-  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(1,0)));
+  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(1, 0)));
 }
 
 TEST(GreedyAssignmentTest, TwoRobotsOneGoal)
 {
   std::vector<Robot> robots {
-    {1, ateam_geometry::Point(1,2)},
-    {2, ateam_geometry::Point(3,4)}
+    {1, ateam_geometry::Point(1, 2)},
+    {2, ateam_geometry::Point(3, 4)}
   };
   std::vector<ateam_geometry::Point> goals = {
-    ateam_geometry::Point(3,4)
+    ateam_geometry::Point(3, 4)
   };
   const auto assignments = greedyAssignment(robots, goals);
-  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(2,0)));
+  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(2, 0)));
 }
 
 TEST(GreedyAssignmentTest, TwoRobotsTwoGoals)
 {
   std::vector<Robot> robots {
-    {1, ateam_geometry::Point(1,2)},
-    {2, ateam_geometry::Point(3,4)}
+    {1, ateam_geometry::Point(1, 2)},
+    {2, ateam_geometry::Point(3, 4)}
   };
   std::vector<ateam_geometry::Point> goals = {
-    ateam_geometry::Point(0,0),
-    ateam_geometry::Point(3,4)
+    ateam_geometry::Point(0, 0),
+    ateam_geometry::Point(3, 4)
   };
   const auto assignments = greedyAssignment(robots, goals);
-  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(1,0), testing::Pair(2,1)));
+  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(1, 0), testing::Pair(2, 1)));
 }
 
 TEST(GreedyAssignmentTest, TwoRobotsSameDistance)
 {
   std::vector<Robot> robots {
-    {1, ateam_geometry::Point(0,1)},
-    {2, ateam_geometry::Point(0,-1)}
+    {1, ateam_geometry::Point(0, 1)},
+    {2, ateam_geometry::Point(0, -1)}
   };
   std::vector<ateam_geometry::Point> goals = {
-    ateam_geometry::Point(1,0),
-    ateam_geometry::Point(-1,0)
+    ateam_geometry::Point(1, 0),
+    ateam_geometry::Point(-1, 0)
   };
   const auto assignments = greedyAssignment(robots, goals);
-  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(1,0), testing::Pair(2,1)));
+  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(1, 0), testing::Pair(2, 1)));
 }

--- a/ateam_kenobi/test/greedy_assignment_test.cpp
+++ b/ateam_kenobi/test/greedy_assignment_test.cpp
@@ -1,0 +1,82 @@
+
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "robot_assignment.hpp"
+
+
+using namespace ateam_kenobi;  // NOLINT(build/namespaces)
+using namespace ateam_kenobi::robot_assignment;  // NOLINT(build/namespaces)
+
+TEST(GreedyAssignmentTest, EmptyRobots)
+{
+  std::vector<Robot> robots;
+  std::vector<ateam_geometry::Point> goals = {
+    ateam_geometry::Point(0,0)
+  };
+  const auto assignments = greedyAssignment(robots, goals);
+  EXPECT_TRUE(assignments.empty());
+}
+
+TEST(GreedyAssignmentTest, EmptyGoals)
+{
+  std::vector<Robot> robots = {
+    {}
+  };
+  std::vector<ateam_geometry::Point> goals;
+  const auto assignments = greedyAssignment(robots, goals);
+  EXPECT_TRUE(assignments.empty());
+}
+
+TEST(GreedyAssignmentTest, OneRobotOneGoal)
+{
+  std::vector<Robot> robots {
+    {1, ateam_geometry::Point(1,2)}
+  };
+  std::vector<ateam_geometry::Point> goals = {
+    ateam_geometry::Point(3,4)
+  };
+  const auto assignments = greedyAssignment(robots, goals);
+  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(1,0)));
+}
+
+TEST(GreedyAssignmentTest, TwoRobotsOneGoal)
+{
+  std::vector<Robot> robots {
+    {1, ateam_geometry::Point(1,2)},
+    {2, ateam_geometry::Point(3,4)}
+  };
+  std::vector<ateam_geometry::Point> goals = {
+    ateam_geometry::Point(3,4)
+  };
+  const auto assignments = greedyAssignment(robots, goals);
+  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(2,0)));
+}
+
+TEST(GreedyAssignmentTest, TwoRobotsTwoGoals)
+{
+  std::vector<Robot> robots {
+    {1, ateam_geometry::Point(1,2)},
+    {2, ateam_geometry::Point(3,4)}
+  };
+  std::vector<ateam_geometry::Point> goals = {
+    ateam_geometry::Point(0,0),
+    ateam_geometry::Point(3,4)
+  };
+  const auto assignments = greedyAssignment(robots, goals);
+  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(1,0), testing::Pair(2,1)));
+}
+
+TEST(GreedyAssignmentTest, TwoRobotsSameDistance)
+{
+  std::vector<Robot> robots {
+    {1, ateam_geometry::Point(0,1)},
+    {2, ateam_geometry::Point(0,-1)}
+  };
+  std::vector<ateam_geometry::Point> goals = {
+    ateam_geometry::Point(1,0),
+    ateam_geometry::Point(-1,0)
+  };
+  const auto assignments = greedyAssignment(robots, goals);
+  EXPECT_THAT(assignments, testing::UnorderedElementsAre(testing::Pair(1,0), testing::Pair(2,1)));
+}


### PR DESCRIPTION
A slightly smarter than hacky temporary assignment algorithm for Kenobi while we continue investigating a real solution.

This approach iterates over the goals and grabs the closest robot to each, removing that robot from the pool for later goals.

This should be near optimal for small numbers of robots, and at least should always give us a valid assignment back without crashing / hanging.