### PR TITLE
Remove the ui namespace

### DIFF
--- a/ateam_ui/launch/ateam_ui_debug_launch.py
+++ b/ateam_ui/launch/ateam_ui_debug_launch.py
@@ -34,14 +34,12 @@ def generate_launch_description():
 
     rosbridge_node = launch_ros.actions.Node(
         package="rosbridge_server",
-        namespace="ui",
         name="rosbridge",
         executable="rosbridge_websocket.py"
     )
 
     rosapi_node = launch_ros.actions.Node(
         package="rosapi",
-        namespace="ui",
         name="rosapi",
         executable="rosapi_node"
     )

--- a/ateam_ui/launch/ateam_ui_launch.py
+++ b/ateam_ui/launch/ateam_ui_launch.py
@@ -34,14 +34,12 @@ def generate_launch_description():
 
     rosbridge_node = launch_ros.actions.Node(
         package="rosbridge_server",
-        namespace="ui",
         name="rosbridge",
         executable="rosbridge_websocket.py"
     )
 
     rosapi_node = launch_ros.actions.Node(
         package="rosapi",
-        namespace="ui",
         name="rosapi",
         executable="rosapi_node"
     )


### PR DESCRIPTION
Ros2-web-bridge made a breaking change to the way the ros2 api works which has not been updated in Roslibjs yet. Removing the namespace on the rosapi and web bridge nodes fixes the issues this causes.