### PR TITLE
Imports comp changes for ateam_bringup.

### DIFF
--- a/ateam_bringup/launch/autonomy.launch.xml
+++ b/ateam_bringup/launch/autonomy.launch.xml
@@ -3,6 +3,7 @@
   <arg name="ssl_vision_port" default="10006"/>
   <arg name="ssl_vision_interface_address" default="10.193.15.132"/>
   <arg name="use_world_velocities" default="false"/>
+  <arg name="use_emulated_ballsense" default="false"/>
   <arg name="team_name" default="A-Team"/>
 
   <node name="ssl_vision_bridge" pkg="ateam_ssl_vision_bridge" exec="ssl_vision_bridge_node" respawn="True">
@@ -14,8 +15,12 @@
   <node name="vision_filter" pkg="ateam_vision_filter" exec="ateam_vision_filter_node" respawn="True">
     <param name="gc_team_name" value="$(var team_name)"/>
   </node>
+  <node name="field_manager" pkg="ateam_field_manager" exec="ateam_field_manager_node" respawn="True">
+    <param name="gc_team_name" value="$(var team_name)"/>
+  </node>
   <node name="kenobi_node" pkg="ateam_kenobi" exec="ateam_kenobi_node" respawn="True">
     <param name="use_world_velocities" value="$(var use_world_velocities)"/>
+    <param name="use_emulated_ballsense" value="$(var use_emulated_ballsense)"/>
     <param name="gc_team_name" value="$(var team_name)"/>
   </node>
 </launch>

--- a/ateam_bringup/launch/bringup_physical.launch.py
+++ b/ateam_bringup/launch/bringup_physical.launch.py
@@ -19,9 +19,10 @@
 # THE SOFTWARE.
 
 import launch
+from launch.conditions import IfCondition, UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch.launch_description_sources import FrontendLaunchDescriptionSource
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, GroupAction
 from launch_ros.actions import Node
 from ateam_bringup.substitutions import PackageLaunchFileSubstitution
 
@@ -37,18 +38,31 @@ def remap_indexed_topics(pattern_pairs):
 def generate_launch_description():
     return launch.LaunchDescription([
         # Marietta IPs
-        DeclareLaunchArgument("vision_interface_address", default_value="172.16.1.10"),
-        DeclareLaunchArgument("gc_interface_address", default_value="172.16.1.10"),
-        DeclareLaunchArgument("gc_server_address", default_value="172.16.1.52"),
-        DeclareLaunchArgument("radio_interface_address", default_value="172.16.1.10"),
-
-        # Competition IPs
-        # DeclareLaunchArgument("vision_interface_address", default_value="10.193.15.132"),
-        # DeclareLaunchArgument("gc_interface_address", default_value="10.193.15.132"),
-        # DeclareLaunchArgument("gc_server_address", default_value="10.193.12.10"),
+        # DeclareLaunchArgument("vision_interface_address", default_value="172.16.1.10"),
+        # DeclareLaunchArgument("gc_interface_address", default_value="172.16.1.10"),
+        # DeclareLaunchArgument("gc_server_address", default_value="172.16.1.52"),
         # DeclareLaunchArgument("radio_interface_address", default_value="172.16.1.10"),
 
+        # Competition IPs
+        DeclareLaunchArgument("vision_interface_address", default_value="192.168.1.40"),
+        DeclareLaunchArgument("radio_interface_address", default_value="172.16.1.10"),
         DeclareLaunchArgument("team_name", default_value="A-Team"),
+        DeclareLaunchArgument("use_local_gc", default_value="False"),
+
+        GroupAction(
+            condition=IfCondition(LaunchConfiguration("use_local_gc")),
+            scoped=False,
+            actions=[
+                DeclareLaunchArgument("gc_interface_address", default_value="172.17.0.1"),
+                DeclareLaunchArgument("gc_server_address", default_value="172.17.0.2"),
+            ]),
+        GroupAction(
+            condition=UnlessCondition(LaunchConfiguration("use_local_gc")),
+            scoped=False,
+            actions=[
+                DeclareLaunchArgument("gc_interface_address", default_value="192.168.1.40"),
+                DeclareLaunchArgument("gc_server_address", default_value="192.168.0.114"),
+            ]),
 
         IncludeLaunchDescription(
             FrontendLaunchDescriptionSource(

--- a/ateam_bringup/launch/bringup_simulation.launch.py
+++ b/ateam_bringup/launch/bringup_simulation.launch.py
@@ -58,8 +58,8 @@ def generate_launch_description():
                 PackageLaunchFileSubstitution("ateam_bringup",
                                               "game_controller_nodes.launch.xml")),
             launch_arguments={
-                "net_interface_address": "",
-                "gc_ip_address": "127.0.0.1",
+                "net_interface_address": "172.17.0.1",
+                "gc_ip_address": "172.17.0.2",
                 "team_name": LaunchConfiguration("team_name")
             }.items()
         ),
@@ -71,7 +71,8 @@ def generate_launch_description():
             launch_arguments={
                 "ssl_vision_interface_address": "",
                 "ssl_vision_port": "10020",
-                "team_name": LaunchConfiguration("team_name")
+                "team_name": LaunchConfiguration("team_name"),
+                "use_emulated_ballsense": "True"
             }.items()
         ),
 

--- a/ateam_bringup/launch/joystick_only_stack.launch.xml
+++ b/ateam_bringup/launch/joystick_only_stack.launch.xml
@@ -1,4 +1,6 @@
 <launch>
   <include file="$(find-pkg-share ateam_joystick_control)/launch/joystick_controller.launch.xml"/>
-  <node name="radio_bridge" pkg="ateam_radio_bridge" exec="radio_bridge_node" respawn="True"/>
+  <node name="radio_bridge" pkg="ateam_radio_bridge" exec="radio_bridge_node" respawn="True">
+    <param name="default_team_color" value="blue"/>
+  </node>
 </launch>

--- a/ateam_bringup/launch/ssl_game_controller.launch.xml
+++ b/ateam_bringup/launch/ssl_game_controller.launch.xml
@@ -1,6 +1,7 @@
 <launch>
   <arg name="data_directory" default="$(find-pkg-share ateam_bringup)/data" />
   <arg name="expose_gc_to_net" default="false" />
-  <executable cmd="docker run --net host --rm robocupssl/ssl-game-controller" output="screen" respawn="True"/>
+  <executable unless="$(var expose_gc_to_net)" cmd="docker run -p 8081:8081 --rm robocupssl/ssl-game-controller -address :8081" output="screen" respawn="True"/>
+  <executable if="$(var expose_gc_to_net)" cmd="docker run --net host--rm robocupssl/ssl-game-controller" output="screen" respawn="True"/>
   <executable if="$(var expose_gc_to_net)" cmd="socat tcp-listen:8082,reuseaddr,fork tcp:127.0.0.1:8081" />
 </launch>


### PR DESCRIPTION
* Adds use_emulated_ballsense parameter
* Adds field_manager to autonomy bringup (will break things until the field_manager is merged)
* Updates comp IPs from Einhoven
* Adds use_local_gc parameter
* Makes simulation bringup use only local GC
* Tweaks handling of expose_gc_to_net