### PR TITLE
Removes call to deprecated create_service override.

### DIFF
--- a/ateam_field_manager/src/ateam_field_manager_node.cpp
+++ b/ateam_field_manager/src/ateam_field_manager_node.cpp
@@ -59,11 +59,10 @@ public:
       10,
       std::bind(&FieldManagerNode::vision_callback, this, std::placeholders::_1));
 
-    set_ignore_field_side_service_ = create_service<ateam_msgs::srv::SetIgnoreFieldSide>(
-      "~/set_ignore_field_side",
-      std::bind(
-        &FieldManagerNode::handle_set_ignore_field_side, this, std::placeholders::_1,
-        std::placeholders::_2), rclcpp::SystemDefaultsQoS().get_rmw_qos_profile());
+    set_ignore_field_side_service_ =
+      create_service<ateam_msgs::srv::SetIgnoreFieldSide>("~/set_ignore_field_side",
+        std::bind(&FieldManagerNode::handle_set_ignore_field_side, this, std::placeholders::_1,
+        std::placeholders::_2));
   }
 
   void vision_callback(


### PR DESCRIPTION
Passing the lower level RMW service profiles to rclcpp functions is deprecated. Additionally, defining the QoS for `create_service` is no longer needed as it provides a default value of `rclcpp::ServicesQoS`.