### PR TITLE
Ignored field side persistence

### DIFF
--- a/ateam_common/CMakeLists.txt
+++ b/ateam_common/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(ssl_league_msgs REQUIRED)
 add_library(${PROJECT_NAME} SHARED
   src/assignment.cpp
   src/bi_directional_udp.cpp
+  src/cache_directory.cpp
   src/get_ip_addresses.cpp
   src/multicast_receiver.cpp
   src/parameters.cpp

--- a/ateam_common/include/ateam_common/cache_directory.hpp
+++ b/ateam_common/include/ateam_common/cache_directory.hpp
@@ -1,0 +1,33 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ATEAM_COMMON__CACHE_DIRECTORY_HPP_
+#define ATEAM_COMMON__CACHE_DIRECTORY_HPP_
+
+#include <filesystem>
+
+namespace ateam_common
+{
+
+std::filesystem::path getCacheDirectory();
+
+}  // namespace ateam_common
+
+#endif  // ATEAM_COMMON__CACHE_DIRECTORY_HPP_

--- a/ateam_common/src/cache_directory.cpp
+++ b/ateam_common/src/cache_directory.cpp
@@ -1,0 +1,44 @@
+// Copyright 2021 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "ateam_common/cache_directory.hpp"
+#include <pwd.h>
+#include <unistd.h>
+
+namespace ateam_common
+{
+
+std::filesystem::path getCacheDirectory()
+{
+  const std::filesystem::path cache_dir = ".ateam/software/";
+  const char * home_env = getenv("HOME");
+  if (home_env != nullptr) {
+    return std::filesystem::path(home_env) / cache_dir;
+  }
+
+  struct passwd * pwd = getpwuid(getuid());    // NOLINT(runtime/threadsafe_fn)
+  if (pwd != nullptr) {
+    return std::filesystem::path(pwd->pw_dir) / cache_dir;
+  }
+
+  return cache_dir;
+}
+
+}  // namespace ateam_common

--- a/ateam_kenobi/src/kenobi_node.cpp
+++ b/ateam_kenobi/src/kenobi_node.cpp
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 
-#include <pwd.h>
 #include <tf2/convert.h>
 #include <tf2/utils.h>
 #include <chrono>
@@ -37,6 +36,7 @@
 #include <ateam_msgs/srv/set_override_play.hpp>
 #include <ateam_msgs/srv/set_play_enabled.hpp>
 #include <ateam_msgs/msg/playbook_state.hpp>
+#include <ateam_common/cache_directory.hpp>
 #include <ateam_common/game_controller_listener.hpp>
 #include <ateam_common/topic_names.hpp>
 #include <ateam_common/indexed_topic_helpers.hpp>
@@ -453,18 +453,7 @@ private:
 
   std::filesystem::path getCacheDirectory()
   {
-    const std::filesystem::path cache_dir = ".ateam/software/kenobi/";
-    const char * home_env = getenv("HOME");
-    if (home_env != nullptr) {
-      return std::filesystem::path(home_env) / cache_dir;
-    }
-
-    struct passwd * pwd = getpwuid(getuid());  // NOLINT(runtime/threadsafe_fn)
-    if (pwd != nullptr) {
-      return std::filesystem::path(pwd->pw_dir) / cache_dir;
-    }
-
-    return cache_dir;
+    return ateam_common::getCacheDirectory() / "kenobi";
   }
 
   void UpdateSpatialEvaluator()


### PR DESCRIPTION
This PR refactors `getCacheDirectory` out of Kenobi and into common, then makes the field manager cache the currently ignored field side between restarts.