### PR TITLE
Adds WiFi scream script

### DIFF
--- a/ateam_bringup/launch/bringup_physical.launch.py
+++ b/ateam_bringup/launch/bringup_physical.launch.py
@@ -25,7 +25,7 @@ from launch.actions import (
     DeclareLaunchArgument,
     GroupAction,
     IncludeLaunchDescription,
-    SetLaunchConfiguration,
+    SetLaunchConfiguration
 )
 from launch.conditions import IfCondition
 from launch.launch_description_sources import FrontendLaunchDescriptionSource
@@ -43,6 +43,12 @@ def generate_launch_description():
 
         DeclareLaunchArgument('team_name', default_value='A-Team'),
         DeclareLaunchArgument('use_local_gc', default_value='False'),
+
+        Node(
+            package='ateam_bringup',
+            executable='scream_if_wifi_enabled.sh',
+            name='wifi_checker',
+        ),
 
         GroupAction(
             condition=IfCondition(LaunchConfiguration('use_local_gc')),

--- a/ateam_bringup/scripts/scream_if_wifi_enabled.sh
+++ b/ateam_bringup/scripts/scream_if_wifi_enabled.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+if nmcli radio wifi | grep -q "enabled"; then
+  while true; do
+    echo -e "\e[31mWIFI IS ENABLED! TURN IT OFF!\e[0m" >&2
+    sleep 1
+  done
+else
+  echo "WiFi disabled check passed." >&2
+fi

--- a/ateam_bringup/scripts/scream_if_wifi_enabled.sh
+++ b/ateam_bringup/scripts/scream_if_wifi_enabled.sh
@@ -1,10 +1,6 @@
 #! /bin/bash
 
-if nmcli radio wifi | grep -q "enabled"; then
-  while true; do
-    echo -e "\e[31mWIFI IS ENABLED! TURN IT OFF!\e[0m" >&2
-    sleep 1
-  done
-else
-  echo "WiFi disabled check passed." >&2
-fi
+while nmcli radio wifi | grep -q "enabled"; do
+  echo -e "\e[31mWIFI IS ENABLED! TURN IT OFF!\e[0m" >&2
+  sleep 1
+done


### PR DESCRIPTION
We should never have WiFi enabled on the coach laptop when running robots. It only leads to sadness.
This PR adds a script to the physical bringup stack which prints errors once a second until WiFi is disabled.