### PR TITLE
STP Parameters

### DIFF
--- a/ateam_kenobi/src/play_selector.cpp
+++ b/ateam_kenobi/src/play_selector.cpp
@@ -35,6 +35,9 @@ PlaySelector::PlaySelector(rclcpp::Node & node)
   using namespace ateam_kenobi::plays;  // NOLINT(build/namespaces)
   stp::Options stp_options;
   stp_options.logger = node.get_logger();
+  stp_options.parameter_interface = stp::ParameterInterface(
+    "stp_parameters",
+    node.get_node_parameters_interface());
   halt_play_ = addPlay<HaltPlay>(stp_options);
   addPlay<TestPlay>(stp_options);
   addPlay<StopPlay>(stp_options);

--- a/ateam_kenobi/src/play_selector.hpp
+++ b/ateam_kenobi/src/play_selector.hpp
@@ -60,6 +60,7 @@ private:
   {
     stp_options.overlays = visualization::Overlays(PlayType::kPlayName);
     stp_options.logger = stp_options.logger.get_child(PlayType::kPlayName);
+    stp_options.parameter_interface = stp_options.parameter_interface.getChild(PlayType::kPlayName);
     auto play = std::make_shared<PlayType>(stp_options);
     plays_.push_back(play);
     return play;

--- a/ateam_kenobi/src/plays/test_kick_play.hpp
+++ b/ateam_kenobi/src/plays/test_kick_play.hpp
@@ -39,7 +39,9 @@ public:
   : stp::Play(kPlayName, stp_options),
     pivot_kick_skill_(createChild<skills::PivotKick>("pivot_kick")),
     line_kick_skill_(createChild<skills::LineKick>("line_kick"))
-  {}
+  {
+    getParamInterface().declareParameter(kUsePivotKickParam, true);
+  }
 
   void reset() override {}
 
@@ -59,6 +61,8 @@ public:
     line_kick_skill_.setTargetPoint(target);
     pivot_kick_skill_.setTargetPoint(target);
 
+    const auto use_pivot_kick = getParamInterface().getParameter<bool>(kUsePivotKickParam);
+
     motion_commands[robot.id] =
       use_pivot_kick ? pivot_kick_skill_.runFrame(world, robot) : line_kick_skill_.runFrame(
       world,
@@ -67,7 +71,7 @@ public:
   }
 
 private:
-  bool use_pivot_kick = true;  // TODO(barulicm) Make this a parameter
+  char const * const kUsePivotKickParam = "use_pivot_kick";
   skills::PivotKick pivot_kick_skill_;
   skills::LineKick line_kick_skill_;
 };

--- a/ateam_kenobi/src/stp/base.hpp
+++ b/ateam_kenobi/src/stp/base.hpp
@@ -27,6 +27,7 @@
 #include <nlohmann/json.hpp>
 #include <rclcpp/logger.hpp>
 #include "visualization/overlays.hpp"
+#include "parameter_interface.hpp"
 
 namespace ateam_kenobi::stp
 {
@@ -37,6 +38,7 @@ struct Options
   visualization::Overlays overlays;
   nlohmann::json play_info;
   rclcpp::Logger logger = rclcpp::get_logger("kenobi_stp_default");
+  ParameterInterface parameter_interface;
 };
 
 class Base
@@ -52,7 +54,8 @@ public:
   : name_(options.name),
     overlays_(options.overlays),
     play_info_(options.play_info),
-    logger_(options.logger)
+    logger_(options.logger),
+    parameter_interface_(options.parameter_interface)
   {
   }
 
@@ -60,7 +63,8 @@ public:
   : name_(name),
     overlays_(options.overlays),
     play_info_(options.play_info),
-    logger_(options.logger)
+    logger_(options.logger),
+    parameter_interface_(options.parameter_interface)
   {
   }
 
@@ -73,7 +77,8 @@ public:
       child_name,
       overlays_.getChild(child_name),
       play_info_[child_name],
-      logger_.get_child(child_name)
+      logger_.get_child(child_name),
+      parameter_interface_.getChild(child_name)
     };
     return ChildType(options, std::forward<Args>(args)...);
   }
@@ -108,11 +113,17 @@ public:
     return logger_;
   }
 
+  ParameterInterface & getParamInterface()
+  {
+    return parameter_interface_;
+  }
+
 private:
   std::string name_;
   visualization::Overlays overlays_;
   nlohmann::json play_info_;
   rclcpp::Logger logger_;
+  ParameterInterface parameter_interface_;
 };
 
 }  // namespace ateam_kenobi::stp

--- a/ateam_kenobi/src/stp/parameter_interface.hpp
+++ b/ateam_kenobi/src/stp/parameter_interface.hpp
@@ -1,0 +1,120 @@
+// Copyright 2024 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#ifndef STP__PARAMETER_INTERFACE_HPP_
+#define STP__PARAMETER_INTERFACE_HPP_
+
+#include <string>
+#include <rclcpp/node_interfaces/node_parameters_interface.hpp>
+
+namespace ateam_kenobi::stp
+{
+
+struct UninitializedParameterInterface : public std::runtime_error
+{
+  UninitializedParameterInterface()
+  : std::runtime_error("ParameterInterface used before being properly initialized.") {}
+};
+
+class ParameterInterface
+{
+public:
+  /**
+   * @brief Default constructor
+   * @note This constructor does not give you a usable parameter interface. It is included to allow
+   * for temporary, paritially initialized instances while the system is getting set up. Make sure
+   * to use the full parameterized constructor below before calling any member functions on this
+   * object.
+   */
+  ParameterInterface() = default;
+
+  ParameterInterface(
+    std::string param_namespace,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr ros_interface)
+  : namespace_(param_namespace),
+    ros_interface_(ros_interface) {}
+
+  const std::string & getNamespace()
+  {
+    return namespace_;
+  }
+
+  std::string getNamespacedName(const std::string & name)
+  {
+    return namespace_ + "." + name;
+  }
+
+  ParameterInterface getChild(const std::string & name)
+  {
+    return ParameterInterface(getNamespacedName(name), ros_interface_);
+  }
+
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr addSetParameterCallback(
+    rclcpp::node_interfaces::NodeParametersInterface::OnParametersSetCallbackType callback)
+  {
+    throwIfUninitialized();
+    return ros_interface_->add_on_set_parameters_callback(callback);
+  }
+
+  void removeSetParameterCallback(rclcpp::node_interfaces::OnSetParametersCallbackHandle * handle)
+  {
+    throwIfUninitialized();
+    ros_interface_->remove_on_set_parameters_callback(handle);
+  }
+
+  bool hasParameter(const std::string & name)
+  {
+    throwIfUninitialized();
+    return ros_interface_->has_parameter(getNamespacedName(name));
+  }
+
+  template<typename ParameterT>
+  ParameterT declareParameter(const std::string & name, const ParameterT & default_value)
+  {
+    throwIfUninitialized();
+
+    return ros_interface_->declare_parameter(
+      getNamespacedName(name),
+      rclcpp::ParameterValue(default_value)).get<ParameterT>();
+  }
+
+  template<typename ParameterT>
+  ParameterT getParameter(const std::string & name)
+  {
+    throwIfUninitialized();
+    return ros_interface_->get_parameter(getNamespacedName(name)).get_value<ParameterT>();
+  }
+
+private:
+  std::string namespace_;
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr ros_interface_;
+
+  void throwIfUninitialized()
+  {
+    if (!ros_interface_) {
+      throw UninitializedParameterInterface();
+    }
+  }
+};
+
+}  // namespace ateam_kenobi::stp
+
+#endif  // STP__PARAMETER_INTERFACE_HPP_


### PR DESCRIPTION
Adds infrastructure to support ROS parameters in STP objects.

Parameters in this system are namespaced to their part of the STP tree, rooted with "stp_parameters".

So, for example, the only parameter added in this PR is named `stp_parameters.TestKickPlay.use_pivot_kick`, and corresponds to this tree:

- stp root
  - TestKickPlay
    - use_pivot_kick

