### PR TITLE
Adds ability to set body vels for individual robots in Kenobi.

### DIFF
--- a/ateam_kenobi/src/kenobi_node.cpp
+++ b/ateam_kenobi/src/kenobi_node.cpp
@@ -404,7 +404,9 @@ private:
 
     joystick_enforcer_.RemoveCommandForJoystickBot(motion_commands);
 
-    if (!get_parameter("use_world_velocities").as_bool()) {
+    if (get_parameter("use_world_velocities").as_bool()) {
+      motion::ConvertBodyVelsToWorldVels(motion_commands, world_.our_robots);
+    } else {
       motion::ConvertWorldVelsToBodyVels(motion_commands, world_.our_robots);
     }
 

--- a/ateam_msgs/msg/RobotMotionCommand.msg
+++ b/ateam_msgs/msg/RobotMotionCommand.msg
@@ -2,6 +2,7 @@
 # XY in translation (m/s)
 # Z in rotation (rad/s)
 geometry_msgs/Twist twist
+uint8 twist_frame 0
 uint8 kick_request
 float32 kick_speed # (m/s)
 float32 dribbler_speed # (rpm)
@@ -15,3 +16,7 @@ uint8 KR_KICK_CAPTURED = 4
 uint8 KR_CHIP_NOW = 5
 uint8 KR_CHIP_TOUCH = 6
 uint8 KR_CHIP_CAPTURED = 7
+
+# frame options
+uint8 FRAME_WORLD = 0
+uint8 FRAME_BODY = 1


### PR DESCRIPTION
With these changes, you can now set body velocities directly from Kenobi's STP classes.
All velocities will be normalized to body or world velocities before Kenobi publishes them, based on the value of the `use_world_velocities` parameter.

For example, telling a robot to go straight forward, regardless of its orientation, can now be done like this:
```C++
ateam_msgs::msg::RobotMotionCommand command;
command.twist.linear.x = 1.0;
command.twist_frame = ateam_msgs::msg::RobotMotionCommand::FRAME_BODY;
```