### PR TITLE
Suppress MotionController initialization warnings

### DIFF
--- a/ateam_kenobi/src/core/motion/motion_controller.cpp
+++ b/ateam_kenobi/src/core/motion/motion_controller.cpp
@@ -46,9 +46,9 @@ CREATE_PARAM(double, "motion/pid/t_max", t_max, 4);
 
 
 MotionController::MotionController()
-: x_controller(0.0, 0.0, 0.0, 0.0, 0.0, control_toolbox::AntiWindupStrategy()),
-  y_controller(0.0, 0.0, 0.0, 0.0, 0.0, control_toolbox::AntiWindupStrategy()),
-  t_controller(0.0, 0.0, 0.0, 0.0, 0.0, control_toolbox::AntiWindupStrategy())
+: x_controller(0.0, 0.0, 0.0, 0.1, -0.1, DefaultAWS()),
+  y_controller(0.0, 0.0, 0.0, 0.1, -0.1, DefaultAWS()),
+  t_controller(0.0, 0.0, 0.0, 0.1, -0.1, DefaultAWS())
 {
   this->reset();
 }

--- a/ateam_kenobi/src/core/motion/motion_controller.hpp
+++ b/ateam_kenobi/src/core/motion/motion_controller.hpp
@@ -120,6 +120,18 @@ private:
   control_toolbox::Pid x_controller;
   control_toolbox::Pid y_controller;
   control_toolbox::Pid t_controller;
+
+  static auto DefaultAWS()
+  {
+    /* This is a workaround for control_toolbox's terrible new AntiWindupStrategy interface.
+     * This allows us to initialize MotionController without printing a ton irrelevant of warnings.
+     */
+    control_toolbox::AntiWindupStrategy aws;
+    aws.type = control_toolbox::AntiWindupStrategy::LEGACY;
+    aws.i_max = 0.3;
+    aws.i_min = -0.3;
+    return aws;
+  }
 };
 
 #endif  // CORE__MOTION__MOTION_CONTROLLER_HPP_


### PR DESCRIPTION
The changes to `MotionController` introduced in #350 resulted in a lot of runtime warnings while zero-intiializing Pid objects.
This PR adds some reasonable non-zero values to allow for temproary initialization without warnings.