### PR TITLE
Removes unused geometry types.

### DIFF
--- a/ateam_geometry/include/ateam_geometry/types.hpp
+++ b/ateam_geometry/include/ateam_geometry/types.hpp
@@ -22,13 +22,7 @@
 #define ATEAM_GEOMETRY__TYPES_HPP_
 
 #include <CGAL/Simple_cartesian.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/point_generators_2.h>
 #include <CGAL/Polygon_2.h>
-#include <CGAL/Orthogonal_k_neighbor_search.h>
-#include <CGAL/Search_traits_2.h>
-
-#include <variant>
 
 namespace ateam_geometry
 {
@@ -39,15 +33,9 @@ using Ray = Kernel::Ray_2;
 using Rectangle = Kernel::Iso_rectangle_2;
 using Circle = Kernel::Circle_2;
 using Line = Kernel::Line_2;
-
-using PointCreator = CGAL::Creator_uniform_2<double, Point>;
 using Polygon = CGAL::Polygon_2<Kernel>;
 using Vector = Kernel::Vector_2;
 using Direction = Kernel::Direction_2;
-
-using TreeTraits = CGAL::Search_traits_2<Kernel>;
-using OrthoNeighborSearch = CGAL::Orthogonal_k_neighbor_search<TreeTraits>;
-using Tree = OrthoNeighborSearch::Tree;
 }  // namespace ateam_geometry
 
 #endif  // ATEAM_GEOMETRY__TYPES_HPP_


### PR DESCRIPTION
This seemed to be the lowest hanging fruit for improving Kenobi build times. Beyond this, things seem to get more subtle and will require more thought.