### PR TITLE
Adds usedCachedPath() to PathPlanner

### DIFF
--- a/ateam_kenobi/src/core/path_planning/path_planner.cpp
+++ b/ateam_kenobi/src/core/path_planning/path_planner.cpp
@@ -48,8 +48,11 @@ PathPlanner::Path PathPlanner::getPath(
     if (!cached_path_truncated_) {
       cached_path_.back() = goal;
     }
+    used_cached_path_ = true;
     return cached_path_;
   }
+
+  used_cached_path_ = false;
 
   std::vector<ateam_geometry::AnyShape> augmented_obstacles = obstacles;
 

--- a/ateam_kenobi/src/core/path_planning/path_planner.hpp
+++ b/ateam_kenobi/src/core/path_planning/path_planner.hpp
@@ -88,12 +88,18 @@ public:
     const std::vector<ateam_geometry::AnyShape> & obstacles,
     const PlannerOptions & options = PlannerOptions());
 
+  bool usedCachedPath() const
+  {
+    return used_cached_path_;
+  }
+
 private:
   visualization::Overlays overlays_;
   bool cached_path_valid_ = false;
   bool cached_path_truncated_ = false;
   Path cached_path_;
   Position cached_path_goal_;
+  bool used_cached_path_ = false;
 
   void removeCollidingObstacles(
     std::vector<ateam_geometry::AnyShape> & obstacles,


### PR DESCRIPTION
Adds the `usedCachedPath` function to `PathPlanner` allowing `EasyMoveTo` to handle the new path accordingly.