### PR TITLE
Adds playbook caching.

### DIFF
--- a/ateam_bringup/launch/autonomy.launch.xml
+++ b/ateam_bringup/launch/autonomy.launch.xml
@@ -3,6 +3,7 @@
   <arg name="use_emulated_ballsense" default="false"/>
   <arg name="team_name" default="A-Team"/>
   <arg name="kenobi_debug" default="false"/>
+  <arg name="kenobi_playbook" default=""/>
 
   <node name="vision_filter" pkg="ateam_vision_filter" exec="ateam_vision_filter_node" respawn="True">
     <param name="gc_team_name" value="$(var team_name)"/>
@@ -15,5 +16,6 @@
     <param name="use_world_velocities" value="$(var use_world_velocities)"/>
     <param name="use_emulated_ballsense" value="$(var use_emulated_ballsense)"/>
     <param name="gc_team_name" value="$(var team_name)"/>
+    <param name="playbook" value="$(var kenobi_playbook)"/>
   </node>
 </launch>

--- a/ateam_kenobi/CMakeLists.txt
+++ b/ateam_kenobi/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(control_toolbox REQUIRED)
 find_package(ompl REQUIRED)
 find_package(angles REQUIRED)
 find_package(OpenCV REQUIRED)
+find_package(nlohmann_json REQUIRED)
 
 add_library(kenobi_node_component SHARED
   src/defense_area_enforcement.cpp
@@ -97,6 +98,7 @@ ament_target_dependencies(
   "OMPL"
   "angles"
   OpenCV
+  nlohmann_json
 )
 rclcpp_components_register_node(
   kenobi_node_component

--- a/ateam_kenobi/src/kenobi_node.cpp
+++ b/ateam_kenobi/src/kenobi_node.cpp
@@ -453,7 +453,7 @@ private:
       return std::filesystem::path(home_env) / cache_dir;
     }
 
-    struct passwd * pwd = getpwuid(getuid());
+    struct passwd * pwd = getpwuid(getuid());  // NOLINT(runtime/threadsafe_fn)
     if (pwd != nullptr) {
       return std::filesystem::path(pwd->pw_dir) / cache_dir;
     }

--- a/ateam_kenobi/src/play_selector.cpp
+++ b/ateam_kenobi/src/play_selector.cpp
@@ -19,11 +19,13 @@
 // THE SOFTWARE.
 
 #include <algorithm>
+#include <fstream>
 #include <iostream>
 #include <limits>
 #include <string>
 #include <utility>
 #include <vector>
+#include <nlohmann/json.hpp>
 #include "play_selector.hpp"
 #include "plays/all_plays.hpp"
 #include "ateam_common/game_controller_listener.hpp"
@@ -134,6 +136,56 @@ stp::Play * PlaySelector::getPlayByName(const std::string name)
     return nullptr;
   }
   return found_iter->get();
+}
+
+
+void PlaySelector::saveToFile(const std::filesystem::path & path)
+{
+  std::filesystem::create_directories(path.parent_path());
+  nlohmann::json data;
+  auto plays_arr = nlohmann::json::array();
+
+  std::ranges::transform(plays_, std::back_inserter(plays_arr), [](const auto & play){
+      return nlohmann::json{
+      {"name", play->getName()},
+      {"enabled", play->isEnabled()}
+      };
+  });
+
+  data["plays"] = plays_arr;
+  std::ofstream file(path);
+  file << std::setw(2) << data << std::endl;
+}
+
+void PlaySelector::loadFromFile(const std::filesystem::path & path)
+{
+  std::ifstream file(path);
+  nlohmann::json data;
+  file >> data;
+
+  const auto & json_plays = data["plays"];
+
+  if(!json_plays.is_array()) {
+    RCLCPP_ERROR(ros_logger_, "No 'plays' member found in playbook file.");
+    return;
+  }
+
+  for(const auto & play_settings : json_plays) {
+    const auto & name = play_settings["name"];
+    if(!name.is_string()) {
+      RCLCPP_WARN(ros_logger_, "Skipping play entry with no name.");
+      continue;
+    }
+    auto play = getPlayByName(name);
+    if(play == nullptr) {
+      RCLCPP_WARN(ros_logger_, "Could not find play with name %s. Skipping.", name.get<std::string>().c_str());
+      continue;
+    }
+    const auto & enabled = play_settings["enabled"];
+    if(enabled.is_boolean()) {
+      play->setEnabled(enabled);
+    }
+  }
 }
 
 stp::Play * PlaySelector::selectOverridePlay()

--- a/ateam_kenobi/src/play_selector.cpp
+++ b/ateam_kenobi/src/play_selector.cpp
@@ -178,7 +178,8 @@ void PlaySelector::loadFromFile(const std::filesystem::path & path)
     }
     auto play = getPlayByName(name);
     if(play == nullptr) {
-      RCLCPP_WARN(ros_logger_, "Could not find play with name %s. Skipping.", name.get<std::string>().c_str());
+      RCLCPP_WARN(ros_logger_, "Could not find play with name %s. Skipping.",
+          name.get<std::string>().c_str());
       continue;
     }
     const auto & enabled = play_settings["enabled"];

--- a/ateam_kenobi/src/play_selector.hpp
+++ b/ateam_kenobi/src/play_selector.hpp
@@ -50,6 +50,10 @@ public:
 
   stp::Play * getPlayByName(const std::string name);
 
+  void saveToFile(const std::filesystem::path & path);
+
+  void loadFromFile(const std::filesystem::path & path);
+
 private:
   rclcpp::Logger ros_logger_;
   std::shared_ptr<stp::Play> halt_play_;


### PR DESCRIPTION
Adds the ability to load and save playbook state to disk, including autosave to a cache directory on shutdown.
For now, this just enables or disables plays by name. Not sure if we'll end up with other settings for plays in this kind of file in the future.

The autosave is saved to `~/.ateam/software/kenobi/playbook/autosave.json`.

An override playbook file can be chosen at launch time with the `kenobi_playbook` launch argument.