### PR TITLE
Adds Play::enter() and Play::exit()

### DIFF
--- a/ateam_kenobi/src/play_selector.cpp
+++ b/ateam_kenobi/src/play_selector.cpp
@@ -208,10 +208,18 @@ void PlaySelector::resetPlayIfNeeded(stp::Play * play)
 {
   void * play_address = static_cast<void *>(play);
   if (play_address != prev_play_address_) {
+    if(prev_play_address_ != nullptr) {
+      static_cast<stp::Play *>(prev_play_address_)->exit();
+    }
     if (play != nullptr) {
       play->reset();
+      play->enter();
     }
     prev_play_address_ = play_address;
+  } else if (play->getCompletionState() == stp::PlayCompletionState::Done) {
+    play->exit();
+    play->reset();
+    play->enter();
   }
 }
 

--- a/ateam_kenobi/src/stp/play.hpp
+++ b/ateam_kenobi/src/stp/play.hpp
@@ -74,7 +74,24 @@ public:
     return PlayCompletionState::NotApplicable;
   }
 
-  virtual void reset() = 0;
+  /**
+   * @deprecated Use @c enter and @c exit instead.
+   */
+  virtual void reset() {}
+
+  /**
+   * @brief Called before a play is run when the previous frame was running a different frame.
+   *
+   * Also called if a play is being chosen again after reporting itself done in @c getCompletionState.
+   */
+  virtual void enter() {}
+
+  /**
+   * @brief Called when a new play is being run and this play was running in the previous frame.
+   *
+   * Also called if a play is being chosen again after reporting itself done in @c getCompletionState.
+   */
+  virtual void exit() {}
 
   virtual std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> runFrame(
     const World & world) = 0;


### PR DESCRIPTION
Deprecates `stp::Play::reset()` in favor of new functions `stp::Play::enter()` and `stp::Play::exit()`.
`enter()` is called when we switch to the play and `exit()` is called when we switch away from the play.
Plays which report a completion status are reset when they report done by calling `exit()` then `enter()` in the same frame.