### PR TITLE
Adds joystick control status topic.

### DIFF
--- a/ateam_common/include/ateam_common/topic_names.hpp
+++ b/ateam_common/include/ateam_common/topic_names.hpp
@@ -44,6 +44,7 @@ constexpr std::string_view kField = "/field";  // Internal vision filter state
 
 // Output from joysticks
 constexpr std::string_view kJoystick = "/joy";
+constexpr std::string_view kJoystickControlStatus = "/joystick_control_status";
 
 // Output from AI
 constexpr std::string_view kRobotMotionCommandPrefix = "/robot_motion_commands/robot";

--- a/ateam_msgs/CMakeLists.txt
+++ b/ateam_msgs/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(ssl_league_msgs REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   msg/BallState.msg
   msg/BehaviorExecutorState.msg
+  msg/JoystickControlStatus.msg
   msg/Mesh1d.msg
   msg/Overlay.msg
   msg/OverlayArray.msg

--- a/ateam_msgs/msg/JoystickControlStatus.msg
+++ b/ateam_msgs/msg/JoystickControlStatus.msg
@@ -1,0 +1,2 @@
+bool is_active
+int8 active_id


### PR DESCRIPTION
This PR adds the joystick control status topic to the joystick control node so it can be used by Kenobi and UI in future PRs.