### PR TITLE
CUDA perf and correctness fixes

### DIFF
--- a/ateam_spatial/CMakeLists.txt
+++ b/ateam_spatial/CMakeLists.txt
@@ -6,6 +6,8 @@ enable_language(CUDA)
 find_package(ament_cmake REQUIRED)
 find_package(CUDAToolkit REQUIRED)
 
+set(CMAKE_CUDA_FLAGS "-Xptxas=\"-v\" --maxrregcount 62")
+
 add_library(${PROJECT_NAME} SHARED
   src/layers/distance_down_field.cu
   src/layers/distance_from_field_edge.cu

--- a/ateam_spatial/CMakeLists.txt
+++ b/ateam_spatial/CMakeLists.txt
@@ -6,8 +6,6 @@ enable_language(CUDA)
 find_package(ament_cmake REQUIRED)
 find_package(CUDAToolkit REQUIRED)
 
-set(CMAKE_CUDA_FLAGS "-Xptxas=\"-v\" --maxrregcount 62")
-
 add_library(${PROJECT_NAME} SHARED
   src/layers/distance_down_field.cu
   src/layers/distance_from_field_edge.cu
@@ -37,6 +35,10 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
   CUDA_STANDARD 17
   CUDA_ARCHITECTURES native
 )
+target_compile_options(${PROJECT_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--maxrregcount 62>)
+if(ATEAM_SPATIAL_CUDA_COMPILE_STATS)
+  target_compile_options(${PROJECT_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xptxas="-v">)
+endif()
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(CUDAToolkit)

--- a/ateam_spatial/include/ateam_spatial/layers/distance_down_field.hpp
+++ b/ateam_spatial/include/ateam_spatial/layers/distance_down_field.hpp
@@ -28,7 +28,7 @@ namespace ateam_spatial::layers
 {
 
 CUDA_HOSTDEV float DistanceDownField(
-  const int x, const FieldDimensions & field_dims,
+  const float x, const FieldDimensions & field_dims,
   const SpatialSettings & settings);
 
 }  // namespace ateam_spatial::layers

--- a/ateam_spatial/include/ateam_spatial/layers/distance_from_field_edge.hpp
+++ b/ateam_spatial/include/ateam_spatial/layers/distance_from_field_edge.hpp
@@ -28,7 +28,7 @@ namespace ateam_spatial::layers
 {
 
 CUDA_HOSTDEV float DistanceFromFieldEdge(
-  const int x, const int y, const FieldDimensions & field_dims,
+  const float x, const float y, const FieldDimensions & field_dims,
   const SpatialSettings & settings);
 
 }  // namespace ateam_spatial::layers

--- a/ateam_spatial/include/ateam_spatial/layers/distance_to_their_bots.hpp
+++ b/ateam_spatial/include/ateam_spatial/layers/distance_to_their_bots.hpp
@@ -28,7 +28,7 @@ namespace ateam_spatial::layers
 {
 
 CUDA_HOSTDEV float DistanceToTheirBots(
-  const int x, const int y, const Robot * their_bots, const FieldDimensions & field_dims,
+  const float x, const float y, const Robot * their_bots, const FieldDimensions & field_dims,
   const SpatialSettings & settings);
 
 }  // namespace ateam_spatial::layers

--- a/ateam_spatial/include/ateam_spatial/layers/in_field.hpp
+++ b/ateam_spatial/include/ateam_spatial/layers/in_field.hpp
@@ -28,7 +28,7 @@ namespace ateam_spatial::layers
 {
 
 CUDA_HOSTDEV float InField(
-  const int x, const int y, const FieldDimensions & field_dims,
+  const float x, const float y, const FieldDimensions & field_dims,
   const SpatialSettings & settings);
 
 }  // namespace ateam_spatial::layers

--- a/ateam_spatial/include/ateam_spatial/layers/line_of_sight_ball.hpp
+++ b/ateam_spatial/include/ateam_spatial/layers/line_of_sight_ball.hpp
@@ -28,7 +28,7 @@ namespace ateam_spatial::layers
 {
 
 CUDA_HOSTDEV float LineOfSightBall(
-  const int x, const int y, const Ball & ball, const Robot * their_bots, const FieldDimensions & field_dims,
+  const float x, const float y, const Ball & ball, const Robot * their_bots, const FieldDimensions & field_dims,
   const SpatialSettings & settings);
 
 }  // namespace ateam_spatial::layers

--- a/ateam_spatial/include/ateam_spatial/layers/outside_their_defense_area.hpp
+++ b/ateam_spatial/include/ateam_spatial/layers/outside_their_defense_area.hpp
@@ -28,7 +28,7 @@ namespace ateam_spatial::layers
 {
 
 CUDA_HOSTDEV float OutsideTheirDefenseArea(
-  const int x, const int y, const FieldDimensions & field_dims,
+  const float x, const float y, const FieldDimensions & field_dims,
   const SpatialSettings & settings);
 
 }  // namespace ateam_spatial::layers

--- a/ateam_spatial/include/ateam_spatial/layers/width_of_shot_on_goal.hpp
+++ b/ateam_spatial/include/ateam_spatial/layers/width_of_shot_on_goal.hpp
@@ -28,7 +28,7 @@ namespace ateam_spatial::layers
 {
 
 CUDA_HOSTDEV float WidthOfShotOnGoal(
-  const int x, const int y, const Robot * their_bots, const FieldDimensions & field_dims,
+  const float x, const float y, const Robot * their_bots, const FieldDimensions & field_dims,
   const SpatialSettings & settings);
 
 }  // namespace ateam_spatial::layers

--- a/ateam_spatial/src/layers/distance_down_field.cu
+++ b/ateam_spatial/src/layers/distance_down_field.cu
@@ -4,8 +4,8 @@
 namespace ateam_spatial::layers
 {
 
-CUDA_HOSTDEV float DistanceDownField(const int x, const FieldDimensions & field_dims, const SpatialSettings & settings) {
-  return SpatialToRealX(x, field_dims, settings) + (WorldWidthReal(field_dims) / 2.0);
+CUDA_HOSTDEV float DistanceDownField(const float x, const FieldDimensions & field_dims, const SpatialSettings & settings) {
+  return x + (WorldWidthReal(field_dims) / 2.0);
 }
   
 } // namespace ateam_spatial::layers

--- a/ateam_spatial/src/layers/distance_from_field_edge.cu
+++ b/ateam_spatial/src/layers/distance_from_field_edge.cu
@@ -4,9 +4,9 @@
 namespace ateam_spatial::layers
 {
 
-CUDA_HOSTDEV float DistanceFromFieldEdge(const int x, const int y, const FieldDimensions & field_dims, const SpatialSettings & settings) {
-  const auto x_real = SpatialToRealX(x, field_dims, settings);
-  const auto y_real = SpatialToRealY(y, field_dims, settings);
+CUDA_HOSTDEV float DistanceFromFieldEdge(const float x, const float y, const FieldDimensions & field_dims, const SpatialSettings & settings) {
+  const auto x_real = x;
+  const auto y_real = y;
   const auto half_world_width = WorldWidthReal(field_dims) / 2.0;
   const auto half_world_height = WorldHeightReal(field_dims) / 2.0;
   const auto half_world_diff = half_world_width - half_world_height;

--- a/ateam_spatial/src/layers/distance_to_their_bots.cu
+++ b/ateam_spatial/src/layers/distance_to_their_bots.cu
@@ -5,9 +5,9 @@
 namespace ateam_spatial::layers
 {
 
-CUDA_HOSTDEV float DistanceToTheirBots(const int x, const int y, const Robot * their_robots, const FieldDimensions & field_dims, const SpatialSettings & settings) {
-  const auto real_x = SpatialToRealX(x, field_dims, settings);
-  const auto real_y = SpatialToRealY(y, field_dims, settings);
+CUDA_HOSTDEV float DistanceToTheirBots(const float x, const float y, const Robot * their_robots, const FieldDimensions & field_dims, const SpatialSettings & settings) {
+  const auto real_x = x;
+  const auto real_y = y;
   auto result = MAXFLOAT;
   for(auto i = 0; i < 16; ++i) {
     const auto & robot = their_robots[i];

--- a/ateam_spatial/src/layers/in_field.cu
+++ b/ateam_spatial/src/layers/in_field.cu
@@ -4,11 +4,11 @@
 namespace ateam_spatial::layers
 {
 
-CUDA_HOSTDEV float InField(const int x, const int y, const FieldDimensions & field_dims, const SpatialSettings & settings) {
-  const auto pos_x_thresh = RealToSpatialX(field_dims.field_length / 2.0, field_dims, settings);
-  const auto neg_x_thresh = RealToSpatialX(-field_dims.field_length / 2.0, field_dims, settings);
-  const auto pos_y_thresh = RealToSpatialY(field_dims.field_width / 2.0, field_dims, settings);
-  const auto neg_y_thresh = RealToSpatialY(-field_dims.field_width / 2.0, field_dims, settings);
+CUDA_HOSTDEV float InField(const float x, const float y, const FieldDimensions & field_dims, const SpatialSettings & settings) {
+  const auto pos_x_thresh = field_dims.field_length / 2.0;
+  const auto neg_x_thresh = -field_dims.field_length / 2.0;
+  const auto pos_y_thresh = field_dims.field_width / 2.0;
+  const auto neg_y_thresh = -field_dims.field_width / 2.0;
 
   return (x <= pos_x_thresh) && (x >= neg_x_thresh) && (y <= pos_y_thresh) && (y >= neg_y_thresh);
 }

--- a/ateam_spatial/src/layers/line_of_sight_ball.cu
+++ b/ateam_spatial/src/layers/line_of_sight_ball.cu
@@ -5,9 +5,9 @@
 namespace ateam_spatial::layers
 {
 
-CUDA_HOSTDEV float LineOfSightBall(const int x, const int y, const Ball & ball, const Robot * their_bots, const FieldDimensions & field_dims, const SpatialSettings & settings) {
-  const auto real_x = SpatialToRealX(x, field_dims, settings);
-  const auto real_y = SpatialToRealY(y, field_dims, settings);
+CUDA_HOSTDEV float LineOfSightBall(const float x, const float y, const Ball & ball, const Robot * their_bots, const FieldDimensions & field_dims, const SpatialSettings & settings) {
+  const auto real_x = x;
+  const auto real_y = y;
 
   return LineOfSight(real_x, real_y, ball.x, ball.y, their_bots, field_dims, settings);
 }

--- a/ateam_spatial/src/layers/outside_their_defense_area.cu
+++ b/ateam_spatial/src/layers/outside_their_defense_area.cu
@@ -4,11 +4,11 @@
 namespace ateam_spatial::layers
 {
 
-CUDA_HOSTDEV float OutsideTheirDefenseArea(const int x, const int y, const FieldDimensions & field_dims, const SpatialSettings & settings) {
-  const auto pos_x_thresh = RealToSpatialX(field_dims.field_length / 2.0, field_dims, settings);
-  const auto neg_x_thresh = RealToSpatialX((field_dims.field_length / 2.0) - field_dims.defense_area_depth, field_dims, settings);
-  const auto pos_y_thresh = RealToSpatialY(field_dims.defense_area_width / 2.0, field_dims, settings);
-  const auto neg_y_thresh = RealToSpatialY(-field_dims.defense_area_width / 2.0, field_dims, settings);
+CUDA_HOSTDEV float OutsideTheirDefenseArea(const float x, const float y, const FieldDimensions & field_dims, const SpatialSettings & settings) {
+  const auto pos_x_thresh = field_dims.field_length / 2.0;
+  const auto neg_x_thresh = (field_dims.field_length / 2.0) - field_dims.defense_area_depth;
+  const auto pos_y_thresh = field_dims.defense_area_width / 2.0;
+  const auto neg_y_thresh = -field_dims.defense_area_width / 2.0;
 
   return !((x <= pos_x_thresh) && (x >= neg_x_thresh) && (y <= pos_y_thresh) && (y >= neg_y_thresh));
 }

--- a/ateam_spatial/src/layers/width_of_shot_on_goal.cu
+++ b/ateam_spatial/src/layers/width_of_shot_on_goal.cu
@@ -5,11 +5,11 @@
 namespace ateam_spatial::layers
 {
 
-CUDA_HOSTDEV float WidthOfShotOnGoal(const int x, const int y, const Robot * their_robots, const FieldDimensions & field_dims, const SpatialSettings & settings) {
+CUDA_HOSTDEV float WidthOfShotOnGoal(const float x, const float y, const Robot * their_robots, const FieldDimensions & field_dims, const SpatialSettings & settings) {
   constexpr int kNumSteps = 100;
 
-  const auto real_x = SpatialToRealX(x, field_dims, settings);
-  const auto real_y = SpatialToRealY(y, field_dims, settings);
+  const auto real_x = x;
+  const auto real_y = y;
 
   const auto goal_x = field_dims.field_length / 2.0;
   const auto goal_y_start = -field_dims.goal_width / 2.0;

--- a/ateam_spatial/src/maps/receiver_position_quality.cu
+++ b/ateam_spatial/src/maps/receiver_position_quality.cu
@@ -6,12 +6,15 @@
 #include "ateam_spatial/layers/line_of_sight_ball.hpp"
 #include "ateam_spatial/layers/outside_their_defense_area.hpp"
 #include "ateam_spatial/layers/width_of_shot_on_goal.hpp"
+#include "ateam_spatial/coordinate_conversions.hpp"
 
 namespace ateam_spatial::maps
 {
 
-CUDA_HOSTDEV float ReceiverPositionQuality(const int x, const int y, const Ball & ball, const Robot * their_bots, const FieldDimensions &field_dims, const SpatialSettings &settings)
+CUDA_HOSTDEV float ReceiverPositionQuality(const int spatial_x, const int spatial_y, const Ball & ball, const Robot * their_bots, const FieldDimensions &field_dims, const SpatialSettings &settings)
 {
+  const auto x = SpatialToRealX(spatial_x, field_dims, settings);
+  const auto y = SpatialToRealY(spatial_y, field_dims, settings);
   const auto max_edge_dist = 0.75;
   const auto edge_dist_multiplier = min(layers::DistanceFromFieldEdge(x, y, field_dims, settings), max_edge_dist) / max_edge_dist;
   const auto shot_width_multiplier = layers::WidthOfShotOnGoal(x, y, their_bots, field_dims, settings) / field_dims.goal_width;

--- a/ateam_spatial/src/spatial_evaluator.cu
+++ b/ateam_spatial/src/spatial_evaluator.cu
@@ -135,6 +135,7 @@ void SpatialEvaluator::UpdateBufferSizes(const FieldDimensions &field)
   gpu_render_buffer_ = GpuVector<uint8_t>(buffer_size);
   settings_.width = world_width_spatial;
   settings_.height = world_height_spatial;
+  cached_field_dims_ = field;
 }
 
 std::size_t SpatialEvaluator::GetMaxLoc(const MapId map)

--- a/ateam_spatial/test/CMakeLists.txt
+++ b/ateam_spatial/test/CMakeLists.txt
@@ -6,7 +6,7 @@ ament_add_gmock(ateam_spatial_tests
   gpu_multibuffer_tests.cpp
   gpu_object_tests.cpp
   gpu_vector_tests.cpp
-  layers_tests.cpp
+  # layers_tests.cpp
   maps_tests.cpp
   min_max_loc_kernel_tests.cu
   spatial_evaluator_tests.cpp

--- a/ateam_spatial/test/CMakeLists.txt
+++ b/ateam_spatial/test/CMakeLists.txt
@@ -6,7 +6,7 @@ ament_add_gmock(ateam_spatial_tests
   gpu_multibuffer_tests.cpp
   gpu_object_tests.cpp
   gpu_vector_tests.cpp
-  # layers_tests.cpp
+  layers_tests.cpp
   maps_tests.cpp
   min_max_loc_kernel_tests.cu
   spatial_evaluator_tests.cpp

--- a/ateam_spatial/test/layers_tests.cpp
+++ b/ateam_spatial/test/layers_tests.cpp
@@ -43,9 +43,9 @@ TEST(LayersTests, DistanceDownField)
   field.goal_width = 1.0;
   field.goal_depth = 0.1;
 
-  EXPECT_FLOAT_EQ(DistanceDownField(0, field, settings), 0.0);
-  EXPECT_FLOAT_EQ(DistanceDownField(8300, field, settings), 8.3);
-  EXPECT_FLOAT_EQ(DistanceDownField(16600, field, settings), 16.6);
+  EXPECT_FLOAT_EQ(DistanceDownField(-8.3, field, settings), 0.0);
+  EXPECT_FLOAT_EQ(DistanceDownField(0.0, field, settings), 8.3);
+  EXPECT_FLOAT_EQ(DistanceDownField(8.3, field, settings), 16.6);
 }
 
 TEST(LayersTests, DistanceFromFieldEdge)
@@ -65,11 +65,11 @@ TEST(LayersTests, DistanceFromFieldEdge)
   field.goal_depth = 0.1;
 
   const auto kAcceptableError = 1e-4;
-  EXPECT_NEAR(DistanceFromFieldEdge(500, 4800, field, settings), 0.5, kAcceptableError);
-  EXPECT_NEAR(DistanceFromFieldEdge(500, 30, field, settings), 0.03, kAcceptableError);
-  EXPECT_NEAR(DistanceFromFieldEdge(8300, 4800, field, settings), 4.8, kAcceptableError);
-  EXPECT_NEAR(DistanceFromFieldEdge(16000, 4800, field, settings), 0.6, kAcceptableError);
-  EXPECT_NEAR(DistanceFromFieldEdge(8300, 1000, field, settings), 1.0, kAcceptableError);
+  EXPECT_NEAR(DistanceFromFieldEdge(0.5, 4.8, field, settings), 0.5, kAcceptableError);
+  EXPECT_NEAR(DistanceFromFieldEdge(0.5, 0.03, field, settings), 0.03, kAcceptableError);
+  EXPECT_NEAR(DistanceFromFieldEdge(8.3, 4.8, field, settings), 4.8, kAcceptableError);
+  EXPECT_NEAR(DistanceFromFieldEdge(16.0, 4.8, field, settings), 0.6, kAcceptableError);
+  EXPECT_NEAR(DistanceFromFieldEdge(8.3, 1.0, field, settings), 1.0, kAcceptableError);
 }
 
 TEST(LayersTests, DistanceToTheirBots)
@@ -109,8 +109,8 @@ TEST(LayersTests, DistanceToTheirBots)
   };
 
   const auto kAcceptableError = 1e-4;
-  EXPECT_NEAR(DistanceToTheirBots(8300, 4800, their_robots.data(), field, settings), 2.236, kAcceptableError);
-  EXPECT_NEAR(DistanceToTheirBots(12300, 4800, their_robots.data(), field, settings), 0.5, kAcceptableError);
+  EXPECT_NEAR(DistanceToTheirBots(8.3, 4.8, their_robots.data(), field, settings), 2.236, kAcceptableError);
+  EXPECT_NEAR(DistanceToTheirBots(12.3, 4.8, their_robots.data(), field, settings), 0.5, kAcceptableError);
 }
 
 TEST(LayersTests, InField)
@@ -129,16 +129,16 @@ TEST(LayersTests, InField)
   field.goal_width = 1.0;
   field.goal_depth = 0.1;
 
-  EXPECT_FLOAT_EQ(InField(0, 4800, field, settings), 0.0);
-  EXPECT_FLOAT_EQ(InField(301, 4800, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(8300, 4800, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(16299, 4800, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(16600, 4800, field, settings), 0.0);
-  EXPECT_FLOAT_EQ(InField(8300, 0, field, settings), 0.0);
-  EXPECT_FLOAT_EQ(InField(8300, 301, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(8300, 4800, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(8300, 9299, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(8300, 9600, field, settings), 0.0);
+  EXPECT_FLOAT_EQ(InField(0.0, 4.8, field, settings), 0.0);
+  EXPECT_FLOAT_EQ(InField(0.301, 4.8, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(InField(8.3, 4.8, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(InField(16.299, 4.8, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(InField(16.6, 4.8, field, settings), 0.0);
+  EXPECT_FLOAT_EQ(InField(8.3, 0.0, field, settings), 0.0);
+  EXPECT_FLOAT_EQ(InField(8.3, 0.301, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(InField(8.3, 4.8, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(InField(8.3, 9.299, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(InField(8.3, 9.6, field, settings), 0.0);
 }
 
 TEST(LayersTests, LineOfSightBall)
@@ -175,9 +175,9 @@ TEST(LayersTests, LineOfSightBall)
     0.0
   };
 
-  EXPECT_FLOAT_EQ(LineOfSightBall(8300, 4800, ball, their_robots.data(), field, settings), 1.0);
-  EXPECT_FLOAT_EQ(LineOfSightBall(9300, 7000, ball, their_robots.data(), field, settings), 0.0);
-  EXPECT_FLOAT_EQ(LineOfSightBall(9300, 5000, ball, their_robots.data(), field, settings), 1.0);
+  EXPECT_FLOAT_EQ(LineOfSightBall(8.3, 4.8, ball, their_robots.data(), field, settings), 1.0);
+  EXPECT_FLOAT_EQ(LineOfSightBall(9.3, 7.0, ball, their_robots.data(), field, settings), 0.0);
+  EXPECT_FLOAT_EQ(LineOfSightBall(9.3, 5.0, ball, their_robots.data(), field, settings), 1.0);
 }
 
 TEST(LayersTests, OutsideTheirDefenseArea)
@@ -196,11 +196,11 @@ TEST(LayersTests, OutsideTheirDefenseArea)
   field.goal_width = 1.0;
   field.goal_depth = 0.1;
 
-  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(0, 0, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(15500, 4800, field, settings), 0.0);
-  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(15500, 1000, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(15500, 6000, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(500, 4800, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(0.0, 0.0, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(15.5, 4.8, field, settings), 0.0);
+  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(15.5, 1.0, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(15.5, 6.0, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(0.5, 4.8, field, settings), 1.0);
 }
 
 
@@ -232,17 +232,17 @@ TEST(LayersTests, WidthOfShotOnGoal)
   };
 
   const auto kAcceptableError = 1e-2;
-  EXPECT_NEAR(WidthOfShotOnGoal(8300, 4800, their_robots.data(), field, settings), 1.0, kAcceptableError);
+  EXPECT_NEAR(WidthOfShotOnGoal(8.3, 4.8, their_robots.data(), field, settings), 1.0, kAcceptableError);
   their_robots[0].x = 0.2;
   their_robots[0].x = 0.0;
-  EXPECT_NEAR(WidthOfShotOnGoal(8300, 4800, their_robots.data(), field, settings), 0.0, kAcceptableError);
+  EXPECT_NEAR(WidthOfShotOnGoal(8.3, 4.8, their_robots.data(), field, settings), 0.0, kAcceptableError);
   their_robots[0].x = 0.2;
   their_robots[0].y = 0.09;
-  EXPECT_NEAR(WidthOfShotOnGoal(8300, 4800, their_robots.data(), field, settings), 0.5, kAcceptableError);
+  EXPECT_NEAR(WidthOfShotOnGoal(8.3, 4.8, their_robots.data(), field, settings), 0.5, kAcceptableError);
   their_robots[0].x = 0.2;
   their_robots[0].y = -0.09;
-  EXPECT_NEAR(WidthOfShotOnGoal(8300, 4800, their_robots.data(), field, settings), 0.5, kAcceptableError);
+  EXPECT_NEAR(WidthOfShotOnGoal(8.3, 4.8, their_robots.data(), field, settings), 0.5, kAcceptableError);
   their_robots[0].x = 4.5;
   their_robots[0].y = 0.18;
-  EXPECT_NEAR(WidthOfShotOnGoal(8300, 4800, their_robots.data(), field, settings), 0.65, kAcceptableError);
+  EXPECT_NEAR(WidthOfShotOnGoal(8.3, 4.8, their_robots.data(), field, settings), 0.65, kAcceptableError);
 }

--- a/ateam_spatial/test/layers_tests.cpp
+++ b/ateam_spatial/test/layers_tests.cpp
@@ -65,11 +65,11 @@ TEST(LayersTests, DistanceFromFieldEdge)
   field.goal_depth = 0.1;
 
   const auto kAcceptableError = 1e-4;
-  EXPECT_NEAR(DistanceFromFieldEdge(0.5, 4.8, field, settings), 0.5, kAcceptableError);
-  EXPECT_NEAR(DistanceFromFieldEdge(0.5, 0.03, field, settings), 0.03, kAcceptableError);
-  EXPECT_NEAR(DistanceFromFieldEdge(8.3, 4.8, field, settings), 4.8, kAcceptableError);
-  EXPECT_NEAR(DistanceFromFieldEdge(16.0, 4.8, field, settings), 0.6, kAcceptableError);
-  EXPECT_NEAR(DistanceFromFieldEdge(8.3, 1.0, field, settings), 1.0, kAcceptableError);
+  EXPECT_NEAR(DistanceFromFieldEdge(-7.8, 0.0, field, settings), 0.5, kAcceptableError);
+  EXPECT_NEAR(DistanceFromFieldEdge(-7.8, -4.77, field, settings), 0.03, kAcceptableError);
+  EXPECT_NEAR(DistanceFromFieldEdge(0.0, 0.0, field, settings), 4.8, kAcceptableError);
+  EXPECT_NEAR(DistanceFromFieldEdge(7.7, 0.0, field, settings), 0.6, kAcceptableError);
+  EXPECT_NEAR(DistanceFromFieldEdge(0.0, -3.8, field, settings), 1.0, kAcceptableError);
 }
 
 TEST(LayersTests, DistanceToTheirBots)
@@ -109,8 +109,8 @@ TEST(LayersTests, DistanceToTheirBots)
   };
 
   const auto kAcceptableError = 1e-4;
-  EXPECT_NEAR(DistanceToTheirBots(8.3, 4.8, their_robots.data(), field, settings), 2.236, kAcceptableError);
-  EXPECT_NEAR(DistanceToTheirBots(12.3, 4.8, their_robots.data(), field, settings), 0.5, kAcceptableError);
+  EXPECT_NEAR(DistanceToTheirBots(0.0, 0.0, their_robots.data(), field, settings), 2.236, kAcceptableError);
+  EXPECT_NEAR(DistanceToTheirBots(4.0, 0.0, their_robots.data(), field, settings), 0.5, kAcceptableError);
 }
 
 TEST(LayersTests, InField)
@@ -129,16 +129,16 @@ TEST(LayersTests, InField)
   field.goal_width = 1.0;
   field.goal_depth = 0.1;
 
-  EXPECT_FLOAT_EQ(InField(0.0, 4.8, field, settings), 0.0);
-  EXPECT_FLOAT_EQ(InField(0.301, 4.8, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(8.3, 4.8, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(16.299, 4.8, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(16.6, 4.8, field, settings), 0.0);
+  EXPECT_FLOAT_EQ(InField(-8.3, 0.0, field, settings), 0.0);
+  EXPECT_FLOAT_EQ(InField(-7.999, 0.0, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(InField(0.0, 0.0, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(InField(7.999, 0.0, field, settings), 1.0);
   EXPECT_FLOAT_EQ(InField(8.3, 0.0, field, settings), 0.0);
-  EXPECT_FLOAT_EQ(InField(8.3, 0.301, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(8.3, 4.8, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(8.3, 9.299, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(InField(8.3, 9.6, field, settings), 0.0);
+  EXPECT_FLOAT_EQ(InField(0.0, -4.8, field, settings), 0.0);
+  EXPECT_FLOAT_EQ(InField(0.0, -4.499, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(InField(0.0, 0.0, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(InField(0.0, 4.499, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(InField(0.0, 4.8, field, settings), 0.0);
 }
 
 TEST(LayersTests, LineOfSightBall)
@@ -175,9 +175,9 @@ TEST(LayersTests, LineOfSightBall)
     0.0
   };
 
-  EXPECT_FLOAT_EQ(LineOfSightBall(8.3, 4.8, ball, their_robots.data(), field, settings), 1.0);
-  EXPECT_FLOAT_EQ(LineOfSightBall(9.3, 7.0, ball, their_robots.data(), field, settings), 0.0);
-  EXPECT_FLOAT_EQ(LineOfSightBall(9.3, 5.0, ball, their_robots.data(), field, settings), 1.0);
+  EXPECT_FLOAT_EQ(LineOfSightBall(0.0, 0.0, ball, their_robots.data(), field, settings), 1.0);
+  EXPECT_FLOAT_EQ(LineOfSightBall(1.0, 2.2, ball, their_robots.data(), field, settings), 0.0);
+  EXPECT_FLOAT_EQ(LineOfSightBall(1.0, 0.2, ball, their_robots.data(), field, settings), 1.0);
 }
 
 TEST(LayersTests, OutsideTheirDefenseArea)
@@ -196,11 +196,11 @@ TEST(LayersTests, OutsideTheirDefenseArea)
   field.goal_width = 1.0;
   field.goal_depth = 0.1;
 
-  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(0.0, 0.0, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(15.5, 4.8, field, settings), 0.0);
-  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(15.5, 1.0, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(15.5, 6.0, field, settings), 1.0);
-  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(0.5, 4.8, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(-8.3, -4.8, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(7.199, 0.0, field, settings), 0.0);
+  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(7.199, -3.8, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(7.199, 1.2, field, settings), 1.0);
+  EXPECT_FLOAT_EQ(OutsideTheirDefenseArea(-7.8, 0.0, field, settings), 1.0);
 }
 
 
@@ -232,17 +232,17 @@ TEST(LayersTests, WidthOfShotOnGoal)
   };
 
   const auto kAcceptableError = 1e-2;
-  EXPECT_NEAR(WidthOfShotOnGoal(8.3, 4.8, their_robots.data(), field, settings), 1.0, kAcceptableError);
+  EXPECT_NEAR(WidthOfShotOnGoal(0.0, 0.0, their_robots.data(), field, settings), 1.0, kAcceptableError);
   their_robots[0].x = 0.2;
   their_robots[0].x = 0.0;
-  EXPECT_NEAR(WidthOfShotOnGoal(8.3, 4.8, their_robots.data(), field, settings), 0.0, kAcceptableError);
+  EXPECT_NEAR(WidthOfShotOnGoal(0.0, 0.0, their_robots.data(), field, settings), 0.0, kAcceptableError);
   their_robots[0].x = 0.2;
   their_robots[0].y = 0.09;
-  EXPECT_NEAR(WidthOfShotOnGoal(8.3, 4.8, their_robots.data(), field, settings), 0.5, kAcceptableError);
+  EXPECT_NEAR(WidthOfShotOnGoal(0.0, 0.0, their_robots.data(), field, settings), 0.5, kAcceptableError);
   their_robots[0].x = 0.2;
   their_robots[0].y = -0.09;
-  EXPECT_NEAR(WidthOfShotOnGoal(8.3, 4.8, their_robots.data(), field, settings), 0.5, kAcceptableError);
+  EXPECT_NEAR(WidthOfShotOnGoal(0.0, 0.0, their_robots.data(), field, settings), 0.5, kAcceptableError);
   their_robots[0].x = 4.5;
   their_robots[0].y = 0.18;
-  EXPECT_NEAR(WidthOfShotOnGoal(8.3, 4.8, their_robots.data(), field, settings), 0.65, kAcceptableError);
+  EXPECT_NEAR(WidthOfShotOnGoal(0.0, 0.0, their_robots.data(), field, settings), 0.65, kAcceptableError);
 }


### PR DESCRIPTION
This PR
* Improves the performance of `update_maps_kernel` by centralizing calls to `SpatialToReal*`.
* Adds missing update step for `cached_field_dims_`, which was causing wildly misplaced spatial pass targets.
* Limits register usage in compiler settings to ensure we can hit the 32x32 block size on the coach computer.