### PR TITLE
Changes joystick repeat rate and deadzone.

### DIFF
--- a/ateam_joystick_control/launch/joystick_controller.launch.xml
+++ b/ateam_joystick_control/launch/joystick_controller.launch.xml
@@ -1,7 +1,10 @@
 <launch>
   <arg name="joy_config_file" default="$(find-pkg-share ateam_joystick_control)/config/xbox_joy_config.yaml"/>
 
-  <node name="joystick_node" pkg="joy" exec="joy_node"/>
+  <node name="joystick_node" pkg="joy" exec="joy_node">
+    <param name="deadzone" value="0.1"/>
+    <param name="autorepeat_rate" value="60.0"/>
+  </node>
   <node name="joystick_control_node" pkg="ateam_joystick_control" exec="joystick_control_node">
     <param from="$(var joy_config_file)"/>
     <param from="$(find-pkg-share ateam_joystick_control)/config/common_params.yaml"/>


### PR DESCRIPTION
Autorepeat set to 60 to match Kenobi loop rate and solve occasional timeout problem.
Deadzone increased to 0.1 to reflect actual physical deadzone of our xbox controllers.

Turns out the joy node does a "smooth deadzone" where it shifts the 0-1 scaling of the joystick to start at the end of the deadzone. You can get arbitrarily small numbers from the joystick, but it doesn't leave 0 until it leaves the deadzone.