### PR TITLE
Adds temporary warning suppression to motion controller.

### DIFF
--- a/ateam_kenobi/src/motion/motion_controller.hpp
+++ b/ateam_kenobi/src/motion/motion_controller.hpp
@@ -28,7 +28,7 @@
 #include <ateam_msgs/msg/robot_motion_command.hpp>
 #include <ateam_geometry/ateam_geometry.hpp>
 
-// TODO(barulicm) Remove when control_toolbox no longer uses deprecated realtime_tools headers 
+// TODO(barulicm) Remove when control_toolbox no longer uses deprecated realtime_tools headers
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcpp"
 #include <control_toolbox/pid.hpp>

--- a/ateam_kenobi/src/motion/motion_controller.hpp
+++ b/ateam_kenobi/src/motion/motion_controller.hpp
@@ -27,7 +27,12 @@
 #include <rclcpp/rclcpp.hpp>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
 #include <ateam_geometry/ateam_geometry.hpp>
+
+// TODO(barulicm) Remove when control_toolbox no longer uses deprecated realtime_tools headers 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcpp"
 #include <control_toolbox/pid.hpp>
+#pragma GCC diagnostic pop
 
 #include "types/robot.hpp"
 #include "types/world.hpp"


### PR DESCRIPTION
The control_toolbox package fixed this warning [here](https://github.com/ros-controls/control_toolbox/commit/74510fd2d9d4bbf074c750d7172ea602b95888c8) but that has not been released yet. The next ros2 sync will probably be in about a month.

This PR suppresses the warning at the include site for now to unblock our builds while still treating other warnings as errors.