### PR TITLE
Fixes race condition causing segfaults on vision bridge startup.

### DIFF
--- a/ateam_ssl_vision_bridge/src/ssl_vision_bridge_node.cpp
+++ b/ateam_ssl_vision_bridge/src/ssl_vision_bridge_node.cpp
@@ -41,6 +41,9 @@ class SSLVisionBridgeNode : public rclcpp::Node
 public:
   explicit SSLVisionBridgeNode(const rclcpp::NodeOptions & options)
   : rclcpp::Node("ssl_vision_bridge", options),
+    vision_publisher_(create_publisher<ssl_league_msgs::msg::VisionWrapper>(
+        std::string(Topics::
+        kVisionMessages), rclcpp::SystemDefaultsQoS())),
     multicast_receiver_(
       declare_parameter<std::string>("ssl_vision_ip", "224.5.23.2"),
       declare_parameter<int>("ssl_vision_port", 10020),
@@ -48,9 +51,6 @@ public:
       declare_parameter<std::string>("net_interface_address", "10.191.12.33"))
   {
     SET_ROS_PROTOBUF_LOG_HANDLER("ssl_vision_bridge.protobuf");
-    vision_publisher_ = create_publisher<ssl_league_msgs::msg::VisionWrapper>(
-      std::string(Topics::kVisionMessages),
-      rclcpp::SystemDefaultsQoS());
   }
 
 private:


### PR DESCRIPTION
Our vision bridge node has a race condition that can sometimes cause it to segfault during startup.

In the original code, `vision_publisher_` is initialized to a non-null value in the constructor body after `multicast_receiver_`, which was initialized in the member initialization list. If a multicast packet is received before `vision_publisher_` is initialized, the attempt to call `publish` in the multicast callback will cause a segfault as it tries to dereference the null publisher shared pointer.

This PR moves the initialization of `vision_publisher_` into the member initialization list so it is initialized before `multicast_receiver_`.

Note: this fix is already checked into our comp branch, but it seemed important enough to get it merged into main ASAP.