### PR TITLE
Refactors robot feedback topic names.

### DIFF
--- a/ateam_bringup/launch/bringup_physical.launch.py
+++ b/ateam_bringup/launch/bringup_physical.launch.py
@@ -100,7 +100,8 @@ def generate_launch_description():
             respawn=True,
             remappings=remap_indexed_topics([
                 ('~/robot_motion_commands/robot', '/robot_motion_commands/robot'),
-                ('~/robot_feedback/robot', '/robot_feedback/robot')
+                ('~/robot_feedback/status/robot', '/robot_feedback/status/robot'),
+                ('~/robot_feedback/motion/robot', '/robot_feedback/motion/robot')
             ])
         )
     ])

--- a/ateam_bringup/launch/joystick_only_stack.launch.py
+++ b/ateam_bringup/launch/joystick_only_stack.launch.py
@@ -1,0 +1,59 @@
+# Copyright 2021 A Team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from ateam_bringup.substitutions import PackageLaunchFileSubstitution
+import launch
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import FrontendLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def remap_indexed_topics(pattern_pairs):
+    return [
+        (pattern_from + str(i), pattern_to + str(i))
+        for i in range(16)
+        for pattern_from, pattern_to in pattern_pairs
+    ]
+
+
+def generate_launch_description():
+    return launch.LaunchDescription([
+        IncludeLaunchDescription(
+            FrontendLaunchDescriptionSource(
+                PackageLaunchFileSubstitution('ateam_joystick_control',
+                                              'joystick_controller.launch.xml')
+            )
+        ),
+        Node(
+            package='ateam_radio_bridge',
+            executable='radio_bridge_node',
+            name='radio_bridge',
+            parameters=[{
+                'default_team_color': 'blue'
+            }],
+            respawn=True,
+            remappings=remap_indexed_topics([
+                ('~/robot_motion_commands/robot', '/robot_motion_commands/robot'),
+                ('~/robot_feedback/status/robot', '/robot_feedback/status/robot'),
+                ('~/robot_feedback/motion/robot', '/robot_feedback/motion/robot')
+            ])
+        )
+    ])

--- a/ateam_bringup/launch/joystick_only_stack.launch.py
+++ b/ateam_bringup/launch/joystick_only_stack.launch.py
@@ -22,7 +22,6 @@ from ateam_bringup.substitutions import PackageLaunchFileSubstitution
 import launch
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import FrontendLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 

--- a/ateam_bringup/launch/joystick_only_stack.launch.xml
+++ b/ateam_bringup/launch/joystick_only_stack.launch.xml
@@ -1,6 +1,0 @@
-<launch>
-  <include file="$(find-pkg-share ateam_joystick_control)/launch/joystick_controller.launch.xml"/>
-  <node name="radio_bridge" pkg="ateam_radio_bridge" exec="radio_bridge_node" respawn="True">
-    <param name="default_team_color" value="blue"/>
-  </node>
-</launch>

--- a/ateam_common/include/ateam_common/topic_names.hpp
+++ b/ateam_common/include/ateam_common/topic_names.hpp
@@ -30,7 +30,8 @@ constexpr std::string_view kVisionMessages = "/vision_messages";  // Raw vision 
 constexpr std::string_view kRefereeMessages = "/referee_messages";  // Raw ref protobufs
 
 // Input from robots
-constexpr std::string_view kRobotFeedbackPrefix = "/robot_feedback/robot";
+constexpr std::string_view kRobotFeedbackPrefix = "/robot_feedback/status/robot";
+constexpr std::string_view kRobotMotionFeedbackPrefix = "/robot_feedback/motion/robot";
 
 // Output from vision filter
 constexpr std::string_view kBall = "/ball";

--- a/ateam_joystick_control/launch/joystick_controller.launch.xml
+++ b/ateam_joystick_control/launch/joystick_controller.launch.xml
@@ -8,7 +8,7 @@
   <node name="joystick_control_node" pkg="ateam_joystick_control" exec="joystick_control_node">
     <param from="$(var joy_config_file)"/>
     <param from="$(find-pkg-share ateam_joystick_control)/config/common_params.yaml"/>
-    <param name="command_topic_template" value="/radio_bridge/robot_motion_commands/robot{}" />
+    <param name="command_topic_template" value="/robot_motion_commands/robot{}" />
     <remap from="~/joy" to="/joy"/>
   </node>
 </launch>

--- a/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -59,7 +59,7 @@ public:
       declare_parameter<uint16_t>("discovery_port", 42069),
       std::bind(&RadioBridgeNode::DiscoveryMessageCallback, this, std::placeholders::_1,
       std::placeholders::_2, std::placeholders::_3, std::placeholders::_4),
-      declare_parameter<std::string>("net_interface_address", "192.168.0.88")),
+      declare_parameter<std::string>("net_interface_address", "172.16.1.10")),
     firmware_parameter_server_(*this, connections_)
   {
     ateam_common::indexed_topic_helpers::create_indexed_subscribers<ateam_msgs::msg::RobotMotionCommand>(

--- a/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -59,7 +59,7 @@ public:
       declare_parameter<uint16_t>("discovery_port", 42069),
       std::bind(&RadioBridgeNode::DiscoveryMessageCallback, this, std::placeholders::_1,
       std::placeholders::_2, std::placeholders::_3, std::placeholders::_4),
-      declare_parameter<std::string>("net_interface_address", "172.16.1.10")),
+      declare_parameter<std::string>("net_interface_address", "192.168.0.88")),
     firmware_parameter_server_(*this, connections_)
   {
     ateam_common::indexed_topic_helpers::create_indexed_subscribers<ateam_msgs::msg::RobotMotionCommand>(
@@ -71,13 +71,13 @@ public:
 
     ateam_common::indexed_topic_helpers::create_indexed_publishers<ateam_msgs::msg::RobotFeedback>(
       feedback_publishers_,
-      "~/robot_feedback/robot",
+      "~/robot_feedback/status/robot",
       rclcpp::SystemDefaultsQoS(),
       this);
 
     ateam_common::indexed_topic_helpers::create_indexed_publishers<ateam_msgs::msg::RobotMotionFeedback>(
       motion_feedback_publishers_,
-      "~/robot_motion_feedback/robot",
+      "~/robot_feedback/motion/robot",
       rclcpp::SystemDefaultsQoS(),
       this);
 

--- a/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
+++ b/ateam_radio_bridge/test/launch_tests/radio_discovery_test.py
@@ -71,7 +71,7 @@ class TestRadioBridgeNode(unittest.TestCase):
     def setUp(self):
         self.feedback_sub = self.node.create_subscription(
             ateam_msgs.msg.RobotFeedback,
-            "/radio_bridge/robot_feedback/robot0",
+            "/radio_bridge/robot_feedback/status/robot0",
             self.feedback_callback_0,
             1,
         )

--- a/ateam_ui/src/src/state.ts
+++ b/ateam_ui/src/src/state.ts
@@ -410,12 +410,12 @@ export class AppState {
 
             let robotStatusTopic = new ROSLIB.Topic({
                 ros: this.ros,
-                name: '/robot_feedback/robot' + i,
+                name: '/robot_feedback/status/robot' + i,
                 messageType: 'ateam_msgs/msg/RobotFeedback'
             });
 
             robotStatusTopic.subscribe(this.getRobotStatusCallback(i));
-            this.subscriptions['/robot_feedback/robot' + i] = robotStatusTopic;
+            this.subscriptions['/robot_feedback/status/robot' + i] = robotStatusTopic;
         }
 
         // Set up overlay subscriber


### PR DESCRIPTION
Fixes #277

Refactors our feedback topic names for better usability in tools like plotjuggler. This puts status and motion feedback topics under the common "/robot_feedback" top level namespace.

This PR also makes the joystick only launch setup use the same topic names as the full stack bringup.