### PR TITLE
Disables path caching until motion controller is ready.

### DIFF
--- a/ateam_kenobi/src/core/path_planning/path_planner.cpp
+++ b/ateam_kenobi/src/core/path_planning/path_planner.cpp
@@ -379,6 +379,8 @@ bool PathPlanner::shouldReplan(
   const std::vector<ateam_geometry::AnyShape> & obstacles,
   const PlannerOptions & options)
 {
+  // TODO(barulicm): re-enable after motion controller is compatible
+  return true;
   if (options.force_replan) {
     return true;
   }


### PR DESCRIPTION
Turns out the motion controller assumes it's restarting the trajectory every time we give it a new one, so path caching breaks everything.
This PR disables path caching until the motion controller revamp is complete that makes it compatible with this feature.