### PR TITLE
Adds FreeKickOnGoalPlay

### DIFF
--- a/ateam_kenobi/CMakeLists.txt
+++ b/ateam_kenobi/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(kenobi_node_component SHARED
   src/path_planning/escape_velocity.cpp
   src/path_planning/obstacles.cpp
   src/path_planning/path_planner.cpp
+  src/plays/free_kick_plays/defense/their_free_kick_play.cpp
+  src/plays/free_kick_plays/offense/free_kick_on_goal_play.cpp
   src/plays/kickoff_plays/defense/their_kickoff_play.cpp
   src/plays/kickoff_plays/offense/kickoff_on_goal.cpp
   src/plays/kickoff_plays/offense/kickoff_pass_play.cpp
@@ -48,7 +50,6 @@ add_library(kenobi_node_component SHARED
   src/plays/wall_play.cpp
   src/plays/basic_122.cpp
   src/plays/our_penalty_play.cpp
-  src/plays/their_free_kick_play.cpp
   src/plays/their_penalty_play.cpp
   src/plays/defense_play.cpp
   src/plays/extract_play.cpp

--- a/ateam_kenobi/src/motion/motion_controller.cpp
+++ b/ateam_kenobi/src/motion/motion_controller.cpp
@@ -134,7 +134,7 @@ ateam_msgs::msg::RobotMotionCommand MotionController::get_command(
     auto vel_vector = ateam_geometry::Vector(x_command, y_command);
 
     // clamp to max/min velocity
-    double min_vel = 0.0;
+    double min_vel = 0.4;
     if (ateam_geometry::norm(vel_vector) > this->v_max) {
       vel_vector = this->v_max * ateam_geometry::normalize(vel_vector);
     }
@@ -175,7 +175,7 @@ ateam_msgs::msg::RobotMotionCommand MotionController::get_command(
     double t_command = this->t_controller.compute_command(t_error, dt);
 
     if (trajectory_complete && xy_slow) {
-      double theta_min = 0.0;
+      double theta_min = 0.6;
       if (abs(t_command) < theta_min) {
         if (t_command > 0) {
           t_command = std::clamp(t_command, theta_min, this->t_max);

--- a/ateam_kenobi/src/motion/motion_controller.cpp
+++ b/ateam_kenobi/src/motion/motion_controller.cpp
@@ -134,7 +134,7 @@ ateam_msgs::msg::RobotMotionCommand MotionController::get_command(
     auto vel_vector = ateam_geometry::Vector(x_command, y_command);
 
     // clamp to max/min velocity
-    double min_vel = 0.4;
+    double min_vel = 0.0;
     if (ateam_geometry::norm(vel_vector) > this->v_max) {
       vel_vector = this->v_max * ateam_geometry::normalize(vel_vector);
     }
@@ -175,7 +175,7 @@ ateam_msgs::msg::RobotMotionCommand MotionController::get_command(
     double t_command = this->t_controller.compute_command(t_error, dt);
 
     if (trajectory_complete && xy_slow) {
-      double theta_min = 0.6;
+      double theta_min = 0.0;
       if (abs(t_command) < theta_min) {
         if (t_command > 0) {
           t_command = std::clamp(t_command, theta_min, this->t_max);

--- a/ateam_kenobi/src/play_selector.cpp
+++ b/ateam_kenobi/src/play_selector.cpp
@@ -85,6 +85,7 @@ PlaySelector::PlaySelector(rclcpp::Node & node)
     PassToLanePlay::PassDirection::Backward);
   addPlay<TestSpatialMapPlay>(stp_options);
   addPlay<SpatialPassPlay>(stp_options);
+  addPlay<FreeKickOnGoalPlay>(stp_options);
 }
 
 stp::Play * PlaySelector::getPlay(const World & world, ateam_msgs::msg::PlaybookState & state_msg)

--- a/ateam_kenobi/src/plays/free_kick_plays/all_free_kick_plays.hpp
+++ b/ateam_kenobi/src/plays/free_kick_plays/all_free_kick_plays.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 A Team
+// Copyright 2025 A Team
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,24 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#ifndef PLAYS__FREE_KICK_PLAYS__ALL_FREE_KICK_PLAYS_HPP_
+#define PLAYS__FREE_KICK_PLAYS__ALL_FREE_KICK_PLAYS_HPP_
 
-#ifndef PLAYS__ALL_PLAYS_HPP_
-#define PLAYS__ALL_PLAYS_HPP_
+#include "defense/their_free_kick_play.hpp"
+#include "offense/free_kick_on_goal_play.hpp"
 
-#include "halt_play.hpp"
-#include "kick_on_goal_play.hpp"
-#include "our_ball_placement_play.hpp"
-#include "their_ball_placement_play.hpp"
-#include "stop_play.hpp"
-#include "wall_play.hpp"
-#include "basic_122.hpp"
-#include "our_penalty_play.hpp"
-#include "their_penalty_play.hpp"
-#include "defense_play.hpp"
-#include "extract_play.hpp"
-#include "passing_plays/all_passing_plays.hpp"
-#include "free_kick_plays/all_free_kick_plays.hpp"
-#include "kickoff_plays/all_kickoff_plays.hpp"
-#include "test_plays/all_test_plays.hpp"
-
-#endif  // PLAYS__ALL_PLAYS_HPP_
+#endif  // PLAYS__FREE_KICK_PLAYS__ALL_FREE_KICK_PLAYS_HPP_

--- a/ateam_kenobi/src/plays/free_kick_plays/defense/their_free_kick_play.cpp
+++ b/ateam_kenobi/src/plays/free_kick_plays/defense/their_free_kick_play.cpp
@@ -107,7 +107,7 @@ void TheirFreeKickPlay::runBlockers(
   const auto ball_obstacle = ateam_geometry::makeDisk(world.ball.pos, 0.7);
   getOverlays().drawCircle("ball_obstacle", ball_obstacle, "red", "transparent");
 
-  // Rules section 8.4.1 require 0.2m distance between all robtos and opponent defense area
+  // Rules section 8.4.1 require 0.2m distance between all robots and opponent defense area
   const auto def_area_margin = kRobotRadius + 0.2;
   const auto def_area_obst_width = world.field.defense_area_width + (2.0 * def_area_margin);
   const auto def_area_obst_depth = world.field.defense_area_depth + def_area_margin;

--- a/ateam_kenobi/src/plays/free_kick_plays/defense/their_free_kick_play.cpp
+++ b/ateam_kenobi/src/plays/free_kick_plays/defense/their_free_kick_play.cpp
@@ -37,23 +37,10 @@ TheirFreeKickPlay::TheirFreeKickPlay(stp::Options stp_options)
 
 stp::PlayScore TheirFreeKickPlay::getScore(const World & world)
 {
-  switch (world.referee_info.running_command) {
-    case ateam_common::GameCommand::DirectFreeTheirs:
-      return world.in_play ? stp::PlayScore::Min() : stp::PlayScore::Max();
-    case ateam_common::GameCommand::NormalStart:
-      {
-        if (world.in_play) {
-          return stp::PlayScore::Min();
-        }
-        switch (world.referee_info.prev_command) {
-          case ateam_common::GameCommand::DirectFreeTheirs:
-            return stp::PlayScore::Max();
-          default:
-            return stp::PlayScore::NaN();
-        }
-      }
-    default:
-      return stp::PlayScore::NaN();
+  if(world.referee_info.running_command == ateam_common::GameCommand::DirectFreeTheirs) {
+    return world.in_play ? stp::PlayScore::Min() : stp::PlayScore::Max();
+  } else {
+    return stp::PlayScore::NaN();
   }
 }
 

--- a/ateam_kenobi/src/plays/free_kick_plays/defense/their_free_kick_play.hpp
+++ b/ateam_kenobi/src/plays/free_kick_plays/defense/their_free_kick_play.hpp
@@ -1,0 +1,61 @@
+// Copyright 2024 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef PLAYS__FREE_KICK_PLAYS__DEFENSE__THEIR_FREE_KICK_PLAY_HPP_
+#define PLAYS__FREE_KICK_PLAYS__DEFENSE__THEIR_FREE_KICK_PLAY_HPP_
+
+#include <vector>
+#include "stp/play.hpp"
+#include "play_helpers/easy_move_to.hpp"
+#include "tactics/standard_defense.hpp"
+
+namespace ateam_kenobi::plays
+{
+
+class TheirFreeKickPlay : public stp::Play
+{
+public:
+  static constexpr const char * kPlayName = "TheirFreeKickPlay";
+
+  explicit TheirFreeKickPlay(stp::Options stp_options);
+
+  stp::PlayScore getScore(const World & world) override;
+
+  void reset() override;
+
+  std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
+    16> runFrame(const World & world) override;
+
+private:
+  tactics::StandardDefense defense_;
+  std::array<play_helpers::EasyMoveTo, 16> easy_move_tos_;
+
+  std::vector<ateam_geometry::Point> getBlockerPoints(const World & world);
+
+  void runBlockers(
+    const World & world, const std::vector<Robot> & robots,
+    const std::vector<ateam_geometry::Point> & points,
+    std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
+    16> & motion_commands);
+};
+
+}  // namespace ateam_kenobi::plays
+
+#endif  // PLAYS__FREE_KICK_PLAYS__DEFENSE__THEIR_FREE_KICK_PLAY_HPP_

--- a/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.cpp
+++ b/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.cpp
@@ -1,0 +1,132 @@
+// Copyright 2025 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#include "free_kick_on_goal_play.hpp"
+#include "play_helpers/window_evaluation.hpp"
+#include "play_helpers/available_robots.hpp"
+#include "play_helpers/robot_assignment.hpp"
+#include "play_helpers/lanes.hpp"
+
+namespace ateam_kenobi::plays
+{
+
+FreeKickOnGoalPlay::FreeKickOnGoalPlay(stp::Options stp_options)
+: stp::Play(kPlayName, stp_options),
+  striker_(createChild<skills::PivotKick>("striker")),
+  idler_1_(createChild<skills::LaneIdler>("idler1")),
+  idler_2_(createChild<skills::LaneIdler>("idler2")),
+  defense_(createChild<tactics::StandardDefense>("defense"))
+{
+}
+
+stp::PlayScore FreeKickOnGoalPlay::getScore(const World & world)
+{
+  if(world.referee_info.running_command != ateam_common::GameCommand::DirectFreeOurs) {
+    return stp::PlayScore::NaN();
+  }
+
+  const auto largest_window = getLargestWindowOnGoal(world);
+  if (!largest_window) {
+    return stp::PlayScore::Min();
+  }
+  const auto squared_goal_width = world.field.goal_width * world.field.goal_width;
+  const auto fraction_of_goal_width = largest_window->squared_length() / squared_goal_width;
+  return stp::PlayScore::Max() * fraction_of_goal_width;
+}
+
+std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
+  16> FreeKickOnGoalPlay::runFrame(const World & world)
+{
+  std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> motion_commands;
+
+  const auto window = getLargestWindowOnGoal(world);
+
+  if(window) {
+    striker_.SetTargetPoint(CGAL::midpoint(*window));
+  } else {
+    const auto goal_center = ateam_geometry::Point(world.field.field_length / 2.0, 0.0);
+    striker_.SetTargetPoint(goal_center);
+  }
+
+  if(play_helpers::lanes::IsBallInLane(world, play_helpers::lanes::Lane::Left)) {
+    idler_1_.SetLane(play_helpers::lanes::Lane::Center);
+    idler_2_.SetLane(play_helpers::lanes::Lane::Right);
+  } else if(play_helpers::lanes::IsBallInLane(world, play_helpers::lanes::Lane::Center)) {
+    idler_1_.SetLane(play_helpers::lanes::Lane::Left);
+    idler_2_.SetLane(play_helpers::lanes::Lane::Right);
+  } else if(play_helpers::lanes::IsBallInLane(world, play_helpers::lanes::Lane::Right)) {
+    idler_1_.SetLane(play_helpers::lanes::Lane::Left);
+    idler_2_.SetLane(play_helpers::lanes::Lane::Center);
+  }
+
+  auto available_robots = play_helpers::getAvailableRobots(world);
+  play_helpers::removeGoalie(available_robots, world);
+
+  play_helpers::GroupAssignmentSet groups;
+  groups.AddPosition("striker", striker_.GetAssignmentPoint(world));
+  groups.AddGroup("defense", defense_.getAssignmentPoints(world));
+  if(available_robots.size() > 3) {
+    groups.AddPosition("idler1", idler_1_.GetAssignmentPoint(world));
+  }
+  if(available_robots.size() > 4) {
+    groups.AddPosition("idler2", idler_2_.GetAssignmentPoint(world));
+  }
+
+  const auto assignments = play_helpers::assignGroups(available_robots, groups);
+
+  assignments.RunPositionIfAssigned("striker", [this, &world, &motion_commands](const auto & robot){
+      motion_commands[robot.id] = striker_.RunFrame(world, robot);
+      getPlayInfo()["Striker"] = robot.id;
+  });
+
+  const auto defenders = assignments.GetGroupFilledAssignmentsOrEmpty("defense");
+  defense_.runFrame(world, defenders, motion_commands);
+  std::ranges::transform(defenders, std::back_inserter(getPlayInfo()["Defenders"]),
+    [](const auto & r){return r.id;});
+
+  assignments.RunPositionIfAssigned("idler1", [this, &world, &motion_commands](const auto & robot){
+      motion_commands[robot.id] = idler_1_.RunFrame(world, robot);
+      getPlayInfo()["Idlers"].push_back(robot.id);
+  });
+
+  assignments.RunPositionIfAssigned("idler2", [this, &world, &motion_commands](const auto & robot){
+      motion_commands[robot.id] = idler_2_.RunFrame(world, robot);
+      getPlayInfo()["Idlers"].push_back(robot.id);
+  });
+
+  return motion_commands;
+}
+
+std::optional<ateam_geometry::Segment> FreeKickOnGoalPlay::getLargestWindowOnGoal(
+  const World & world)
+{
+  const ateam_geometry::Segment their_goal_segment{
+    ateam_geometry::Point{world.field.field_length / 2.0, -world.field.goal_width / 2.0},
+    ateam_geometry::Point{world.field.field_length / 2.0, world.field.goal_width / 2.0}
+  };
+  const auto windows = play_helpers::window_evaluation::getWindows(
+    their_goal_segment,
+    world.ball.pos, play_helpers::getVisibleRobots(
+      world.their_robots));
+  return play_helpers::window_evaluation::getLargestWindow(windows);
+}
+
+}  // namespace ateam_kenobi::plays

--- a/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.hpp
+++ b/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 A Team
+// Copyright 2025 A Team
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,44 +18,40 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef PLAYS__THEIR_FREE_KICK_PLAY_HPP_
-#define PLAYS__THEIR_FREE_KICK_PLAY_HPP_
+#ifndef PLAYS__FREE_KICK_PLAYS__DEFENSE__FREE_KICK_ON_GOAL_PLAY_HPP_
+#define PLAYS__FREE_KICK_PLAYS__DEFENSE__FREE_KICK_ON_GOAL_PLAY_HPP_
 
 #include <vector>
 #include "stp/play.hpp"
 #include "play_helpers/easy_move_to.hpp"
 #include "tactics/standard_defense.hpp"
+#include "skills/pivot_kick.hpp"
+#include "skills/lane_idler.hpp"
 
 namespace ateam_kenobi::plays
 {
 
-class TheirFreeKickPlay : public stp::Play
+class FreeKickOnGoalPlay : public stp::Play
 {
 public:
-  static constexpr const char * kPlayName = "TheirFreeKickPlay";
+  static constexpr const char * kPlayName = "FreeKickOnGoalPlay";
 
-  explicit TheirFreeKickPlay(stp::Options stp_options);
+  explicit FreeKickOnGoalPlay(stp::Options stp_options);
 
   stp::PlayScore getScore(const World & world) override;
-
-  void reset() override;
 
   std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
     16> runFrame(const World & world) override;
 
 private:
+  skills::PivotKick striker_;
+  skills::LaneIdler idler_1_;
+  skills::LaneIdler idler_2_;
   tactics::StandardDefense defense_;
-  std::array<play_helpers::EasyMoveTo, 16> easy_move_tos_;
 
-  std::vector<ateam_geometry::Point> getBlockerPoints(const World & world);
-
-  void runBlockers(
-    const World & world, const std::vector<Robot> & robots,
-    const std::vector<ateam_geometry::Point> & points,
-    std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
-    16> & motion_commands);
+  std::optional<ateam_geometry::Segment> getLargestWindowOnGoal(const World & world);
 };
 
 }  // namespace ateam_kenobi::plays
 
-#endif  // PLAYS__THEIR_FREE_KICK_PLAY_HPP_
+#endif  // PLAYS__FREE_KICK_PLAYS__DEFENSE__FREE_KICK_ON_GOAL_PLAY_HPP_

--- a/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.hpp
+++ b/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.hpp
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef PLAYS__FREE_KICK_PLAYS__DEFENSE__FREE_KICK_ON_GOAL_PLAY_HPP_
-#define PLAYS__FREE_KICK_PLAYS__DEFENSE__FREE_KICK_ON_GOAL_PLAY_HPP_
+#ifndef PLAYS__FREE_KICK_PLAYS__OFFENSE__FREE_KICK_ON_GOAL_PLAY_HPP_
+#define PLAYS__FREE_KICK_PLAYS__OFFENSE__FREE_KICK_ON_GOAL_PLAY_HPP_
 
 #include <vector>
 #include "stp/play.hpp"
@@ -49,9 +49,11 @@ private:
   skills::LaneIdler idler_2_;
   tactics::StandardDefense defense_;
 
-  std::optional<ateam_geometry::Segment> getLargestWindowOnGoal(const World & world);
+  std::optional<ateam_geometry::Segment> GetLargestWindowOnGoal(const World & world);
+
+  void SetDefenseAreaObstacles(const World & world);
 };
 
 }  // namespace ateam_kenobi::plays
 
-#endif  // PLAYS__FREE_KICK_PLAYS__DEFENSE__FREE_KICK_ON_GOAL_PLAY_HPP_
+#endif  // PLAYS__FREE_KICK_PLAYS__OFFENSE__FREE_KICK_ON_GOAL_PLAY_HPP_

--- a/ateam_kenobi/src/plays/passing_plays/pass_to_segment_play.cpp
+++ b/ateam_kenobi/src/plays/passing_plays/pass_to_segment_play.cpp
@@ -45,8 +45,7 @@ stp::PlayScore PassToSegmentPlay::getScore(const World & world)
   // TODO(barulicm) does not work generically if we want to use this to get the ball into play
   if (!world.in_play &&
     world.referee_info.running_command != ateam_common::GameCommand::ForceStart &&
-    world.referee_info.running_command != ateam_common::GameCommand::NormalStart &&
-    world.referee_info.running_command != ateam_common::GameCommand::DirectFreeOurs)
+    world.referee_info.running_command != ateam_common::GameCommand::NormalStart)
   {
     return stp::PlayScore::NaN();
   }

--- a/ateam_kenobi/src/plays/passing_plays/spatial_pass_play.cpp
+++ b/ateam_kenobi/src/plays/passing_plays/spatial_pass_play.cpp
@@ -44,6 +44,12 @@ SpatialPassPlay::SpatialPassPlay(stp::Options stp_options)
 
 stp::PlayScore SpatialPassPlay::getScore(const World & world)
 {
+  if (!world.in_play &&
+    world.referee_info.running_command != ateam_common::GameCommand::ForceStart &&
+    world.referee_info.running_command != ateam_common::GameCommand::NormalStart)
+  {
+    return stp::PlayScore::NaN();
+  }
   if(play_helpers::WhoHasPossession(world) == play_helpers::PossessionResult::Theirs) {
     return stp::PlayScore::Min();
   }

--- a/ateam_kenobi/src/skills/lane_idler.cpp
+++ b/ateam_kenobi/src/skills/lane_idler.cpp
@@ -45,7 +45,7 @@ ateam_msgs::msg::RobotMotionCommand LaneIdler::RunFrame(const World & world, con
 {
   easy_move_to_.setTargetPosition(GetIdlingPosition(world));
   easy_move_to_.face_point(world.ball.pos);
-  return easy_move_to_.runFrame(robot, world);
+  return easy_move_to_.runFrame(robot, world, extra_obstacles_);
 }
 
 ateam_geometry::Point LaneIdler::GetIdlingPosition(const World & world)

--- a/ateam_kenobi/src/skills/lane_idler.hpp
+++ b/ateam_kenobi/src/skills/lane_idler.hpp
@@ -21,6 +21,8 @@
 #ifndef SKILLS__LANE_IDLER_HPP_
 #define SKILLS__LANE_IDLER_HPP_
 
+#include <vector>
+#include <ateam_geometry/any_shape.hpp>
 #include "stp/skill.hpp"
 #include "play_helpers/easy_move_to.hpp"
 #include "play_helpers/lanes.hpp"
@@ -44,9 +46,15 @@ public:
     lane_ = lane;
   }
 
+  void SetExtraObstacles(std::vector<ateam_geometry::AnyShape> obstacles)
+  {
+    extra_obstacles_ = obstacles;
+  }
+
 private:
   play_helpers::lanes::Lane lane_ = play_helpers::lanes::Lane::Center;
   play_helpers::EasyMoveTo easy_move_to_;
+  std::vector<ateam_geometry::AnyShape> extra_obstacles_;
 
   ateam_geometry::Point GetIdlingPosition(const World & world);
 };


### PR DESCRIPTION
This PR adds our first dedicated free kick play.
This involves a few changes:
- Adds `OurFreeKickOnGoal` play for free kicks where we have a direct shot on goal
- Disables `SpatialPassPlay` and `PassToSegmentPlay` during our free kicks
  - we were previously using these to bring the ball into play
- Moves all free kick plays into the `free_kick_plays` folder
- Adds ability to set extra obstacles on the `LaneIdler` skill.
  - I don't _love_ this pattern, but hopefully it just doesn't show up that much.

Future PRs will add more plays to pick from for offensive free kicks.