### PR TITLE
Fixes message translation in sim radio bridge.

### DIFF
--- a/ateam_ssl_simulation_radio_bridge/src/message_conversions.cpp
+++ b/ateam_ssl_simulation_radio_bridge/src/message_conversions.cpp
@@ -33,7 +33,9 @@ ateam_msgs::msg::RobotFeedback fromProto(const RobotFeedback & proto_msg)
   ateam_msgs::msg::RobotFeedback robot_feedback;
 
   robot_feedback.radio_connected = true;
-  robot_feedback.breakbeam_ball_detected = proto_msg.dribbler_ball_contact();
+  if(proto_msg.has_dribbler_ball_contact()) {
+    robot_feedback.breakbeam_ball_detected = proto_msg.dribbler_ball_contact();
+  }
 
   return robot_feedback;
 }


### PR DESCRIPTION
Pulling in changes to `ateam_ssl_simulatoin_radio_bridge` from the quals branch.
Includes:
- Sets up protobuf logging via ROS
- Fixes call to deprecated override of `rclcpp::Node::createService`
- Fixes inverted error handling of protobuf parsing
- Adds existence check for optional `dribbler_ball_contact` field