### PR TITLE
Update robot radio submodule

### DIFF
--- a/ateam_msgs/msg/RobotMotorFeedback.msg
+++ b/ateam_msgs/msg/RobotMotorFeedback.msg
@@ -1,3 +1,31 @@
-float32 setpoint
-float32 velocity
-float32 torque
+bool master_error
+bool hall_power_error
+bool hall_disconnected_error
+bool bldc_transition_error
+bool bldc_commutation_watchdog_error
+bool enc_disconnected_error
+bool enc_decoding_error
+bool hall_enc_vel_disagreement_error
+bool overcurrent_error
+bool undervoltage_error
+bool overvoltage_error
+bool torque_limited
+bool control_loop_time_error
+bool reset_watchdog_independent
+bool reset_watchdog_window
+bool reset_low_power
+bool reset_software
+bool reset_pin
+
+float32 vel_setpoint
+float32 vel_setpoint_clamped
+int32 encoder_delta
+float32 vel_enc_estimate
+float32 vel_computed_error
+float32 vel_computed_setpoint
+
+float32 torque_setpoint
+float32 current_estimate
+float32 torque_estimate
+float32 torque_computed_error
+float32 torque_computed_setpoint

--- a/ateam_radio_bridge/src/conversion.cpp
+++ b/ateam_radio_bridge/src/conversion.cpp
@@ -89,13 +89,41 @@ geometry_msgs::msg::Twist ConvertFloatArrayToTwist(const float (&fw_state_space_
   return twist;
 }
 
-ateam_msgs::msg::RobotMotorFeedback Convert(const MotorDebugTelemetry & motor_debug_telemetry) {
+ateam_msgs::msg::RobotMotorFeedback Convert(const MotorResponse_Motion_Packet & motor_debug_telemetry) {
   ateam_msgs::msg::RobotMotorFeedback robot_motor_feedback;
 
-  robot_motor_feedback.setpoint = motor_debug_telemetry.wheel_setpoint;
-  robot_motor_feedback.velocity = motor_debug_telemetry.wheel_velocity;
-  robot_motor_feedback.torque = motor_debug_telemetry.wheel_torque;
+  robot_motor_feedback.master_error = motor_debug_telemetry.master_error;
+  robot_motor_feedback.hall_power_error = motor_debug_telemetry.hall_power_error;
+  robot_motor_feedback.hall_disconnected_error = motor_debug_telemetry.hall_disconnected_error;
+  robot_motor_feedback.bldc_transition_error = motor_debug_telemetry.bldc_transition_error;
+  robot_motor_feedback.bldc_commutation_watchdog_error = motor_debug_telemetry.bldc_commutation_watchdog_error;
+  robot_motor_feedback.enc_disconnected_error = motor_debug_telemetry.enc_disconnected_error;
+  robot_motor_feedback.enc_decoding_error = motor_debug_telemetry.enc_decoding_error;
+  robot_motor_feedback.hall_enc_vel_disagreement_error = motor_debug_telemetry.hall_enc_vel_disagreement_error;
+  robot_motor_feedback.overcurrent_error = motor_debug_telemetry.overcurrent_error;
+  robot_motor_feedback.undervoltage_error = motor_debug_telemetry.undervoltage_error;
+  robot_motor_feedback.overvoltage_error = motor_debug_telemetry.overvoltage_error;
+  robot_motor_feedback.torque_limited = motor_debug_telemetry.torque_limited;
+  robot_motor_feedback.control_loop_time_error = motor_debug_telemetry.control_loop_time_error;
+  robot_motor_feedback.reset_watchdog_independent = motor_debug_telemetry.reset_watchdog_independent;
+  robot_motor_feedback.reset_watchdog_window = motor_debug_telemetry.reset_watchdog_window;
+  robot_motor_feedback.reset_low_power = motor_debug_telemetry.reset_low_power;
+  robot_motor_feedback.reset_software = motor_debug_telemetry.reset_software;
+  robot_motor_feedback.reset_pin = motor_debug_telemetry.reset_pin;
 
+  robot_motor_feedback.vel_setpoint = motor_debug_telemetry.vel_setpoint;
+  robot_motor_feedback.vel_setpoint_clamped = motor_debug_telemetry.vel_setpoint_clamped;
+  robot_motor_feedback.encoder_delta = motor_debug_telemetry.encoder_delta;
+  robot_motor_feedback.vel_enc_estimate = motor_debug_telemetry.vel_enc_estimate;
+  robot_motor_feedback.vel_computed_error = motor_debug_telemetry.vel_computed_error;
+  robot_motor_feedback.vel_computed_setpoint = motor_debug_telemetry.vel_computed_setpoint;
+  
+  robot_motor_feedback.torque_setpoint = motor_debug_telemetry.torque_setpoint;
+  robot_motor_feedback.current_estimate = motor_debug_telemetry.current_estimate;
+  robot_motor_feedback.torque_estimate = motor_debug_telemetry.torque_estimate;
+  robot_motor_feedback.torque_computed_error = motor_debug_telemetry.torque_computed_error;
+  robot_motor_feedback.torque_computed_setpoint = motor_debug_telemetry.torque_computed_setpoint;
+  
   return robot_motor_feedback;
 }
 

--- a/ateam_radio_bridge/src/conversion.hpp
+++ b/ateam_radio_bridge/src/conversion.hpp
@@ -34,7 +34,7 @@ namespace ateam_radio_bridge
 {
 
 ateam_msgs::msg::RobotFeedback Convert(const BasicTelemetry & basic_telemetry);
-ateam_msgs::msg::RobotMotorFeedback Convert(const MotorDebugTelemetry & motor_debug_telemetry);
+ateam_msgs::msg::RobotMotorFeedback Convert(const MotorResponse_Motion_Packet & motor_debug_telemetry);
 ateam_msgs::msg::RobotMotionFeedback Convert(const ControlDebugTelemetry & control_debug_telemetry);
 
 }

--- a/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
+++ b/ateam_radio_bridge/test/unit_tests/conversion_tests.cpp
@@ -93,30 +93,20 @@ TEST(ConvertBasicTelemmetry, PacketConversions)
 }
 
 TEST(ConvertControlDebugTelemetry, PacketConversions) {
+  MotorResponse_Motion_Packet front_left_motor_packet;
+  front_left_motor_packet.vel_setpoint = 1.0f;
+  MotorResponse_Motion_Packet back_left_motor_packet;
+  back_left_motor_packet.vel_setpoint = 2.0f;
+  MotorResponse_Motion_Packet back_right_motor_packet;
+  back_right_motor_packet.vel_setpoint = 3.0f;
+  MotorResponse_Motion_Packet front_right_motor_packet;
+  front_right_motor_packet.vel_setpoint = 4.0f;
+
   ControlDebugTelemetry control_debug_telemetry {
-    MotorDebugTelemetry {
-      3.14,
-      3.12,
-      2.0
-    },
-
-    MotorDebugTelemetry {
-      3.14,
-      3.14,
-      3.0
-    },
-
-    MotorDebugTelemetry {
-      3.14,
-      3.15,
-      2.0
-    },
-
-    MotorDebugTelemetry {
-      3.14,
-      3.20,
-      1.0
-    },
+    front_left_motor_packet,
+    back_left_motor_packet,
+    back_right_motor_packet,
+    front_right_motor_packet,
 
     {10.0, 20.0, 30.0},
     {100.0, 200.0, 300.0},
@@ -131,21 +121,12 @@ TEST(ConvertControlDebugTelemetry, PacketConversions) {
   };
 
   const auto motion_feedback_msg = ateam_radio_bridge::Convert(control_debug_telemetry);
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_LEFT_MOTOR].setpoint, 3.14);
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_LEFT_MOTOR].velocity, 3.12);
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_LEFT_MOTOR].torque, 2.0);
 
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_LEFT_MOTOR].setpoint, 3.14);
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_LEFT_MOTOR].velocity, 3.14);
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_LEFT_MOTOR].torque, 3.0);
-
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_RIGHT_MOTOR].setpoint, 3.14);
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_RIGHT_MOTOR].velocity, 3.15);
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_RIGHT_MOTOR].torque, 2.0);
-
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_RIGHT_MOTOR].setpoint, 3.14);
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_RIGHT_MOTOR].velocity, 3.20);
-  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_RIGHT_MOTOR].torque, 1.0);
+  // This just checks that the motor ordering is correct
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_LEFT_MOTOR].vel_setpoint, 1.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_LEFT_MOTOR].vel_setpoint, 2.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.BACK_RIGHT_MOTOR].vel_setpoint, 3.0);
+  EXPECT_FLOAT_EQ(motion_feedback_msg.motors[motion_feedback_msg.FRONT_RIGHT_MOTOR].vel_setpoint, 4.0);
 
   EXPECT_FLOAT_EQ(motion_feedback_msg.imu.orientation_covariance[0], -1.0);
 
@@ -182,4 +163,57 @@ TEST(ConvertControlDebugTelemetry, PacketConversions) {
   EXPECT_FLOAT_EQ(motion_feedback_msg.clamped_wheel_velocity_control_variable[motion_feedback_msg.BACK_LEFT_MOTOR], 2.0);
   EXPECT_FLOAT_EQ(motion_feedback_msg.clamped_wheel_velocity_control_variable[motion_feedback_msg.BACK_RIGHT_MOTOR], 3.0);
   EXPECT_FLOAT_EQ(motion_feedback_msg.clamped_wheel_velocity_control_variable[motion_feedback_msg.FRONT_RIGHT_MOTOR], 4.0);
+}
+
+
+TEST(ConvertMotorFeedback, PacketConversions) {
+  const MotorResponse_Motion_Packet src {
+    0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1,
+    0,
+    1.0f,
+    2.0f,
+    3,
+    4.0f,
+    5.0f,
+    6.0f,
+    7.0f,
+    8.0f,
+    9.0f,
+    10.0f,
+    11.0f
+  };
+
+  const auto dst = ateam_radio_bridge::Convert(src);
+
+  EXPECT_FALSE(dst.master_error);
+  EXPECT_TRUE(dst.hall_power_error);
+  EXPECT_FALSE(dst.hall_disconnected_error);
+  EXPECT_TRUE(dst.bldc_transition_error);
+  EXPECT_FALSE(dst.bldc_commutation_watchdog_error);
+  EXPECT_FALSE(dst.enc_disconnected_error);
+  EXPECT_TRUE(dst.enc_decoding_error);
+  EXPECT_TRUE(dst.hall_enc_vel_disagreement_error);
+  EXPECT_FALSE(dst.overcurrent_error);
+  EXPECT_TRUE(dst.undervoltage_error);
+  EXPECT_TRUE(dst.overvoltage_error);
+  EXPECT_FALSE(dst.torque_limited);
+  EXPECT_TRUE(dst.control_loop_time_error);
+  EXPECT_FALSE(dst.reset_watchdog_independent);
+  EXPECT_FALSE(dst.reset_watchdog_window);
+  EXPECT_TRUE(dst.reset_low_power);
+  EXPECT_FALSE(dst.reset_software);
+  EXPECT_TRUE(dst.reset_pin);
+
+  EXPECT_FLOAT_EQ(dst.vel_setpoint, 1.0f);
+  EXPECT_FLOAT_EQ(dst.vel_setpoint_clamped, 2.0f);
+  EXPECT_EQ(dst.encoder_delta, 3);
+  EXPECT_FLOAT_EQ(dst.vel_enc_estimate, 4.0f);
+  EXPECT_FLOAT_EQ(dst.vel_computed_error, 5.0f);
+  EXPECT_FLOAT_EQ(dst.vel_computed_setpoint, 6.0f);
+
+  EXPECT_FLOAT_EQ(dst.torque_setpoint, 7.0f);
+  EXPECT_FLOAT_EQ(dst.current_estimate, 8.0f);
+  EXPECT_FLOAT_EQ(dst.torque_estimate, 9.0f);
+  EXPECT_FLOAT_EQ(dst.torque_computed_error, 10.0f);
+  EXPECT_FLOAT_EQ(dst.torque_computed_setpoint, 11.0f);
 }


### PR DESCRIPTION
Updates our software_communication submodule to point to [dev/will/torque_data](https://github.com/SSL-A-Team/software-communication/tree/dev/will/torque_data) currently used in firmware on the robots.
This includes changes to the motor feedback packet and associated conversion function.