### PR TITLE
Fixes incorrectly formatted remap rules in physical bringup.

### DIFF
--- a/ateam_bringup/launch/bringup_physical.launch.py
+++ b/ateam_bringup/launch/bringup_physical.launch.py
@@ -28,7 +28,8 @@ from ateam_bringup.substitutions import PackageLaunchFileSubstitution
 
 def remap_indexed_topics(pattern_pairs):
     return [
-        [(pattern_from+str(i), pattern_to+str(i)) for i in range(16)]
+        (pattern_from + str(i), pattern_to + str(i))
+        for i in range(16)
         for pattern_from, pattern_to in pattern_pairs
     ]
 


### PR DESCRIPTION
Remap rules need to be a list of tuples but were instead a list of list of tuples after the relatively recent refactoring of this code. This PR collapses the list comprehension to put all remap tuples in one list.