### PR TITLE
Fixes game controller docker commands and cleans up bringup GC configs.

### DIFF
--- a/ateam_bringup/launch/bringup_physical.launch.py
+++ b/ateam_bringup/launch/bringup_physical.launch.py
@@ -20,8 +20,13 @@
 
 from ateam_bringup.substitutions import PackageLaunchFileSubstitution
 import launch
-from launch.actions import DeclareLaunchArgument, GroupAction, IncludeLaunchDescription
-from launch.conditions import IfCondition, UnlessCondition
+from launch.actions import (
+    DeclareLaunchArgument,
+    GroupAction,
+    IncludeLaunchDescription,
+    SetLaunchConfiguration,
+)
+from launch.conditions import IfCondition
 from launch.launch_description_sources import FrontendLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
@@ -38,14 +43,16 @@ def remap_indexed_topics(pattern_pairs):
 def generate_launch_description():
     return launch.LaunchDescription([
         # Marietta IPs
-        # DeclareLaunchArgument('vision_interface_address', default_value='172.16.1.10'),
-        # DeclareLaunchArgument('gc_interface_address', default_value='172.16.1.10'),
-        # DeclareLaunchArgument('gc_server_address', default_value='172.16.1.52'),
-        # DeclareLaunchArgument('radio_interface_address', default_value='172.16.1.10'),
-
-        # Competition IPs
-        DeclareLaunchArgument('vision_interface_address', default_value='192.168.1.40'),
+        DeclareLaunchArgument('vision_interface_address', default_value='172.16.1.10'),
         DeclareLaunchArgument('radio_interface_address', default_value='172.16.1.10'),
+        DeclareLaunchArgument('gc_interface_address', default_value='172.16.1.10'),
+        DeclareLaunchArgument('gc_server_address', default_value='172.16.1.52'),
+        # Competition IPs
+        # DeclareLaunchArgument('vision_interface_address', default_value='192.168.1.40'),
+        # DeclareLaunchArgument('radio_interface_address', default_value='172.16.1.10'),
+        # DeclareLaunchArgument('gc_interface_address', default_value='192.168.1.40'),
+        # DeclareLaunchArgument('gc_server_address', default_value='192.168.0.114'),
+
         DeclareLaunchArgument('team_name', default_value='A-Team'),
         DeclareLaunchArgument('use_local_gc', default_value='False'),
 
@@ -53,15 +60,8 @@ def generate_launch_description():
             condition=IfCondition(LaunchConfiguration('use_local_gc')),
             scoped=False,
             actions=[
-                DeclareLaunchArgument('gc_interface_address', default_value='172.17.0.1'),
-                DeclareLaunchArgument('gc_server_address', default_value='172.17.0.2'),
-            ]),
-        GroupAction(
-            condition=UnlessCondition(LaunchConfiguration('use_local_gc')),
-            scoped=False,
-            actions=[
-                DeclareLaunchArgument('gc_interface_address', default_value='192.168.1.40'),
-                DeclareLaunchArgument('gc_server_address', default_value='192.168.0.114'),
+                SetLaunchConfiguration('gc_interface_address', '172.17.0.1'),
+                SetLaunchConfiguration('gc_server_address', '172.17.0.2'),
             ]),
 
         IncludeLaunchDescription(

--- a/ateam_bringup/launch/ssl_game_controller.launch.xml
+++ b/ateam_bringup/launch/ssl_game_controller.launch.xml
@@ -1,7 +1,9 @@
 <launch>
   <arg name="data_directory" default="$(find-pkg-share ateam_bringup)/data" />
   <arg name="expose_gc_to_net" default="false" />
-  <executable unless="$(var expose_gc_to_net)" cmd="docker run -p 8081:8081 --rm robocupssl/ssl-game-controller -address :8081" output="screen" respawn="True"/>
-  <executable if="$(var expose_gc_to_net)" cmd="docker run --net host--rm robocupssl/ssl-game-controller" output="screen" respawn="True"/>
+
+  <executable unless="$(var expose_gc_to_net)" cmd="docker run --rm -p 8081:8081 -p 10007:10007 -p 10008:10008 -p 10011:10011 robocupssl/ssl-game-controller -address :8081" output="screen" respawn="True"/>
+  
+  <executable if="$(var expose_gc_to_net)" cmd="docker run --net host --rm robocupssl/ssl-game-controller" output="screen" respawn="True"/>
   <executable if="$(var expose_gc_to_net)" cmd="socat tcp-listen:8082,reuseaddr,fork tcp:127.0.0.1:8081" />
 </launch>


### PR DESCRIPTION
Fixes #276

* Adds missing port mappings to local GC run command
* Fixes typo in exposed GC run command
* Switches physical bringup defaults back to Marietta IPs
* Simplifies `use_local_gc` implementation

This doesn't fix the issue where the GC docker container doesn't respond to SIGINT. Still not sure what's going on there.