### PR TITLE
Fix kenobi world message data

### DIFF
--- a/ateam_kenobi/src/kenobi_node.cpp
+++ b/ateam_kenobi/src/kenobi_node.cpp
@@ -259,6 +259,7 @@ private:
 
   void ball_state_callback(const ateam_msgs::msg::BallState::SharedPtr ball_state_msg)
   {
+    world_.ball.visible = ball_state_msg->visible;
     if (ball_state_msg->visible) {
       world_.ball.pos = ateam_geometry::Point(
         ball_state_msg->pose.position.x,

--- a/ateam_kenobi/src/types/ball.hpp
+++ b/ateam_kenobi/src/types/ball.hpp
@@ -30,6 +30,7 @@ struct Ball
 {
   ateam_geometry::Point pos;
   ateam_geometry::Vector vel;
+  bool visible = false;
 };
 }  // namespace ateam_kenobi
 

--- a/ateam_kenobi/src/types/message_conversions.cpp
+++ b/ateam_kenobi/src/types/message_conversions.cpp
@@ -85,6 +85,7 @@ ateam_msgs::msg::BallState toMsg(const Ball & obj)
   ball_state_msg.pose.position.y = obj.pos.y();
   ball_state_msg.twist.linear.x = obj.vel.x();
   ball_state_msg.twist.linear.y = obj.vel.y();
+  ball_state_msg.visible = obj.visible;
 
   return ball_state_msg;
 }
@@ -98,6 +99,7 @@ ateam_msgs::msg::RobotState toMsg(const Robot & obj)
   robot_state_msg.twist.linear.x = obj.vel.x();
   robot_state_msg.twist.linear.y = obj.vel.y();
   robot_state_msg.twist.angular.z = obj.omega;
+  robot_state_msg.visible = obj.visible;
 
   return robot_state_msg;
 }
@@ -108,7 +110,7 @@ ateam_msgs::msg::World toMsg(const World & obj)
 
   world_msg.current_time =
     rclcpp::Time(
-    std::chrono::duration_cast<std::chrono::duration<double>>(
+    std::chrono::duration_cast<std::chrono::nanoseconds>(
       obj.current_time.time_since_epoch()).count());
 
   world_msg.field = toMsg(obj.field);
@@ -117,7 +119,7 @@ ateam_msgs::msg::World toMsg(const World & obj)
   world_msg.balls.push_back(toMsg(obj.ball));
 
   for (const Robot & robot : obj.our_robots) {
-    if (robot.IsAvailable()) {
+    if (robot.visible || robot.radio_connected) {
       world_msg.our_robots.push_back(toMsg(robot));
     } else {
       world_msg.our_robots.push_back(ateam_msgs::msg::RobotState());
@@ -125,7 +127,7 @@ ateam_msgs::msg::World toMsg(const World & obj)
   }
 
   for (const Robot & robot : obj.their_robots) {
-    if (robot.IsAvailable()) {
+    if (robot.visible) {
       world_msg.their_robots.push_back(toMsg(robot));
     } else {
       world_msg.their_robots.push_back(ateam_msgs::msg::RobotState());


### PR DESCRIPTION
Fixes several issues with the Kenobi Node world message:
* A double value of seconds was being passed into the nanoseconds field of the rclcpp:Time constructor
* The Ball and Robot toMsg conversion didn't populate the visible field
* Robots in the our and their robot msgs fields were only updated if they were "Available" which is probably not what we wanted for either option.

I did notice that Kenobi node currently seems to use a timestamp based off the time since starting your computer or something like that. Would it be better to swap to actual time since Unix epoch or something more absolute?

Closes #312