### PR TITLE
Fix neutralino for Ubuntu 24.04

### DIFF
--- a/ateam_ui/src/neutralino.config.json
+++ b/ateam_ui/src/neutralino.config.json
@@ -1,10 +1,14 @@
 {
+  "$schema": "https://raw.githubusercontent.com/neutralinojs/neutralinojs/main/schemas/neutralino.config.schema.json",
   "applicationId": "A-Team",
+  "version": "1.0.0",
   "port": 0,
   "defaultMode": "window",
-  "enableHTTPServer": true,
+  "documentRoot": "/resources/",
+  "url": "/",
+  "enableServer": true,
   "enableNativeAPI": true,
-  "url": "/resources/",
+  "tokenSecurity": "one-time",
   "nativeBlockList": [],
   "globalVariables": {
     "TEST": "Test Value"
@@ -30,7 +34,7 @@
     "binaryName": "Ateam_UI",
     "resourcesPath": "/resources/",
     "clientLibrary": "/resources/neutralino.js",
-    "binaryVersion": "2.8.0",
-    "clientVersion": "1.5.0"
+    "binaryVersion": "5.6.0",
+    "clientVersion": "5.6.0"
   }
 }


### PR DESCRIPTION
Turns out neutralino changed the name of some of the configuration options in the json file which caused some important configuration to just not get set