### PR TITLE
Bringup changes from 2024 quals work

### DIFF
--- a/ateam_bringup/launch/bringup_physical.launch.py
+++ b/ateam_bringup/launch/bringup_physical.launch.py
@@ -26,13 +26,11 @@ from launch_ros.actions import Node
 from ateam_bringup.substitutions import PackageLaunchFileSubstitution
 
 
-def remap_indexed_topics(pattern_from, pattern_to):
-    return list(
-        zip(
-            [pattern_from + str(i) for i in range(16)],
-            [pattern_to + str(i) for i in range(16)],
-        )
-    )
+def remap_indexed_topics(pattern_pairs):
+    return [
+        [(pattern_from+str(i), pattern_to+str(i)) for i in range(16)]
+        for pattern_from, pattern_to in pattern_pairs
+    ]
 
 
 def generate_launch_description():
@@ -84,10 +82,10 @@ def generate_launch_description():
                 "net_interface_address": LaunchConfiguration("radio_interface_address"),
                 "gc_team_name": LaunchConfiguration("team_name")
             }],
-            remappings=remap_indexed_topics("~/robot_motion_commands/robot",
-                                            "/robot_motion_commands/robot") +
-                       remap_indexed_topics("~/robot_feedback/robot",
-                                            "/robot_feedback/robot"),
-            respawn=True
+            respawn=True,
+            remappings=remap_indexed_topics([
+                ("~/robot_motion_commands/robot", "/robot_motion_commands/robot"),
+                ("~/robot_feedback/robot", "/robot_feedback/robot")
+            ])
         )
     ])

--- a/ateam_bringup/launch/bringup_physical.launch.py
+++ b/ateam_bringup/launch/bringup_physical.launch.py
@@ -49,6 +49,8 @@ def generate_launch_description():
         # DeclareLaunchArgument("gc_server_address", default_value="10.193.12.10"),
         # DeclareLaunchArgument("radio_interface_address", default_value="172.16.1.10"),
 
+        DeclareLaunchArgument("team_name", default_value="A-Team"),
+
         IncludeLaunchDescription(
             FrontendLaunchDescriptionSource(
                 PackageLaunchFileSubstitution("ateam_bringup",
@@ -78,10 +80,14 @@ def generate_launch_description():
             package="ateam_radio_bridge",
             executable="radio_bridge_node",
             name="radio_bridge",
-            parameters=[{"net_interface_address": LaunchConfiguration("radio_interface_address")}],
+            parameters=[{
+                "net_interface_address": LaunchConfiguration("radio_interface_address"),
+                "gc_team_name": LaunchConfiguration("team_name")
+            }],
             remappings=remap_indexed_topics("~/robot_motion_commands/robot",
                                             "/robot_motion_commands/robot") +
                        remap_indexed_topics("~/robot_feedback/robot",
-                                            "/robot_feedback/robot")
+                                            "/robot_feedback/robot"),
+            respawn=True
         )
     ])

--- a/ateam_bringup/launch/bringup_simulation.launch.py
+++ b/ateam_bringup/launch/bringup_simulation.launch.py
@@ -31,6 +31,7 @@ def generate_launch_description():
     return launch.LaunchDescription([
         DeclareLaunchArgument("start_sim", default_value="True"),
         DeclareLaunchArgument("start_gc", default_value="True"),
+        DeclareLaunchArgument("start_ui", default_value="True"),
         DeclareLaunchArgument("headless_sim", default_value="True"),
         DeclareLaunchArgument("sim_radio_ip", default_value="127.0.0.1"),
         DeclareLaunchArgument("team_name", default_value="A-Team"),
@@ -77,7 +78,8 @@ def generate_launch_description():
         IncludeLaunchDescription(
             FrontendLaunchDescriptionSource(
                 PackageLaunchFileSubstitution("ateam_bringup",
-                                              "ui.launch.xml"))
+                                              "ui.launch.xml")),
+            condition=IfCondition(LaunchConfiguration("start_ui"))
         ),
 
         Node(

--- a/ateam_bringup/launch/ssl_game_controller.launch.xml
+++ b/ateam_bringup/launch/ssl_game_controller.launch.xml
@@ -1,4 +1,6 @@
 <launch>
   <arg name="data_directory" default="$(find-pkg-share ateam_bringup)/data" />
+  <arg name="expose_gc_to_net" default="false" />
   <executable cmd="docker run --net host --rm robocupssl/ssl-game-controller" output="screen" respawn="True"/>
+  <executable if="$(var expose_gc_to_net)" cmd="socat tcp-listen:8082,reuseaddr,fork tcp:127.0.0.1:8081" />
 </launch>


### PR DESCRIPTION
This PR:
- Adds `team_name` launch argument to physical launch file
- Rewrites `remap_indexed_topics` helper in physical launch file for cleaner formatting at call site
- Adds respawn to radio bridge
- Adds `start_ui` launch argument to simulation launch file
- Adds `expose_gc_to_net` to game controller launch file