### PR TITLE
Fix package duplication in workflow command

### DIFF
--- a/.github/workflows/get_changed_packages.sh
+++ b/.github/workflows/get_changed_packages.sh
@@ -22,6 +22,8 @@ for file in $changed_files; do
   done < <(colcon --log-base /dev/null list)
 done
 
-printf "%s " "${changed_packages[*]}"
+deduped_changed_packages=($(printf "%s\n" "${changed_packages[@]}" | sort -u))
+
+printf "%s " "${deduped_changed_packages[*]}"
 
 popd > /dev/null


### PR DESCRIPTION
Adds a step to deduplicate package names returned by `get_changed_packages.sh`.

Having duplicate package names shouldn't really break anything. It's just a bit silly.