### PR TITLE
Fixes bug in double touch causing sticky double touch enforcement.

### DIFF
--- a/ateam_kenobi/src/double_touch_eval.hpp
+++ b/ateam_kenobi/src/double_touch_eval.hpp
@@ -46,7 +46,6 @@ public:
     {
       // Game is in a state where the double-touch rule does not apply.
       double_touch_rule_applies_ = false;
-      return;
     }
 
     if (running_command != prev_game_command_ &&


### PR DESCRIPTION
An errant early return in `DoubleTouchEval` prevented world state from being cleared properly causing the double touch exclusion behavior to stick longer than it should.

This change was originally made on our quals branch.