### PR TITLE
Pre-cuda changes

### DIFF
--- a/ateam_geometry/CMakeLists.txt
+++ b/ateam_geometry/CMakeLists.txt
@@ -31,7 +31,7 @@ ament_target_dependencies(${PROJECT_NAME} PUBLIC
 )
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(CGAL)
+ament_export_dependencies(CGAL angles)
 
 install(
   DIRECTORY include/

--- a/ateam_kenobi/src/core/types/field.hpp
+++ b/ateam_kenobi/src/core/types/field.hpp
@@ -34,13 +34,13 @@ struct FieldSidedInfo
 };
 struct Field
 {
-  float field_length;
-  float field_width;
-  float goal_width;
-  float goal_depth;
-  float boundary_width;
-  float defense_area_width;
-  float defense_area_depth;
+  float field_length = 0.f;
+  float field_width = 0.f;
+  float goal_width = 0.f;
+  float goal_depth = 0.f;
+  float boundary_width = 0.f;
+  float defense_area_width = 0.f;
+  float defense_area_depth = 0.f;
   std::array<ateam_geometry::Point, 4> field_corners;
   FieldSidedInfo ours;
   FieldSidedInfo theirs;

--- a/ateam_kenobi/src/core/types/referee_info.hpp
+++ b/ateam_kenobi/src/core/types/referee_info.hpp
@@ -30,11 +30,11 @@ namespace ateam_kenobi
 {
 struct RefereeInfo
 {
-  int our_goalie_id;
-  int their_goalie_id;
-  ateam_common::GameStage current_game_stage;
-  ateam_common::GameCommand running_command;
-  ateam_common::GameCommand prev_command;
+  int our_goalie_id = -1;
+  int their_goalie_id = -1;
+  ateam_common::GameStage current_game_stage = ateam_common::GameStage::Unknown;
+  ateam_common::GameCommand running_command = ateam_common::GameCommand::Halt;
+  ateam_common::GameCommand prev_command = ateam_common::GameCommand::Halt;
   ateam_geometry::Point designated_position;
   std::chrono::system_clock::time_point command_time;
 };

--- a/ateam_kenobi/src/core/types/robot.hpp
+++ b/ateam_kenobi/src/core/types/robot.hpp
@@ -33,9 +33,9 @@ struct Robot
   bool radio_connected = false;
 
   ateam_geometry::Point pos;
-  double theta;
+  double theta = 0.0;
   ateam_geometry::Vector vel;
-  double omega;
+  double omega = 0.0;
 
   bool breakbeam_ball_detected = false;
 

--- a/ateam_kenobi/src/core/types/world.hpp
+++ b/ateam_kenobi/src/core/types/world.hpp
@@ -45,9 +45,9 @@ struct World
   std::array<Robot, 16> our_robots;
   std::array<Robot, 16> their_robots;
 
-  bool in_play;
-  bool our_penalty;
-  bool their_penalty;
+  bool in_play = false;
+  bool our_penalty = false;
+  bool their_penalty = false;
 
   int ignore_side = 0;
 

--- a/ateam_kenobi/src/core/visualization/overlays.cpp
+++ b/ateam_kenobi/src/core/visualization/overlays.cpp
@@ -302,6 +302,30 @@ void Overlays::drawHeatmap(
   addOverlay(msg);
 }
 
+
+void Overlays::drawHeatmap(
+  const std::string & name, const ateam_geometry::Rectangle & bounds,
+  const std::vector<uint8_t> & data, const std::size_t resolution_width,
+  const std::size_t resolution_height, const uint8_t alpha, const uint32_t lifetime)
+{
+  ateam_msgs::msg::Overlay msg;
+  msg.ns = ns_;
+  msg.name = name;
+  msg.visible = true;
+  msg.type = ateam_msgs::msg::Overlay::HEATMAP;
+  msg.command = ateam_msgs::msg::Overlay::REPLACE;
+  msg.lifetime = lifetime;
+  msg.position.x = std::midpoint(bounds.xmin(), bounds.xmax());
+  msg.position.y = std::midpoint(bounds.ymin(), bounds.ymax());
+  msg.scale.x = bounds.xmax() - bounds.xmin();
+  msg.scale.y = bounds.ymax() - bounds.ymin();
+  msg.heatmap_resolution_width = resolution_width;
+  msg.heatmap_resolution_height = resolution_height;
+  msg.heatmap_alpha = {alpha};
+  msg.heatmap_data = data;
+  addOverlay(msg);
+}
+
 void Overlays::addOverlay(ateam_msgs::msg::Overlay overlay)
 {
   if (overlay_array_) {

--- a/ateam_kenobi/src/core/visualization/overlays.hpp
+++ b/ateam_kenobi/src/core/visualization/overlays.hpp
@@ -85,6 +85,12 @@ public:
     const std::string & name, const ateam_geometry::Rectangle & bounds,
     const cv::Mat & data, const cv::Mat & alpha, const uint32_t lifetime = kDefaultLifetime);
 
+  void drawHeatmap(
+    const std::string & name, const ateam_geometry::Rectangle & bounds,
+    const std::vector<uint8_t> & data, const std::size_t resolution_width,
+    const std::size_t resolution_height, const uint8_t alpha = 255,
+    const uint32_t lifetime = kDefaultLifetime);
+
 private:
   static const uint32_t kDefaultLifetime = 200;
   std::string ns_;


### PR DESCRIPTION
While working on the CUDA spatial stuff, I changed a few things that aren't specific to spatial stuff. This PR includes those changes.

* Adds missing dependency export to ateam_geometry
* Adds field initializers to Kenobi internal types
* Adds a new overload to `drawHeatmap` that doesn't depend on OpenCV