### PR TITLE
Adds in-play and double-touch states to world message.

### DIFF
--- a/ateam_kenobi/src/types/message_conversions.cpp
+++ b/ateam_kenobi/src/types/message_conversions.cpp
@@ -132,6 +132,10 @@ ateam_msgs::msg::World toMsg(const World & obj)
     }
   }
 
+  world_msg.ball_in_play = obj.in_play;
+  world_msg.double_touch_enforced = obj.double_touch_forbidden_id_.has_value();
+  world_msg.double_touch_id = obj.double_touch_forbidden_id_.value_or(-1);
+
   return world_msg;
 }
 

--- a/ateam_msgs/msg/World.msg
+++ b/ateam_msgs/msg/World.msg
@@ -10,3 +10,7 @@ RobotState[] their_robots
 RobotState[] plan_from_our_robots
 
 ateam_msgs/BehaviorExecutorState behavior_executor_state
+
+bool ball_in_play
+bool double_touch_enforced
+int32 double_touch_id


### PR DESCRIPTION
These fields have been useful for debugging Kenobi's internal state. Should be useful in game bags.