### PR TITLE
Automatic network management

### DIFF
--- a/ateam_bringup/launch/autonomy.launch.xml
+++ b/ateam_bringup/launch/autonomy.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <arg name="ssl_vision_ip" default="224.5.23.2"/>
   <arg name="ssl_vision_port" default="10006"/>
-  <arg name="ssl_vision_interface_address" default="10.193.15.132"/>
+  <arg name="ssl_vision_interface_address" default=""/>
   <arg name="use_world_velocities" default="false"/>
   <arg name="use_emulated_ballsense" default="false"/>
   <arg name="team_name" default="A-Team"/>

--- a/ateam_bringup/launch/bringup_physical.launch.py
+++ b/ateam_bringup/launch/bringup_physical.launch.py
@@ -41,7 +41,7 @@ def generate_launch_description():
         DeclareLaunchArgument('vision_interface_address', default_value=''),
         DeclareLaunchArgument('radio_interface_address', default_value=''),
         DeclareLaunchArgument('gc_interface_address', default_value=''),
-        DeclareLaunchArgument('gc_server_address', default_value='127.0.0.1'),
+        DeclareLaunchArgument('gc_server_address', default_value=''),
 
         DeclareLaunchArgument('team_name', default_value='A-Team'),
         DeclareLaunchArgument('use_local_gc', default_value='False'),

--- a/ateam_bringup/launch/bringup_physical.launch.py
+++ b/ateam_bringup/launch/bringup_physical.launch.py
@@ -37,15 +37,12 @@ def remap_indexed_topics(pattern_pairs):
 
 def generate_launch_description():
     return launch.LaunchDescription([
-        # Marietta IPs
-        # DeclareLaunchArgument('vision_interface_address', default_value='172.16.1.10'),
-        # DeclareLaunchArgument('gc_interface_address', default_value='172.16.1.10'),
-        # DeclareLaunchArgument('gc_server_address', default_value='172.16.1.52'),
-        # DeclareLaunchArgument('radio_interface_address', default_value='172.16.1.10'),
+        # IP Overrides
+        DeclareLaunchArgument('vision_interface_address', default_value=''),
+        DeclareLaunchArgument('radio_interface_address', default_value=''),
+        DeclareLaunchArgument('gc_interface_address', default_value=''),
+        DeclareLaunchArgument('gc_server_address', default_value='127.0.0.1'),
 
-        # Competition IPs
-        DeclareLaunchArgument('vision_interface_address', default_value='192.168.1.40'),
-        DeclareLaunchArgument('radio_interface_address', default_value='172.16.1.10'),
         DeclareLaunchArgument('team_name', default_value='A-Team'),
         DeclareLaunchArgument('use_local_gc', default_value='False'),
 

--- a/ateam_bringup/launch/game_controller_nodes.launch.xml
+++ b/ateam_bringup/launch/game_controller_nodes.launch.xml
@@ -1,6 +1,6 @@
 <launch>
-  <arg name="gc_ip_address" default="10.193.12.10"/>
-  <arg name="net_interface_address" default="10.193.15.132"/>
+  <arg name="gc_ip_address" default=""/>
+  <arg name="net_interface_address" default=""/>
   <arg name="team_name" default="A-Team"/>
   <node name="gc_multicast_bridge_node" pkg="ateam_game_controller_bridge" exec="gc_multicast_bridge_node" respawn="True">
     <param name="net_interface_address" value="$(var net_interface_address)"/>

--- a/ateam_common/CMakeLists.txt
+++ b/ateam_common/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(ssl_league_msgs REQUIRED)
 add_library(${PROJECT_NAME} SHARED
   src/assignment.cpp
   src/bi_directional_udp.cpp
+  src/get_ip_addresses.cpp
   src/multicast_receiver.cpp
   src/parameters.cpp
   src/status.cpp

--- a/ateam_common/include/ateam_common/get_ip_addresses.hpp
+++ b/ateam_common/include/ateam_common/get_ip_addresses.hpp
@@ -1,0 +1,36 @@
+// Copyright 2024 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ATEAM_COMMON__GET_IP_ADDRESSES_HPP_
+#define ATEAM_COMMON__GET_IP_ADDRESSES_HPP_
+
+#include <vector>
+#include <string>
+
+namespace ateam_common {
+
+/**
+ * Returns a vector of local IP addresses. Effectively enumerating available network interfaces.
+ */
+std::vector<std::string> GetIpAdresses(const bool include_ipv6 = true);
+
+}  // namespace ateam_common
+
+#endif  // ATEAM_COMMON__GET_IP_ADDRESSES_HPP_

--- a/ateam_common/include/ateam_common/get_ip_addresses.hpp
+++ b/ateam_common/include/ateam_common/get_ip_addresses.hpp
@@ -24,7 +24,8 @@
 #include <vector>
 #include <string>
 
-namespace ateam_common {
+namespace ateam_common
+{
 
 /**
  * Returns a vector of local IP addresses. Effectively enumerating available network interfaces.

--- a/ateam_common/src/get_ip_addresses.cpp
+++ b/ateam_common/src/get_ip_addresses.cpp
@@ -27,37 +27,39 @@
 namespace ateam_common
 {
 
-std::vector<std::string> GetIpAdresses(const bool include_ipv6) {
-    std::vector<std::string> addresses;
-    ifaddrs * iface_info=nullptr;
-    getifaddrs(&iface_info);
-    auto iface_info_current = iface_info;
-    while(iface_info_current != nullptr)
-    {
-        if(!iface_info_current->ifa_addr) {
-            continue;
-        }
+std::vector<std::string> GetIpAdresses(const bool include_ipv6)
+{
+  std::vector<std::string> addresses;
+  ifaddrs * iface_info = nullptr;
+  getifaddrs(&iface_info);
+  auto iface_info_current = iface_info;
+  while(iface_info_current != nullptr) {
+    if(!iface_info_current->ifa_addr) {
+      continue;
+    }
 
-        if(iface_info_current->ifa_addr->sa_family == AF_INET) {
+    if(iface_info_current->ifa_addr->sa_family == AF_INET) {
             // IPv4 address
-            void* net_address = &(reinterpret_cast<sockaddr_in*>(iface_info_current->ifa_addr)->sin_addr);
-            char buffer[INET_ADDRSTRLEN];
-            inet_ntop(AF_INET, net_address, buffer, INET_ADDRSTRLEN);
-            addresses.emplace_back(buffer);
-        } else if(include_ipv6 && iface_info_current->ifa_addr->sa_family == AF_INET6) {
+      void * net_address =
+        &(reinterpret_cast<sockaddr_in *>(iface_info_current->ifa_addr)->sin_addr);
+      char buffer[INET_ADDRSTRLEN];
+      inet_ntop(AF_INET, net_address, buffer, INET_ADDRSTRLEN);
+      addresses.emplace_back(buffer);
+    } else if(include_ipv6 && iface_info_current->ifa_addr->sa_family == AF_INET6) {
             // IPv6 address
-            void* net_address = &(reinterpret_cast<sockaddr_in*>(iface_info_current->ifa_addr)->sin_addr);
-            char buffer[INET6_ADDRSTRLEN];
-            inet_ntop(AF_INET6, net_address, buffer, INET6_ADDRSTRLEN);
-            addresses.emplace_back(buffer);
-        }
+      void * net_address =
+        &(reinterpret_cast<sockaddr_in *>(iface_info_current->ifa_addr)->sin_addr);
+      char buffer[INET6_ADDRSTRLEN];
+      inet_ntop(AF_INET6, net_address, buffer, INET6_ADDRSTRLEN);
+      addresses.emplace_back(buffer);
+    }
 
-        iface_info_current = iface_info_current->ifa_next;
-    }
-    if(iface_info != nullptr) {
-        freeifaddrs(iface_info);
-    }
-    return addresses;
+    iface_info_current = iface_info_current->ifa_next;
+  }
+  if(iface_info != nullptr) {
+    freeifaddrs(iface_info);
+  }
+  return addresses;
 }
 
-} // namespace ateam_common
+}  // namespace ateam_common

--- a/ateam_common/src/get_ip_addresses.cpp
+++ b/ateam_common/src/get_ip_addresses.cpp
@@ -1,0 +1,63 @@
+// Copyright 2024 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "ateam_common/get_ip_addresses.hpp"
+
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+namespace ateam_common
+{
+
+std::vector<std::string> GetIpAdresses(const bool include_ipv6) {
+    std::vector<std::string> addresses;
+    ifaddrs * iface_info=nullptr;
+    getifaddrs(&iface_info);
+    auto iface_info_current = iface_info;
+    while(iface_info_current != nullptr)
+    {
+        if(!iface_info_current->ifa_addr) {
+            continue;
+        }
+
+        if(iface_info_current->ifa_addr->sa_family == AF_INET) {
+            // IPv4 address
+            void* net_address = &(reinterpret_cast<sockaddr_in*>(iface_info_current->ifa_addr)->sin_addr);
+            char buffer[INET_ADDRSTRLEN];
+            inet_ntop(AF_INET, net_address, buffer, INET_ADDRSTRLEN);
+            addresses.emplace_back(buffer);
+        } else if(include_ipv6 && iface_info_current->ifa_addr->sa_family == AF_INET6) {
+            // IPv6 address
+            void* net_address = &(reinterpret_cast<sockaddr_in*>(iface_info_current->ifa_addr)->sin_addr);
+            char buffer[INET6_ADDRSTRLEN];
+            inet_ntop(AF_INET6, net_address, buffer, INET6_ADDRSTRLEN);
+            addresses.emplace_back(buffer);
+        }
+
+        iface_info_current = iface_info_current->ifa_next;
+    }
+    if(iface_info != nullptr) {
+        freeifaddrs(iface_info);
+    }
+    return addresses;
+}
+
+} // namespace ateam_common

--- a/ateam_common/src/multicast_receiver.cpp
+++ b/ateam_common/src/multicast_receiver.cpp
@@ -31,6 +31,8 @@
 
 #include <boost/bind/bind.hpp>
 
+#include "ateam_common/get_ip_addresses.hpp"
+
 namespace ateam_common
 {
 
@@ -48,7 +50,14 @@ MulticastReceiver::MulticastReceiver(
   multicast_socket_.set_option(boost::asio::ip::udp::socket::reuse_address(true));
   multicast_socket_.bind(multicast_endpoint);
   if (interface_address.empty()) {
-    multicast_socket_.set_option(boost::asio::ip::multicast::join_group(multicast_address));
+    // If no interface specified, join on all interfaces
+    const auto available_interface_addresses = GetIpAdresses(false);
+    for(const auto & address : available_interface_addresses) {
+      multicast_socket_.set_option(
+        boost::asio::ip::multicast::join_group(
+          multicast_address,
+          boost::asio::ip::make_address_v4(address)));
+    }
   } else {
     multicast_socket_.set_option(
       boost::asio::ip::multicast::join_group(

--- a/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
+++ b/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
@@ -54,7 +54,7 @@ public:
       multicast_port, std::bind(
         &GCMulticastBridgeNode::PublishMulticastMessage, this, std::placeholders::_3,
         std::placeholders::_4),
-      declare_parameter<std::string>("net_interface_address", "10.191.12.1"));
+      declare_parameter<std::string>("net_interface_address", ""));
   }
 
 private:

--- a/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
+++ b/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
@@ -45,10 +45,8 @@ public:
       std::string(Topics::kRefereeMessages),
       rclcpp::SystemDefaultsQoS());
 
-    client_callback_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
     reconnect_client_ =
-      create_client<ateam_msgs::srv::ReconnectTeamClient>("/team_client_node/reconnect",
-        rclcpp::ServicesQoS(), client_callback_group_);
+      create_client<ateam_msgs::srv::ReconnectTeamClient>("/team_client_node/reconnect");
 
     team_client_connection_subscription_ =
       create_subscription<ateam_msgs::msg::TeamClientConnectionStatus>(
@@ -76,7 +74,6 @@ private:
   bool team_client_connected_ = false;
   std::chrono::steady_clock::time_point last_reconnect_attempt_time_;
   rclcpp::Publisher<ssl_league_msgs::msg::Referee>::SharedPtr referee_publisher_;
-  rclcpp::CallbackGroup::SharedPtr client_callback_group_;
   rclcpp::Client<ateam_msgs::srv::ReconnectTeamClient>::SharedPtr reconnect_client_;
   rclcpp::Subscription<ateam_msgs::msg::TeamClientConnectionStatus>::SharedPtr
     team_client_connection_subscription_;

--- a/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
+++ b/ateam_game_controller_bridge/src/gc_multicast_bridge_node.cpp
@@ -50,7 +50,11 @@ public:
       create_client<ateam_msgs::srv::ReconnectTeamClient>("/team_client_node/reconnect",
         rclcpp::ServicesQoS(), client_callback_group_);
 
-    team_client_connection_subscription_ = create_subscription<ateam_msgs::msg::TeamClientConnectionStatus>("/team_client_node/connection_status", rclcpp::SystemDefaultsQoS(), std::bind(&GCMulticastBridgeNode::TeamClientConnectionStatusCallback, this, std::placeholders::_1));
+    team_client_connection_subscription_ =
+      create_subscription<ateam_msgs::msg::TeamClientConnectionStatus>(
+        "/team_client_node/connection_status", rclcpp::SystemDefaultsQoS(),
+        std::bind(&GCMulticastBridgeNode::TeamClientConnectionStatusCallback, this,
+        std::placeholders::_1));
 
     const auto multicast_address =
       declare_parameter<std::string>("multicast.address", "224.5.23.1");

--- a/ateam_game_controller_bridge/src/team_client.cpp
+++ b/ateam_game_controller_bridge/src/team_client.cpp
@@ -46,6 +46,12 @@ bool TeamClient::Connect(const ConnectionParameters & parameters)
   return true;
 }
 
+void TeamClient::Disconnect()
+{
+  connected_ = false;
+  socket_.close();
+}
+
 TeamClient::Result TeamClient::SetDesiredKeeper(const int keeper_id)
 {
   TeamToController team_to_controller;

--- a/ateam_game_controller_bridge/src/team_client.hpp
+++ b/ateam_game_controller_bridge/src/team_client.hpp
@@ -73,6 +73,8 @@ public:
 
   bool Connect(const ConnectionParameters & parameters);
 
+  void Disconnect();
+
   bool IsConnected() const
   {
     return connected_;

--- a/ateam_game_controller_bridge/src/team_client_node.cpp
+++ b/ateam_game_controller_bridge/src/team_client_node.cpp
@@ -194,6 +194,10 @@ private:
       const auto result = team_client_.Ping();
       status_msg.connected = result.request_result.accepted;
       status_msg.ping = rclcpp::Duration(result.ping);
+      if(!result.request_result.accepted) {
+        team_client_.Disconnect();
+        RCLCPP_WARN(get_logger(), "Ping failed. Team client disconnected.");
+      }
     }
     connection_status_publisher_->publish(status_msg);
   }

--- a/ateam_game_controller_bridge/src/team_client_node.cpp
+++ b/ateam_game_controller_bridge/src/team_client_node.cpp
@@ -40,7 +40,7 @@ public:
   {
     SET_ROS_PROTOBUF_LOG_HANDLER("team_client_node.protobuf");
 
-    declare_parameter<std::string>("gc_ip_address", "127.0.0.1");
+    declare_parameter<std::string>("gc_ip_address", "");
     declare_parameter<uint16_t>("gc_port", 10008);
     declare_parameter<std::string>("team_name", "A-Team");
     declare_parameter<std::string>("team_color", "auto");
@@ -49,28 +49,28 @@ public:
       "~/set_desired_keeper",
       std::bind(
         &TeamClientNode::HandleSetDesiredKeeper, this, std::placeholders::_1,
-        std::placeholders::_2), rclcpp::SystemDefaultsQoS().get_rmw_qos_profile());
+        std::placeholders::_2), rclcpp::ServicesQoS());
 
     substitute_bot_service_ = create_service<ateam_msgs::srv::SubstituteBot>(
       "~/substitute_bot",
       std::bind(
         &TeamClientNode::HandleSubstituteBot, this, std::placeholders::_1,
-        std::placeholders::_2), rclcpp::SystemDefaultsQoS().get_rmw_qos_profile());
+        std::placeholders::_2), rclcpp::ServicesQoS());
 
     reconnect_service_ = create_service<ateam_msgs::srv::ReconnectTeamClient>(
       "~/reconnect",
       std::bind(
         &TeamClientNode::HandleReconnectTeamClient, this, std::placeholders::_1,
-        std::placeholders::_2), rclcpp::SystemDefaultsQoS().get_rmw_qos_profile());
+        std::placeholders::_2), rclcpp::ServicesQoS());
 
     advantage_choice_service_ = create_service<ateam_msgs::srv::SetTeamAdvantageChoice>(
       "~/set_advantage_choice",
       std::bind(
         &TeamClientNode::HandleSetAdvantageChoice, this, std::placeholders::_1,
-        std::placeholders::_2), rclcpp::SystemDefaultsQoS().get_rmw_qos_profile());
+        std::placeholders::_2), rclcpp::ServicesQoS());
 
     connection_status_publisher_ = create_publisher<ateam_msgs::msg::TeamClientConnectionStatus>(
-      "~/connection_status", rclcpp::SystemDefaultsQoS());
+      "~/connection_status", rclcpp::ServicesQoS());
 
     const auto ping_period = declare_parameter<double>("ping_period", 5);
     ping_timer_ =
@@ -95,9 +95,14 @@ private:
 
   bool Connect()
   {
+    const auto address_string = get_parameter("gc_ip_address").as_string();
+    if(address_string.empty()) {
+      RCLCPP_WARN(get_logger(), "Address parameter empty. Cannot attempt to connect.");
+      // Returning "success" because this isn't a problem during setup.
+      return true;
+    }
     TeamClient::ConnectionParameters connection_parameters;
-    connection_parameters.address =
-      boost::asio::ip::address::from_string(get_parameter("gc_ip_address").as_string());
+    connection_parameters.address = boost::asio::ip::address::from_string(address_string);
     connection_parameters.port = get_parameter("gc_port").as_int();
     connection_parameters.team_name = get_parameter("team_name").as_string();
     const auto team_color_name = get_parameter("team_color").as_string();
@@ -146,9 +151,12 @@ private:
   }
 
   void HandleReconnectTeamClient(
-    const ateam_msgs::srv::ReconnectTeamClient::Request::SharedPtr /*request*/,
+    const ateam_msgs::srv::ReconnectTeamClient::Request::SharedPtr request,
     ateam_msgs::srv::ReconnectTeamClient::Response::SharedPtr response)
   {
+    if(!request->server_address.empty()) {
+      set_parameter(rclcpp::Parameter("gc_ip_address", request->server_address));
+    }
     response->success = Connect();
   }
 

--- a/ateam_msgs/srv/ReconnectTeamClient.srv
+++ b/ateam_msgs/srv/ReconnectTeamClient.srv
@@ -1,4 +1,9 @@
 # Request
+
+# Address of the server to connect to. If blank, will reconnect to the last used address.
+string server_address ""
+
 ---
 # Response
+
 bool success

--- a/ateam_ssl_vision_bridge/src/ssl_vision_bridge_node.cpp
+++ b/ateam_ssl_vision_bridge/src/ssl_vision_bridge_node.cpp
@@ -48,7 +48,7 @@ public:
       declare_parameter<std::string>("ssl_vision_ip", "224.5.23.2"),
       declare_parameter<int>("ssl_vision_port", 10020),
       std::bind_front(&SSLVisionBridgeNode::multicastCallback, this),
-      declare_parameter<std::string>("net_interface_address", "10.191.12.33"))
+      declare_parameter<std::string>("net_interface_address", ""))
   {
     SET_ROS_PROTOBUF_LOG_HANDLER("ssl_vision_bridge.protobuf");
   }


### PR DESCRIPTION
This PR adds automatic discovery / handling of IP addresses that we currently have to configure for each field / environment we run in. With these changes, manually specifying addresses / interfaces is longer required in normal circumstances.

This includes these features:
* `MulticastListener` gains the ability to listen on all interfaces at once if the interface address argument is left empty.
* IP address launch arguments are now blank to default to auto-discovery. They are kept so they can be used as command line overrides when needed.
* The team client reconnect service can now optionally change the game controller IP address.
* The GC multicast bridge node will now call the team client reconnect service when multicast packets are received and the team client is not connected.