### PR TITLE
Adds namespace for vision filter.

### DIFF
--- a/ateam_vision_filter/src/camera.cpp
+++ b/ateam_vision_filter/src/camera.cpp
@@ -30,6 +30,9 @@
 #include "filters/interacting_multiple_model_filter.hpp"
 #include "types/models.hpp"
 
+namespace ateam_vision_filter
+{
+
 Camera::Camera(
   std::shared_ptr<ModelInputGenerator> model_input_generator,
   std::shared_ptr<TransmissionProbabilityGenerator> transmission_probability_generator)
@@ -232,3 +235,5 @@ std::array<std::optional<Camera::RobotWithScore>, 16> Camera::get_robot_estimate
 
   return output;
 }
+
+}  // namespace ateam_vision_filter

--- a/ateam_vision_filter/src/camera.hpp
+++ b/ateam_vision_filter/src/camera.hpp
@@ -35,6 +35,9 @@
 #include "generators/transmission_probability_generator.hpp"
 #include "types/camera_measurement.hpp"
 
+namespace ateam_vision_filter
+{
+
 class Camera
 {
 public:
@@ -98,5 +101,7 @@ private:
   std::array<MultipleHypothesisTracker, 16> blue_team;
   MultipleHypothesisTracker ball;
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // CAMERA_HPP_

--- a/ateam_vision_filter/src/filters/interacting_multiple_model_filter.cpp
+++ b/ateam_vision_filter/src/filters/interacting_multiple_model_filter.cpp
@@ -27,6 +27,9 @@
 #include <vector>
 #include <iostream>
 
+namespace ateam_vision_filter
+{
+
 void InteractingMultipleModelFilter::setup(
   const KalmanFilter & base_model,
   std::vector<Models::ModelType> model_types,
@@ -227,3 +230,5 @@ double InteractingMultipleModelFilter::normal_multivariate_distribution_pdf(
          std::exp(-1.0 / 2.0 * (x - mu).transpose() * sigma.inverse() * (x - mu)) +
          1e-6;
 }
+
+}  // namespace ateam_vision_filter

--- a/ateam_vision_filter/src/filters/interacting_multiple_model_filter.hpp
+++ b/ateam_vision_filter/src/filters/interacting_multiple_model_filter.hpp
@@ -46,6 +46,9 @@
 #include "generators/model_input_generator.hpp"
 #include "generators/transmission_probability_generator.hpp"
 
+namespace ateam_vision_filter
+{
+
 class InteractingMultipleModelFilter
 {
 public:
@@ -128,5 +131,7 @@ private:
   std::shared_ptr<ModelInputGenerator> model_input_generator;
   std::shared_ptr<TransmissionProbabilityGenerator> transmission_probability_generator;
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // FILTERS__INTERACTING_MULTIPLE_MODEL_FILTER_HPP_

--- a/ateam_vision_filter/src/filters/kalman_filter.cpp
+++ b/ateam_vision_filter/src/filters/kalman_filter.cpp
@@ -22,6 +22,9 @@
 
 #include <angles/angles.h>
 
+namespace ateam_vision_filter
+{
+
 void KalmanFilter::set_initial_x_hat(const Eigen::VectorXd & x_hat)
 {
   this->x_hat = x_hat;
@@ -112,3 +115,5 @@ Eigen::VectorXd KalmanFilter::get_potential_measurement_error(const Eigen::Vecto
 {
   return z - H * F * x_hat;
 }
+
+}  // namespace ateam_vision_filter

--- a/ateam_vision_filter/src/filters/kalman_filter.hpp
+++ b/ateam_vision_filter/src/filters/kalman_filter.hpp
@@ -25,6 +25,9 @@
 
 // Standard kalman filter
 
+namespace ateam_vision_filter
+{
+
 class KalmanFilter
 {
 public:
@@ -57,5 +60,7 @@ private:
   Eigen::VectorXd x_hat;
   Eigen::MatrixXd P;
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // FILTERS__KALMAN_FILTER_HPP_

--- a/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.cpp
+++ b/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.cpp
@@ -30,6 +30,9 @@
 
 #include "ateam_common/assignment.hpp"
 
+namespace ateam_vision_filter
+{
+
 void MultipleHypothesisTracker::set_base_track(const InteractingMultipleModelFilter & base_track)
 {
   this->base_track = base_track;
@@ -122,3 +125,5 @@ void MultipleHypothesisTracker::life_cycle_management()
         return !track.has_been_updated_regularly();
       }), tracks.end());
 }
+
+}  // namespace ateam_vision_filter

--- a/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.hpp
+++ b/ateam_vision_filter/src/filters/multiple_hypothesis_tracker.hpp
@@ -36,6 +36,9 @@
 
 #include "filters/interacting_multiple_model_filter.hpp"
 
+namespace ateam_vision_filter
+{
+
 class MultipleHypothesisTracker
 {
 public:
@@ -60,5 +63,7 @@ private:
 
   std::vector<InteractingMultipleModelFilter> tracks;
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // FILTERS__MULTIPLE_HYPOTHESIS_TRACKER_HPP_

--- a/ateam_vision_filter/src/generators/generator_util.cpp
+++ b/ateam_vision_filter/src/generators/generator_util.cpp
@@ -24,7 +24,10 @@
 
 #include "types/models.hpp"
 
-std::optional<Robot> generator_util::get_closest_robot(
+namespace ateam_vision_filter::generator_util
+{
+
+std::optional<Robot> get_closest_robot(
   const Eigen::Vector2d & position,
   const std::array<std::optional<Robot>, 16> & blue_robots,
   const std::array<std::optional<Robot>, 16> & yellow_robots)
@@ -60,7 +63,7 @@ std::optional<Robot> generator_util::get_closest_robot(
 }
 
 
-bool generator_util::is_near_robot(
+bool is_near_robot(
   const Eigen::Vector2d & position,
   const std::optional<Robot> & robot)
 {
@@ -71,7 +74,7 @@ bool generator_util::is_near_robot(
   return (robot.value().position - position).norm() < 0.5;
 }
 
-bool generator_util::is_in_robot_mouth(
+bool is_in_robot_mouth(
   const Eigen::Vector2d & position,
   const std::optional<Robot> & robot)
 {
@@ -87,7 +90,7 @@ bool generator_util::is_in_robot_mouth(
          heading.dot(robot_to_ball) / (heading.norm() * robot_to_ball.norm());
 }
 
-bool generator_util::is_moving_towards_robot(
+bool is_moving_towards_robot(
   const Eigen::Vector2d & position,
   const Eigen::Vector2d & velocity,
   const std::optional<Robot> & robot)
@@ -96,3 +99,5 @@ bool generator_util::is_moving_towards_robot(
 
   return ball_to_robot.dot(velocity) > 0;
 }
+
+}  // namespace ateam_vision_filter::generator_util

--- a/ateam_vision_filter/src/generators/generator_util.hpp
+++ b/ateam_vision_filter/src/generators/generator_util.hpp
@@ -58,6 +58,6 @@ bool is_in_robot_mouth(
 bool is_moving_towards_robot(
   const Eigen::Vector2d & position, const Eigen::Vector2d & velocity,
   const std::optional<Robot> & robot);
-}  // namespace generator_util
+}  // namespace ateam_vision_filter::generator_util
 
 #endif  // GENERATORS__GENERATOR_UTIL_HPP_

--- a/ateam_vision_filter/src/generators/generator_util.hpp
+++ b/ateam_vision_filter/src/generators/generator_util.hpp
@@ -29,7 +29,7 @@
 #include "types/robot.hpp"
 
 
-namespace generator_util
+namespace ateam_vision_filter::generator_util
 {
 /**
  * @return Closest robot to the position given (if one exists)

--- a/ateam_vision_filter/src/generators/model_input_generator.cpp
+++ b/ateam_vision_filter/src/generators/model_input_generator.cpp
@@ -24,6 +24,9 @@
 
 #include "generators/generator_util.hpp"
 
+namespace ateam_vision_filter
+{
+
 void ModelInputGenerator::update(
   const std::array<std::optional<Robot>, 16> & blue_robots,
   const std::array<std::optional<Robot>, 16> & yellow_robots,
@@ -230,3 +233,5 @@ Eigen::VectorXd ModelInputGenerator::get_output_with_kick_at_speed(
 
   return output;
 }
+
+}  // namespace ateam_vision_filter

--- a/ateam_vision_filter/src/generators/model_input_generator.hpp
+++ b/ateam_vision_filter/src/generators/model_input_generator.hpp
@@ -30,6 +30,9 @@
 #include "types/models.hpp"
 #include "types/robot.hpp"
 
+namespace ateam_vision_filter
+{
+
 class ModelInputGenerator
 {
 public:
@@ -56,5 +59,7 @@ private:
     const Eigen::VectorXd & possible_state,
     const double kick_speed) const;
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // GENERATORS__MODEL_INPUT_GENERATOR_HPP_

--- a/ateam_vision_filter/src/generators/transmission_probability_generator.cpp
+++ b/ateam_vision_filter/src/generators/transmission_probability_generator.cpp
@@ -22,6 +22,9 @@
 
 #include "generators/generator_util.hpp"
 
+namespace ateam_vision_filter
+{
+
 void TransmissionProbabilityGenerator::update(
   const std::array<std::optional<Robot>, 16> & blue_robots,
   const std::array<std::optional<Robot>, 16> & yellow_robots,
@@ -117,3 +120,5 @@ double TransmissionProbabilityGenerator::get_transmission_probability(
   // Not possible to transition
   return 0.0;
 }
+
+}  // namespace ateam_vision_filter

--- a/ateam_vision_filter/src/generators/transmission_probability_generator.hpp
+++ b/ateam_vision_filter/src/generators/transmission_probability_generator.hpp
@@ -35,6 +35,9 @@
 #include "types/models.hpp"
 #include "types/robot.hpp"
 
+namespace ateam_vision_filter
+{
+
 class TransmissionProbabilityGenerator
 {
 public:
@@ -63,5 +66,7 @@ private:
   std::array<std::optional<Robot>, 16> yellow_robots;
   std::optional<Ball> ball;
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // GENERATORS__TRANSMISSION_PROBABILITY_GENERATOR_HPP_

--- a/ateam_vision_filter/src/types/ball.hpp
+++ b/ateam_vision_filter/src/types/ball.hpp
@@ -23,6 +23,9 @@
 
 #include <Eigen/Dense>
 
+namespace ateam_vision_filter
+{
+
 class Ball
 {
 public:
@@ -40,5 +43,7 @@ public:
     velocity(from_state.block(2, 0, 2, 1)),
     acceleration(from_state.block(4, 0, 2, 1)) {}
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // TYPES__BALL_HPP_

--- a/ateam_vision_filter/src/types/ball_measurement.hpp
+++ b/ateam_vision_filter/src/types/ball_measurement.hpp
@@ -23,6 +23,9 @@
 
 #include <Eigen/Dense>
 
+namespace ateam_vision_filter
+{
+
 struct BallMeasurement
 {
   Eigen::Vector2d position;
@@ -32,5 +35,7 @@ struct BallMeasurement
     position *= -1.0;
   }
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // TYPES__BALL_MEASUREMENT_HPP_

--- a/ateam_vision_filter/src/types/camera_measurement.hpp
+++ b/ateam_vision_filter/src/types/camera_measurement.hpp
@@ -27,6 +27,9 @@
 #include "types/ball_measurement.hpp"
 #include "types/robot_measurement.hpp"
 
+namespace ateam_vision_filter
+{
+
 struct CameraMeasurement
 {
   std::array<std::vector<RobotMeasurement>, 16> yellow_robots;
@@ -52,5 +55,7 @@ struct CameraMeasurement
     invert_array(ball);
   }
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // TYPES__CAMERA_MEASUREMENT_HPP_

--- a/ateam_vision_filter/src/types/models.hpp
+++ b/ateam_vision_filter/src/types/models.hpp
@@ -23,7 +23,7 @@
 
 #include <Eigen/Dense>
 
-namespace Models
+namespace ateam_vision_filter::Models
 {
 
 enum ModelType
@@ -188,6 +188,6 @@ const Eigen::MatrixXd R =
   0, 0, sigma_theta_squared).finished();
 
 }  // namespace Robot
-}  // namespace Models
+}  // namespace ateam_vision_filter::Models
 
 #endif  // TYPES__MODELS_HPP_

--- a/ateam_vision_filter/src/types/robot.hpp
+++ b/ateam_vision_filter/src/types/robot.hpp
@@ -23,6 +23,9 @@
 
 #include <Eigen/Dense>
 
+namespace ateam_vision_filter
+{
+
 class Robot
 {
 public:
@@ -43,5 +46,7 @@ public:
     velocity(from_state.block(3, 0, 2, 1)), omega(from_state(5, 0)),
     acceleration(from_state.block(6, 0, 2, 1)), alpha(from_state(8, 0)) {}
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // TYPES__ROBOT_HPP_

--- a/ateam_vision_filter/src/types/robot_measurement.hpp
+++ b/ateam_vision_filter/src/types/robot_measurement.hpp
@@ -24,6 +24,9 @@
 #include <Eigen/Dense>
 #include <angles/angles.h>
 
+namespace ateam_vision_filter
+{
+
 struct RobotMeasurement
 {
   Eigen::Vector2d position;
@@ -35,5 +38,7 @@ struct RobotMeasurement
     theta = angles::normalize_angle_positive(theta + M_PI);
   }
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // TYPES__ROBOT_MEASUREMENT_HPP_

--- a/ateam_vision_filter/src/world.cpp
+++ b/ateam_vision_filter/src/world.cpp
@@ -27,6 +27,9 @@
 #include <utility>
 #include <vector>
 
+namespace ateam_vision_filter
+{
+
 World::World()
 : model_input_generator(std::make_shared<ModelInputGenerator>()),
   transmission_probability_generator(std::make_shared<TransmissionProbabilityGenerator>()) {}
@@ -228,3 +231,5 @@ ateam_msgs::msg::VisionWorldState World::get_vision_world_state() const
 
   return world_state;
 }
+
+}  // namespace ateam_vision_filter

--- a/ateam_vision_filter/src/world.hpp
+++ b/ateam_vision_filter/src/world.hpp
@@ -36,6 +36,9 @@
 #include "types/camera_measurement.hpp"
 #include "types/robot.hpp"
 
+namespace ateam_vision_filter
+{
+
 class World
 {
 public:
@@ -81,5 +84,7 @@ private:
   std::shared_ptr<TransmissionProbabilityGenerator> transmission_probability_generator;
   std::map<CameraID, Camera> cameras;
 };
+
+}  // namespace ateam_vision_filter
 
 #endif  // WORLD_HPP_

--- a/ateam_vision_filter/test/camera_test.cpp
+++ b/ateam_vision_filter/test/camera_test.cpp
@@ -25,6 +25,8 @@
 
 #include "camera.hpp"
 
+using namespace ateam_vision_filter;
+
 TEST(Camera, getEstimateWithScore_ShouldReturnNullopt_WhenNoData)
 {
   std::shared_ptr<ModelInputGenerator> mig = std::make_shared<ModelInputGenerator>();

--- a/ateam_vision_filter/test/camera_test.cpp
+++ b/ateam_vision_filter/test/camera_test.cpp
@@ -25,7 +25,7 @@
 
 #include "camera.hpp"
 
-using namespace ateam_vision_filter;
+using namespace ateam_vision_filter;  // NOLINT(build/namespaces)
 
 TEST(Camera, getEstimateWithScore_ShouldReturnNullopt_WhenNoData)
 {

--- a/ateam_vision_filter/test/filters/interacting_multiple_model_filter_test.cpp
+++ b/ateam_vision_filter/test/filters/interacting_multiple_model_filter_test.cpp
@@ -29,6 +29,8 @@
 #include "generators/transmission_probability_generator.hpp"
 #include "types/models.hpp"
 
+using namespace ateam_vision_filter;
+
 TEST(InteractingMultipleModelFilter, getStateEstimate_ShouldReturnIntial_WhenNothingChanges)
 {
   KalmanFilter kf;

--- a/ateam_vision_filter/test/filters/interacting_multiple_model_filter_test.cpp
+++ b/ateam_vision_filter/test/filters/interacting_multiple_model_filter_test.cpp
@@ -29,7 +29,7 @@
 #include "generators/transmission_probability_generator.hpp"
 #include "types/models.hpp"
 
-using namespace ateam_vision_filter;
+using namespace ateam_vision_filter;  // NOLINT(build/namespaces)
 
 TEST(InteractingMultipleModelFilter, getStateEstimate_ShouldReturnIntial_WhenNothingChanges)
 {

--- a/ateam_vision_filter/test/filters/kalman_filter_test.cpp
+++ b/ateam_vision_filter/test/filters/kalman_filter_test.cpp
@@ -24,6 +24,8 @@
 
 #include <vector>
 
+using namespace ateam_vision_filter;
+
 TEST(KalmanFilter, getXHat_ShouldReturnIntial_WhenNoPredictOrUpdate)
 {
   KalmanFilter kf;

--- a/ateam_vision_filter/test/filters/kalman_filter_test.cpp
+++ b/ateam_vision_filter/test/filters/kalman_filter_test.cpp
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-using namespace ateam_vision_filter;
+using namespace ateam_vision_filter;  // NOLINT(build/namespaces)
 
 TEST(KalmanFilter, getXHat_ShouldReturnIntial_WhenNoPredictOrUpdate)
 {

--- a/ateam_vision_filter/test/filters/multiple_hypothesis_tracker_test.cpp
+++ b/ateam_vision_filter/test/filters/multiple_hypothesis_tracker_test.cpp
@@ -26,6 +26,8 @@
 #include <utility>
 #include <vector>
 
+using namespace ateam_vision_filter;
+
 TEST(MultipleHypothesisTracker, getStateEstimate_ShouldReturnNothing_WhenNoTracks)
 {
   MultipleHypothesisTracker mht;

--- a/ateam_vision_filter/test/filters/multiple_hypothesis_tracker_test.cpp
+++ b/ateam_vision_filter/test/filters/multiple_hypothesis_tracker_test.cpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-using namespace ateam_vision_filter;
+using namespace ateam_vision_filter;  // NOLINT(build/namespaces)
 
 TEST(MultipleHypothesisTracker, getStateEstimate_ShouldReturnNothing_WhenNoTracks)
 {

--- a/ateam_vision_filter/test/generators/model_input_generator_test.cpp
+++ b/ateam_vision_filter/test/generators/model_input_generator_test.cpp
@@ -28,6 +28,8 @@
 #include "types/models.hpp"
 #include "types/robot.hpp"
 
+using namespace ateam_vision_filter;
+
 TEST(ModelInputGenerator, getModelInput_ShouldReturnSmallerVelocity_WhenBallRollingFriction)
 {
   ModelInputGenerator mig;

--- a/ateam_vision_filter/test/generators/model_input_generator_test.cpp
+++ b/ateam_vision_filter/test/generators/model_input_generator_test.cpp
@@ -28,7 +28,7 @@
 #include "types/models.hpp"
 #include "types/robot.hpp"
 
-using namespace ateam_vision_filter;
+using namespace ateam_vision_filter;  // NOLINT(build/namespaces)
 
 TEST(ModelInputGenerator, getModelInput_ShouldReturnSmallerVelocity_WhenBallRollingFriction)
 {

--- a/ateam_vision_filter/test/generators/transmission_probability_generator_test.cpp
+++ b/ateam_vision_filter/test/generators/transmission_probability_generator_test.cpp
@@ -28,7 +28,7 @@
 #include "types/models.hpp"
 #include "types/robot.hpp"
 
-using namespace ateam_vision_filter;
+using namespace ateam_vision_filter;  // NOLINT(build/namespaces)
 
 TEST(
   TransmissionProbabilityGenerator,

--- a/ateam_vision_filter/test/generators/transmission_probability_generator_test.cpp
+++ b/ateam_vision_filter/test/generators/transmission_probability_generator_test.cpp
@@ -28,6 +28,8 @@
 #include "types/models.hpp"
 #include "types/robot.hpp"
 
+using namespace ateam_vision_filter;
+
 TEST(
   TransmissionProbabilityGenerator,
   getTransmissionProbability_ShouldReturn085_WhenSameModelToFrom)

--- a/ateam_vision_filter/test/world_test.cpp
+++ b/ateam_vision_filter/test/world_test.cpp
@@ -25,7 +25,7 @@
 
 #include "world.hpp"
 
-using namespace ateam_vision_filter;
+using namespace ateam_vision_filter;  // NOLINT(build/namespaces)
 
 TEST(World, getEstimate_ShouldReturnNullopt_WhenNoData)
 {

--- a/ateam_vision_filter/test/world_test.cpp
+++ b/ateam_vision_filter/test/world_test.cpp
@@ -25,6 +25,8 @@
 
 #include "world.hpp"
 
+using namespace ateam_vision_filter;
+
 TEST(World, getEstimate_ShouldReturnNullopt_WhenNoData)
 {
   World world;


### PR DESCRIPTION
Intellisense in vs code was being annoying when working on kenobi because it couldn't tell the difference between kenobi's types (ie. World, Robot, etc.) and vision filter's types since they had the same name and the vision filter code didn't define a namespace. This PR puts everything in the vision filter behind a namespace. This makes no functional changes to the filter itself.