### PR TITLE
Adds chip to joystick controller.

### DIFF
--- a/ateam_joystick_control/config/xbox_joy_config.yaml
+++ b/ateam_joystick_control/config/xbox_joy_config.yaml
@@ -12,8 +12,9 @@
         z:
           axis: 3
           scale: 4.0
-      kick: 5
+      kick: "axis 5 < -0.8"
+      chip: "button 5"
       dribbler:
-        increment: 3
-        decrement: 2
-        spin: 4
+        increment: "button 3"
+        decrement: "button 2"
+        spin: "button 4"


### PR DESCRIPTION
This PR adds the concept of trigger functions to the joystick control node. This allows us to use an axis (ie. a gamepad trigger) to fire off a boolean control (ie. kicking). This was done so I could move "kick" to the right trigger and add "chip" as the right shoulder button.

With this PR, the joystick control node can send chip commands.

New controls (xbox):

| Control | Input |
| --- | --- |
| x vel | left stick y |
| y vel | left stick x |
| angular vel | right stick x |
| kick | right trigger |
| chip | right shoulder |
| dribble | left shoulder |
| dribbler speed  up | Y |
| dribbler speed down | X |