### PR TITLE
Imports play helper changes from quals branch.

### DIFF
--- a/ateam_kenobi/src/kenobi_node.cpp
+++ b/ateam_kenobi/src/kenobi_node.cpp
@@ -69,6 +69,8 @@ public:
     joystick_enforcer_(*this),
     game_controller_listener_(*this)
   {
+    initialize_robot_ids();
+
     declare_parameter<bool>("use_world_velocities", false);
     declare_parameter<bool>("use_emulated_ballsense", false);
 
@@ -169,24 +171,38 @@ private:
 
   rclcpp::TimerBase::SharedPtr timer_;
 
+  void initialize_robot_ids()
+  {
+    for(auto i = 0u; i < world_.our_robots.size(); ++i) {
+      world_.our_robots[i].id = i;
+    }
+    for(auto i = 0u; i < world_.their_robots.size(); ++i) {
+      world_.their_robots[i].id = i;
+    }
+  }
+
   void blue_robot_state_callback(
     const ateam_msgs::msg::RobotState::SharedPtr robot_state_msg,
     int id)
   {
-    const auto are_we_blue = game_controller_listener_.GetTeamColor() ==
-      ateam_common::TeamColor::Blue;
+    const auto our_color = game_controller_listener_.GetTeamColor();
+    if(our_color == ateam_common::TeamColor::Unknown) {
+      return;
+    }
+    const auto are_we_blue = our_color == ateam_common::TeamColor::Blue;
     auto & robot_state_array = are_we_blue ? world_.our_robots : world_.their_robots;
     robot_state_callback(robot_state_array, id, robot_state_msg);
   }
 
-  // TODO(CAVIDANO): REMOVE THE THEIR ROBOTS HERE THIS SHOULD NOT ASSIGN ANYTHING IN THE NOT CASE
-  // AS IT ALSO CATCHES UNKOWN TEAM
   void yellow_robot_state_callback(
     const ateam_msgs::msg::RobotState::SharedPtr robot_state_msg,
     int id)
   {
-    const auto are_we_yellow = game_controller_listener_.GetTeamColor() ==
-      ateam_common::TeamColor::Yellow;
+    const auto our_color = game_controller_listener_.GetTeamColor();
+    if(our_color == ateam_common::TeamColor::Unknown) {
+      return;
+    }
+    const auto are_we_yellow = our_color == ateam_common::TeamColor::Yellow;
     auto & robot_state_array = are_we_yellow ? world_.our_robots : world_.their_robots;
     robot_state_callback(robot_state_array, id, robot_state_msg);
   }

--- a/ateam_kenobi/src/play_helpers/robot_assignment.cpp
+++ b/ateam_kenobi/src/play_helpers/robot_assignment.cpp
@@ -192,6 +192,19 @@ std::vector<Robot> GroupAssignmentResult::GetGroupFilledAssignments(const std::s
   return robots;
 }
 
+std::vector<Robot> GroupAssignmentResult::GetGroupFilledAssignmentsOrEmpty(
+  const std::string & name) const
+{
+  const auto record_iter = std::ranges::find_if(
+    records_, [&name](const GroupRecord & record) {
+      return record.name == name;
+    });
+  if(record_iter == records_.end()) {
+    return {};
+  }
+  return GetGroupFilledAssignments(name);
+}
+
 const GroupRecord & GroupAssignmentResult::GetRecord(const std::string & name) const
 {
   const auto record_iter = std::ranges::find_if(

--- a/ateam_kenobi/src/play_helpers/robot_assignment.hpp
+++ b/ateam_kenobi/src/play_helpers/robot_assignment.hpp
@@ -95,6 +95,11 @@ public:
 
   std::vector<Robot> GetGroupFilledAssignments(const std::string & name) const;
 
+  /**
+   * @brief Same as @c GetGroupFilledAssignments but if there is no group with the given name, this function returns an empty array instead of throwing.
+   */
+  std::vector<Robot> GetGroupFilledAssignmentsOrEmpty(const std::string & name) const;
+
   template<typename PositionFunc>
   void RunPositionIfAssigned(const std::string & name, PositionFunc func) const
   {

--- a/ateam_kenobi/src/play_helpers/window_evaluation.cpp
+++ b/ateam_kenobi/src/play_helpers/window_evaluation.cpp
@@ -134,7 +134,7 @@ std::pair<ateam_geometry::Ray, ateam_geometry::Ray> getRobotShadowRays(
 {
   const auto source_center_vector = robot.pos - source;
   const auto source_center_distance = ateam_geometry::norm(source_center_vector);
-  const auto shadow_angle = std::atan(kRobotRadius / source_center_distance);
+  const auto shadow_angle = std::asin(kRobotRadius / source_center_distance);
   const CGAL::Aff_transformation_2<ateam_geometry::Kernel> rotate(CGAL::ROTATION,
     std::sin(shadow_angle), std::cos(shadow_angle));
   const auto source_to_bot_tangent_distance = std::hypot(source_center_distance, kRobotRadius);

--- a/ateam_kenobi/test/window_evaluation_test.cpp
+++ b/ateam_kenobi/test/window_evaluation_test.cpp
@@ -65,9 +65,9 @@ TEST(WindowEvaluationTest, OneRobot)
       SegmentIsNear(
         ateam_geometry::Segment{
     ateam_geometry::Point{4.5, -1},
-    ateam_geometry::Point{4.5, -0.12}}),
+    ateam_geometry::Point{4.5, -0.120605}}),
       SegmentIsNear(
         ateam_geometry::Segment{
-    ateam_geometry::Point{4.5, 0.12},
+    ateam_geometry::Point{4.5, 0.120605},
     ateam_geometry::Point{4.5, 1}})));
 }


### PR DESCRIPTION
Includes:

* Initializing robot IDs in the world object because some helpers were failing in the first frame before any robots were detected.
* Ignores robot detectionz when we don't know what team color we are.
* Adds `GetGroupFilledAssignmentsOrEmpty` to address the "not enough bots for defense" anti-pattern
* Fixes trig bug in window evaluator & adjusts associated unit test