### PR TITLE
Fixes violations of 'Robot Too Close To Opponent Defense Area' rule

### DIFF
--- a/ateam_kenobi/CMakeLists.txt
+++ b/ateam_kenobi/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(kenobi_node_component SHARED
   src/joystick_enforcer.cpp
   src/kenobi_node.cpp
   src/play_selector.cpp
+  src/path_planning/escape_velocity.cpp
   src/path_planning/obstacles.cpp
   src/path_planning/path_planner.cpp
   src/plays/kickoff_plays/defense/their_kickoff_play.cpp

--- a/ateam_kenobi/src/path_planning/escape_velocity.cpp
+++ b/ateam_kenobi/src/path_planning/escape_velocity.cpp
@@ -1,0 +1,124 @@
+// Copyright 2025 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "escape_velocity.hpp"
+#include <algorithm>
+#include <ateam_common/robot_constants.hpp>
+#include "obstacles.hpp"
+
+namespace ateam_kenobi::path_planning
+{
+
+geometry_msgs::msg::Twist GenerateEscapeVelocity(
+  const Robot & robot,
+  const ateam_geometry::AnyShape & obstacle)
+{
+  if (std::holds_alternative<ateam_geometry::Circle>(obstacle)) {
+    const auto & circle = std::get<ateam_geometry::Circle>(obstacle);
+    return GenerateEscapeVelocity(robot, circle);
+  }
+
+  if (std::holds_alternative<ateam_geometry::Disk>(obstacle)) {
+    const auto & disk = std::get<ateam_geometry::Disk>(obstacle);
+    return GenerateEscapeVelocity(robot, disk);
+  }
+
+  if (std::holds_alternative<ateam_geometry::Rectangle>(obstacle)) {
+    const auto & rectangle = std::get<ateam_geometry::Rectangle>(obstacle);
+    return GenerateEscapeVelocity(robot, rectangle);
+  }
+
+  // Default case when we don't recognize the obstacle type
+  return geometry_msgs::msg::Twist{};
+}
+
+geometry_msgs::msg::Twist GenerateEscapeVelocity(
+  const Robot & robot,
+  const ateam_geometry::Circle & obstacle)
+{
+  const auto vector = robot.pos - obstacle.center();
+  const auto velocity = ateam_geometry::normalize(vector) * kSafeEscapeVelocity;
+  geometry_msgs::msg::Twist msg;
+  msg.linear.x = velocity.x();
+  msg.linear.y = velocity.y();
+  return msg;
+}
+
+geometry_msgs::msg::Twist GenerateEscapeVelocity(
+  const Robot & robot,
+  const ateam_geometry::Disk & obstacle)
+{
+  const auto vector = robot.pos - obstacle.center();
+  const auto velocity = ateam_geometry::normalize(vector) * kSafeEscapeVelocity;
+  geometry_msgs::msg::Twist msg;
+  msg.linear.x = velocity.x();
+  msg.linear.y = velocity.y();
+  return msg;
+}
+
+geometry_msgs::msg::Twist GenerateEscapeVelocity(
+  const Robot & robot,
+  const ateam_geometry::Rectangle & obstacle)
+{
+  std::array<ateam_geometry::Segment, 4> edges = {
+    ateam_geometry::Segment{obstacle[0], obstacle[1]},
+    ateam_geometry::Segment{obstacle[1], obstacle[2]},
+    ateam_geometry::Segment{obstacle[2], obstacle[3]},
+    ateam_geometry::Segment{obstacle[3], obstacle[0]},
+  };
+  std::array<double, 4> distances;
+  std::ranges::transform(
+        edges, distances.begin(), [&robot](const auto & edge) {
+      return CGAL::squared_distance(robot.pos, edge);
+        });
+  const auto min_iter = std::ranges::min_element(distances);
+
+  const auto closest_edge = edges[std::distance(distances.begin(), min_iter)];
+
+  const auto edge_direction = closest_edge.direction();
+
+  // Rotate direction by -90 deg. Assumes vertices are reported in counterclockwise order
+  const ateam_geometry::Vector escape_vector{edge_direction.dy(), -edge_direction.dx()};
+
+  const auto velocity = escape_vector * kSafeEscapeVelocity;
+  geometry_msgs::msg::Twist msg;
+  msg.linear.x = velocity.x();
+  msg.linear.y = velocity.y();
+  return msg;
+}
+
+std::optional<geometry_msgs::msg::Twist> GenerateEscapeVelocity(
+  const Robot & robot,
+  const std::vector<ateam_geometry::AnyShape> & obstacles, double footprint_inflation)
+{
+  const auto robot_footprint = ateam_geometry::makeDisk(robot.pos,
+      kRobotRadius + footprint_inflation);
+
+  /* TODO(barulicm): Using only the first colliding obstacle to generate escape velocities may not
+   * yield a useful velocity when multiple collisions are occurring simultaneously.
+   */
+  const auto colliding_obstacle = path_planning::GetCollidingObstacle(robot_footprint, obstacles);
+  if (!colliding_obstacle) {
+    return std::nullopt;
+  }
+  return GenerateEscapeVelocity(robot, *colliding_obstacle);
+}
+
+}  // namespace ateam_kenobi::path_planning

--- a/ateam_kenobi/src/path_planning/escape_velocity.hpp
+++ b/ateam_kenobi/src/path_planning/escape_velocity.hpp
@@ -1,0 +1,69 @@
+// Copyright 2025 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef PATH_PLANNING__ESCAPE_VELOCITY_HPP_
+#define PATH_PLANNING__ESCAPE_VELOCITY_HPP_
+
+#include <vector>
+#include <ateam_geometry/types.hpp>
+#include <ateam_geometry/any_shape.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include "types/robot.hpp"
+
+namespace ateam_kenobi::path_planning
+{
+
+constexpr double kSafeEscapeVelocity = 0.5;  // m/s
+
+/**
+ * @brief Creates a low velocity in the quickest direction to escape the given obstacle.
+ *
+ * @note This function does not actually check if the robot is currently in the given obstacle.
+ */
+geometry_msgs::msg::Twist GenerateEscapeVelocity(
+  const Robot & robot,
+  const ateam_geometry::AnyShape & obstacle);
+
+geometry_msgs::msg::Twist GenerateEscapeVelocity(
+  const Robot & robot,
+  const ateam_geometry::Circle & obstacle);
+
+geometry_msgs::msg::Twist GenerateEscapeVelocity(
+  const Robot & robot,
+  const ateam_geometry::Disk & obstacle);
+
+geometry_msgs::msg::Twist GenerateEscapeVelocity(
+  const Robot & robot,
+  const ateam_geometry::Rectangle & obstacle);
+
+/**
+ * @brief Creates a low velocity in the quickest direction to escape the first colliding obstacle
+ * in @c obstacles.
+ *
+ * @return std::optional<geometry_msgs::msg::Twist> The escape velocity, or @c nullopt if no
+ * obstacles collide with the robot.
+ */
+std::optional<geometry_msgs::msg::Twist> GenerateEscapeVelocity(
+  const Robot & robot,
+  const std::vector<ateam_geometry::AnyShape> & obstacles, double footprint_inflation = 0.06);
+
+}  // namespace ateam_kenobi::path_planning
+
+#endif  // PATH_PLANNING__ESCAPE_VELOCITY_HPP_

--- a/ateam_kenobi/src/plays/stop_play.hpp
+++ b/ateam_kenobi/src/plays/stop_play.hpp
@@ -57,6 +57,20 @@ private:
   bool isPointInOrBehindGoal(const ateam_geometry::Point & point, const World & world);
 
   std::vector<ateam_geometry::AnyShape> getAddedObstacles(const World & world);
+
+  void drawObstacles(
+    const World & world,
+    const std::vector<ateam_geometry::AnyShape> & added_obstacles);
+
+  void moveBotsTooCloseToBall(
+    const World & world,
+    const std::vector<ateam_geometry::AnyShape> & added_obstacles,
+    std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> & motion_commands);
+
+  void moveBotsInObstacles(
+    const World & world,
+    const std::vector<ateam_geometry::AnyShape> & added_obstacles,
+    std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> & motion_commands);
 };
 }  // namespace ateam_kenobi::plays
 

--- a/ateam_kenobi/src/plays/their_free_kick_play.cpp
+++ b/ateam_kenobi/src/plays/their_free_kick_play.cpp
@@ -116,10 +116,25 @@ void TheirFreeKickPlay::runBlockers(
   const std::vector<ateam_geometry::Point> & points,
   std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> & motion_commands)
 {
-  // See rules section 5.3.3 for Free Kick rules, with extra
-  const auto keepout_obstacle = ateam_geometry::makeDisk(world.ball.pos, 0.7);
-  getOverlays().drawCircle("keepout", keepout_obstacle, "red", "transparent");
-  std::vector<ateam_geometry::AnyShape> obstacles = {keepout_obstacle};
+  // Rules section 5.3.3 require 0.5m distance between defenders and ball
+  const auto ball_obstacle = ateam_geometry::makeDisk(world.ball.pos, 0.7);
+  getOverlays().drawCircle("ball_obstacle", ball_obstacle, "red", "transparent");
+
+  // Rules section 8.4.1 require 0.2m distance between all robtos and opponent defense area
+  const auto def_area_margin = kRobotRadius + 0.2;
+  const auto def_area_obst_width = world.field.defense_area_width + (2.0 * def_area_margin);
+  const auto def_area_obst_depth = world.field.defense_area_depth + def_area_margin;
+  const auto half_field_length = world.field.field_length / 2.0;
+  const auto def_area_back_x = half_field_length + ( 2 * world.field.boundary_width ) +
+    def_area_obst_depth;
+  const auto def_area_front_x = half_field_length - def_area_obst_depth;
+  const auto defense_area_obstacle = ateam_geometry::Rectangle{
+    ateam_geometry::Point{def_area_front_x, -def_area_obst_width / 2.0},
+    ateam_geometry::Point{def_area_back_x, def_area_obst_width / 2.0}
+  };
+  getOverlays().drawRectangle("defense_area_obstacle", defense_area_obstacle, "red", "transparent");
+
+  std::vector<ateam_geometry::AnyShape> obstacles = {ball_obstacle, defense_area_obstacle};
   for (auto i = 0ul; i < std::min(robots.size(), points.size()); ++i) {
     const auto & robot = robots[i];
     const auto & point = points[i];


### PR DESCRIPTION
In Stop and Free Kick, all robots need to keep at least 0.2m away from the opponent defense area.
This PR adjusts `StopPlay` and `TheirFreeKickPlay` to enforce this keepout rule.

Along the way, I refactored escape velocity generation out of `EasyMoveTo` into its own set of functions so it can be reused in other places (ie. `StopPlay`).

Handling this rule for our free kicks will be future work.