### PR TITLE
Comp 2025: ateam_kenobi plays

### DIFF
--- a/ateam_kenobi/CMakeLists.txt
+++ b/ateam_kenobi/CMakeLists.txt
@@ -71,12 +71,14 @@ target_sources(kenobi_node_component PRIVATE
   src/plays/test_plays/test_play.cpp
   src/plays/test_plays/triangle_pass_play.cpp
   src/plays/test_plays/waypoints_play.cpp
+  src/plays/util_plays/corner_lineup_play.cpp
   src/plays/halt_play.cpp
   src/plays/kick_on_goal_play.cpp
   src/plays/our_ball_placement_play.cpp
   src/plays/their_ball_placement_play.cpp
   src/plays/wall_play.cpp
   src/plays/basic_122.cpp
+  src/plays/defenders_only_play.cpp
   src/plays/our_penalty_play.cpp
   src/plays/their_penalty_play.cpp
   src/plays/defense_play.cpp

--- a/ateam_kenobi/src/plays/all_plays.hpp
+++ b/ateam_kenobi/src/plays/all_plays.hpp
@@ -28,6 +28,7 @@
 #include "their_ball_placement_play.hpp"
 #include "wall_play.hpp"
 #include "basic_122.hpp"
+#include "defenders_only_play.hpp"
 #include "our_penalty_play.hpp"
 #include "their_penalty_play.hpp"
 #include "defense_play.hpp"
@@ -37,5 +38,6 @@
 #include "kickoff_plays/all_kickoff_plays.hpp"
 #include "stop_plays/all_stop_plays.hpp"
 #include "test_plays/all_test_plays.hpp"
+#include "util_plays/all_util_plays.hpp"
 
 #endif  // PLAYS__ALL_PLAYS_HPP_

--- a/ateam_kenobi/src/plays/defenders_only_play.hpp
+++ b/ateam_kenobi/src/plays/defenders_only_play.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 A Team
+// Copyright 2025 A Team
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,41 +18,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-
-#ifndef PLAYS__OUR_PENALTY_PLAY_HPP_
-#define PLAYS__OUR_PENALTY_PLAY_HPP_
+#ifndef PLAYS__DEFENDERS_ONLY_PLAY_HPP_
+#define PLAYS__DEFENDERS_ONLY_PLAY_HPP_
 
 #include "core/stp/play.hpp"
-#include "skills/goalie.hpp"
-#include "skills/universal_kick.hpp"
-#include "core/play_helpers/easy_move_to.hpp"
+#include "tactics/standard_defense.hpp"
 
 namespace ateam_kenobi::plays
 {
 
-class OurPenaltyPlay : public stp::Play
+class DefendersOnlyPlay : public stp::Play
 {
 public:
-  static constexpr const char * kPlayName = "OurPenaltyPlay";
+  static constexpr const char * kPlayName = "DefendersOnlyPlay";
 
-  explicit OurPenaltyPlay(stp::Options stp_options);
+  explicit DefendersOnlyPlay(stp::Options stp_options);
 
   stp::PlayScore getScore(const World & world) override;
 
   void reset() override;
 
-  std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
-    16> runFrame(const World & world) override;
+  std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> runFrame(
+    const World & world) override;
 
 private:
-  skills::Goalie goalie_skill_;
-  skills::UniversalKick kick_skill_;
-  std::array<play_helpers::EasyMoveTo, 16> move_tos_;
-  std::chrono::steady_clock::time_point kick_time_ = std::chrono::steady_clock::time_point::max();
-
-  ateam_geometry::Point chooseKickTarget(const World & world);
+  tactics::StandardDefense defense_tactic_;
 };
 
 }  // namespace ateam_kenobi::plays
 
-#endif  // PLAYS__OUR_PENALTY_PLAY_HPP_
+
+#endif  // PLAYS__DEFENDERS_ONLY_PLAY_HPP_

--- a/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.cpp
+++ b/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.cpp
@@ -121,14 +121,16 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
     [](const auto & r){return r.id;});
 
   if(available_robots.size() > 3) {
-    assignments.RunPositionIfAssigned("idler1", [this, &world, &motion_commands](const auto & robot){
+    assignments.RunPositionIfAssigned("idler1",
+      [this, &world, &motion_commands](const auto & robot){
         motion_commands[robot.id] = idler_1_.RunFrame(world, robot);
         getPlayInfo()["Idlers"].push_back(robot.id);
     });
   }
 
   if(available_robots.size() > 4) {
-    assignments.RunPositionIfAssigned("idler2", [this, &world, &motion_commands](const auto & robot){
+    assignments.RunPositionIfAssigned("idler2",
+      [this, &world, &motion_commands](const auto & robot){
         motion_commands[robot.id] = idler_2_.RunFrame(world, robot);
         getPlayInfo()["Idlers"].push_back(robot.id);
     });

--- a/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.cpp
+++ b/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.cpp
@@ -31,16 +31,26 @@ namespace ateam_kenobi::plays
 
 FreeKickOnGoalPlay::FreeKickOnGoalPlay(stp::Options stp_options)
 : stp::Play(kPlayName, stp_options),
-  striker_(createChild<skills::PivotKick>("striker")),
+  striker_(createChild<skills::UniversalKick>("striker")),
   idler_1_(createChild<skills::LaneIdler>("idler1")),
   idler_2_(createChild<skills::LaneIdler>("idler2")),
   defense_(createChild<tactics::StandardDefense>("defense"))
 {
+  striker_.SetPreferredKickType(skills::UniversalKick::KickType::Line);
 }
 
 stp::PlayScore FreeKickOnGoalPlay::getScore(const World & world)
 {
   if(world.referee_info.running_command != ateam_common::GameCommand::DirectFreeOurs) {
+    return stp::PlayScore::NaN();
+  }
+
+  if((world.in_play || striker_.IsDone()) && world.ball.vel.x() < 0.01) {
+    // Ball is stopped or moving up field
+    return stp::PlayScore::NaN();
+  }
+
+  if(world.ball.pos.x() < 0.0) {
     return stp::PlayScore::NaN();
   }
 
@@ -51,6 +61,11 @@ stp::PlayScore FreeKickOnGoalPlay::getScore(const World & world)
   const auto squared_goal_width = world.field.goal_width * world.field.goal_width;
   const auto fraction_of_goal_width = largest_window->squared_length() / squared_goal_width;
   return stp::PlayScore::Max() * fraction_of_goal_width;
+}
+
+void FreeKickOnGoalPlay::enter()
+{
+  striker_.Reset();
 }
 
 std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
@@ -105,15 +120,19 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
   std::ranges::transform(defenders, std::back_inserter(getPlayInfo()["Defenders"]),
     [](const auto & r){return r.id;});
 
-  assignments.RunPositionIfAssigned("idler1", [this, &world, &motion_commands](const auto & robot){
-      motion_commands[robot.id] = idler_1_.RunFrame(world, robot);
-      getPlayInfo()["Idlers"].push_back(robot.id);
-  });
+  if(available_robots.size() > 3) {
+    assignments.RunPositionIfAssigned("idler1", [this, &world, &motion_commands](const auto & robot){
+        motion_commands[robot.id] = idler_1_.RunFrame(world, robot);
+        getPlayInfo()["Idlers"].push_back(robot.id);
+    });
+  }
 
-  assignments.RunPositionIfAssigned("idler2", [this, &world, &motion_commands](const auto & robot){
-      motion_commands[robot.id] = idler_2_.RunFrame(world, robot);
-      getPlayInfo()["Idlers"].push_back(robot.id);
-  });
+  if(available_robots.size() > 4) {
+    assignments.RunPositionIfAssigned("idler2", [this, &world, &motion_commands](const auto & robot){
+        motion_commands[robot.id] = idler_2_.RunFrame(world, robot);
+        getPlayInfo()["Idlers"].push_back(robot.id);
+    });
+  }
 
   return motion_commands;
 }

--- a/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.hpp
+++ b/ateam_kenobi/src/plays/free_kick_plays/offense/free_kick_on_goal_play.hpp
@@ -25,7 +25,7 @@
 #include "core/stp/play.hpp"
 #include "core/play_helpers/easy_move_to.hpp"
 #include "tactics/standard_defense.hpp"
-#include "skills/pivot_kick.hpp"
+#include "skills/universal_kick.hpp"
 #include "skills/lane_idler.hpp"
 
 namespace ateam_kenobi::plays
@@ -40,11 +40,13 @@ public:
 
   stp::PlayScore getScore(const World & world) override;
 
+  void enter() override;
+
   std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
     16> runFrame(const World & world) override;
 
 private:
-  skills::PivotKick striker_;
+  skills::UniversalKick striker_;
   skills::LaneIdler idler_1_;
   skills::LaneIdler idler_2_;
   tactics::StandardDefense defense_;

--- a/ateam_kenobi/src/plays/kick_on_goal_play.cpp
+++ b/ateam_kenobi/src/plays/kick_on_goal_play.cpp
@@ -47,7 +47,8 @@ stp::PlayScore KickOnGoalPlay::getScore(const World & world)
   if (world.referee_info.running_command != ateam_common::GameCommand::NormalStart &&
     world.referee_info.running_command != ateam_common::GameCommand::ForceStart &&
     world.referee_info.running_command != ateam_common::GameCommand::DirectFreeOurs &&
-    !(world.in_play && world.referee_info.running_command == ateam_common::GameCommand::DirectFreeTheirs))
+    !(world.in_play &&
+    world.referee_info.running_command == ateam_common::GameCommand::DirectFreeTheirs))
   {
     return stp::PlayScore::NegativeInfinity();
   }

--- a/ateam_kenobi/src/plays/kick_on_goal_play.hpp
+++ b/ateam_kenobi/src/plays/kick_on_goal_play.hpp
@@ -23,7 +23,7 @@
 
 #include "core/stp/play.hpp"
 #include "tactics/standard_defense.hpp"
-#include "skills/pivot_kick.hpp"
+#include "skills/universal_kick.hpp"
 #include "skills/lane_idler.hpp"
 
 namespace ateam_kenobi::plays
@@ -45,7 +45,7 @@ public:
 
 private:
   tactics::StandardDefense defense_;
-  skills::PivotKick striker_;
+  skills::UniversalKick striker_;
   skills::LaneIdler lane_idler_a_;
   skills::LaneIdler lane_idler_b_;
 };

--- a/ateam_kenobi/src/plays/kickoff_plays/offense/kickoff_on_goal.cpp
+++ b/ateam_kenobi/src/plays/kickoff_plays/offense/kickoff_on_goal.cpp
@@ -29,9 +29,11 @@ namespace ateam_kenobi::plays
 KickoffOnGoalPlay::KickoffOnGoalPlay(stp::Options stp_options)
 : stp::Play(kPlayName, stp_options),
   defense_(createChild<tactics::StandardDefense>("defense")),
-  kick_(createChild<skills::LineKick>("kick")),
+  kick_(createChild<skills::UniversalKick>("kick")),
   multi_move_to_(createChild<tactics::MultiMoveTo>("support"))
-{}
+{
+  kick_.SetPreferredKickType(skills::UniversalKick::KickType::Line);
+}
 
 stp::PlayScore KickoffOnGoalPlay::getScore(const World & world)
 {

--- a/ateam_kenobi/src/plays/kickoff_plays/offense/kickoff_on_goal.hpp
+++ b/ateam_kenobi/src/plays/kickoff_plays/offense/kickoff_on_goal.hpp
@@ -23,7 +23,7 @@
 
 #include "core/stp/play.hpp"
 #include "tactics/standard_defense.hpp"
-#include "skills/line_kick.hpp"
+#include "skills/universal_kick.hpp"
 #include "tactics/multi_move_to.hpp"
 
 namespace ateam_kenobi::plays
@@ -45,7 +45,7 @@ public:
 
 private:
   tactics::StandardDefense defense_;
-  skills::LineKick kick_;
+  skills::UniversalKick kick_;
   tactics::MultiMoveTo multi_move_to_;
 
   std::optional<ateam_geometry::Segment> getLargestWindowOnGoal(const World & world);

--- a/ateam_kenobi/src/plays/kickoff_plays/offense/kickoff_pass_play.cpp
+++ b/ateam_kenobi/src/plays/kickoff_plays/offense/kickoff_pass_play.cpp
@@ -37,6 +37,7 @@ KickoffPassPlay::KickoffPassPlay(stp::Options stp_options)
   pass_(createChild<tactics::Pass>("pass"))
 {
   pass_.setCaptureSpeed(0.3);
+  pass_.SetPreferredKickType(skills::UniversalKick::KickType::Line);
 }
 
 stp::PlayScore KickoffPassPlay::getScore(const World & world)

--- a/ateam_kenobi/src/plays/our_ball_placement_play.cpp
+++ b/ateam_kenobi/src/plays/our_ball_placement_play.cpp
@@ -89,19 +89,22 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> OurBallPlacem
   auto maybe_offset_vector = calculateObstacleOffset(world);
 
   const bool use_extract = true;
+  const auto should_extract = use_extract && world.ball.visible && ball_dist > 0.2 &&
+    maybe_offset_vector.has_value();
 
   if (state_ != State::Placing &&
     world.ball.visible &&
     ball_dist < 0.12 &&
-    ball_speed < 0.04) {
-
+    ball_speed < 0.04)
+  {
     state_ = State::Done;
 
   // detect ball near goal/walls
-  } else if (use_extract && world.ball.visible && ball_dist > 0.2 && maybe_offset_vector.has_value()) {
+  } else if (should_extract) {
     approach_point_ = world.ball.pos + maybe_offset_vector.value();
     state_ = State::Extracting;
-    getOverlays().drawCircle("approach_point", ateam_geometry::makeCircle(approach_point_, 0.025), "#0000FFFF");
+    getOverlays().drawCircle("approach_point", ateam_geometry::makeCircle(approach_point_, 0.025),
+        "#0000FFFF");
   }
 
   const bool see_ball_clear_of_obstacle = world.ball.visible && !maybe_offset_vector.has_value();
@@ -131,8 +134,9 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> OurBallPlacem
     case State::Placing:
       // Ball must be placed in a 0.15m radius
       // if (ball_dist < 0.13 && ball_speed < 0.08) {
-      if (dribble_.isDone()
-        || (false && ball_dist < 0.08 && ball_speed < 0.04)) {
+      if (dribble_.isDone() ||
+        (false && ball_dist < 0.08 && ball_speed < 0.04))
+      {
         state_ = State::Done;
 
         // Can try to pass if the ball is far away and we have enough robots
@@ -165,31 +169,30 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> OurBallPlacem
 
       ateam_geometry::Point target_position = robot.pos;
       if (ateam_geometry::norm(robot.pos - nearest_point) < 0.6 + kRobotRadius) {
-
         target_position = nearest_point +
           0.7 * ateam_geometry::Vector(std::cos(angle + M_PI / 2), std::sin(angle + M_PI / 2));
 
         const auto alternate_position = nearest_point +
           0.7 * ateam_geometry::Vector(std::cos(angle - M_PI / 2), std::sin(angle - M_PI / 2));
 
-      const auto offset = kRobotRadius * 0.95;
-      const auto x_bound = (world.field.field_length / 2.0) + world.field.boundary_width - offset;
-      const auto y_bound = (world.field.field_width / 2.0) + world.field.boundary_width - offset;
-      ateam_geometry::Rectangle pathable_region(ateam_geometry::Point(-x_bound, -y_bound),
-        ateam_geometry::Point(x_bound, y_bound));
-      
-      if (!CGAL::do_intersect(target_position, pathable_region)) {
-        target_position = alternate_position;
-      } else if (!CGAL::do_intersect(alternate_position, pathable_region)) {
-        // Stick with target_position
-      } else {
-        // Use the shorter path
-        if (ateam_geometry::norm(target_position - robot.pos) >
-          ateam_geometry::norm(alternate_position - robot.pos))
-        {
+        const auto offset = kRobotRadius * 0.95;
+        const auto x_bound = (world.field.field_length / 2.0) + world.field.boundary_width - offset;
+        const auto y_bound = (world.field.field_width / 2.0) + world.field.boundary_width - offset;
+        ateam_geometry::Rectangle pathable_region(ateam_geometry::Point(-x_bound, -y_bound),
+          ateam_geometry::Point(x_bound, y_bound));
+
+        if (!CGAL::do_intersect(target_position, pathable_region)) {
           target_position = alternate_position;
+        } else if (!CGAL::do_intersect(alternate_position, pathable_region)) {
+        // Stick with target_position
+        } else {
+        // Use the shorter path
+          if (ateam_geometry::norm(target_position - robot.pos) >
+            ateam_geometry::norm(alternate_position - robot.pos))
+          {
+            target_position = alternate_position;
+          }
         }
-      }
 
         emt.setTargetPosition(target_position);
         emt.face_point(world.ball.pos);
@@ -264,24 +267,25 @@ void OurBallPlacementPlay::runExtracting(
   const auto ball_to_approach = approach_point_ - world.ball.pos;
 
   // const double ball_to_approach_angle = std::atan2(ball_to_approach.y(), ball_to_approach.x());
-  const double robot_approach_angle_offset = std::acos((-robot_to_ball * ball_to_approach)
-    / (ateam_geometry::norm(robot_to_ball) * ateam_geometry::norm(ball_to_approach))
+  const double robot_approach_angle_offset = std::acos((-robot_to_ball * ball_to_approach) /
+      (ateam_geometry::norm(robot_to_ball) * ateam_geometry::norm(ball_to_approach))
   );
   const double robot_to_ball_angle = std::atan2(robot_to_ball.y(), robot_to_ball.x());
 
   const bool robot_near_approach_point = ateam_geometry::norm(
     extract_robot.pos - approach_point_
-  ) < 0.05;
+    ) < 0.05;
   const bool robot_facing_ball = abs(robot_to_ball_angle - extract_robot.theta) < 0.1;
   const bool robot_near_ball = ateam_geometry::norm(robot_to_ball) <= approach_radius_;
-  const bool robot_already_in_position = robot_near_ball && robot_facing_ball
-    && abs(robot_approach_angle_offset) < 0.3;
+  const bool robot_already_in_position = robot_near_ball && robot_facing_ball &&
+    abs(robot_approach_angle_offset) < 0.3;
 
   auto motion_command = ateam_msgs::msg::RobotMotionCommand();
   if (extract_robot.breakbeam_ball_detected_filtered) {
     getPlayInfo()["ExtractState"] = "extracting ball";
 
-    getPlayInfo()["extract bot approach dist"] = ateam_geometry::norm(extract_robot.pos - approach_point_);
+    getPlayInfo()["extract bot approach dist"] = ateam_geometry::norm(extract_robot.pos -
+        approach_point_);
     if (ateam_geometry::norm(extract_robot.pos - approach_point_) < 0.03) {
       const bool use_pivot = true;
       if (use_pivot && !world.ball.visible) {
@@ -289,7 +293,7 @@ void OurBallPlacementPlay::runExtracting(
 
         // This vector feels backwards but it works I guess
         const double direction = angles::shortest_angular_distance(
-          ateam_geometry::ToHeading(extract_robot.pos - ateam_geometry::Point(0,0)),
+          ateam_geometry::ToHeading(extract_robot.pos - ateam_geometry::Point(0, 0)),
           extract_robot.theta
         );
 
@@ -313,8 +317,8 @@ void OurBallPlacementPlay::runExtracting(
       if (world.ball.visible) {
         emt.face_point(world.ball.pos);
 
-      // If the ball is occluded we sometimes drive past its previous position and try to turn around
-      // so its better to just keep facing the same direction if we lose track of it
+      // If the ball is occluded we sometimes drive past its previous position and try to turn
+      // around so its better to just keep facing the same direction if we lose track of it
       } else {
         emt.face_absolute(extract_robot.theta);
       }
@@ -449,7 +453,8 @@ void OurBallPlacementPlay::DrawKeepoutArea(
       "Cyan");
 }
 
-std::optional<ateam_geometry::Vector> OurBallPlacementPlay::calculateObstacleOffset(const World & world)
+std::optional<ateam_geometry::Vector> OurBallPlacementPlay::calculateObstacleOffset(
+  const World & world)
 {
   double obstacle_offset_x = 0;
   double obstacle_offset_y = 0;
@@ -460,8 +465,10 @@ std::optional<ateam_geometry::Vector> OurBallPlacementPlay::calculateObstacleOff
   bool is_inside_goal = is_inside_goal_x && is_between_goalposts;
 
   if (is_inside_goal) {
-    bool is_near_back_goal_x = abs(world.ball.pos.x()) + ball_distance_from_obstacle_ > (world.field.field_length / 2) + world.field.goal_depth;
-    bool is_near_inside_goalposts_y = abs(world.ball.pos.y()) + ball_distance_from_obstacle_ > world.field.goal_width / 2;
+    bool is_near_back_goal_x = abs(world.ball.pos.x()) + ball_distance_from_obstacle_ >
+      (world.field.field_length / 2) + world.field.goal_depth;
+    bool is_near_inside_goalposts_y = abs(world.ball.pos.y()) + ball_distance_from_obstacle_ >
+      world.field.goal_width / 2;
 
     if (is_near_back_goal_x) {
       obstacle_offset_x = (world.ball.pos.x() > 0) ? -1.0 : 1.0;
@@ -470,13 +477,16 @@ std::optional<ateam_geometry::Vector> OurBallPlacementPlay::calculateObstacleOff
       obstacle_offset_y = (world.ball.pos.y() > 0) ? -1.0 : 1.0;
     }
 
-    auto offset_vector = approach_radius_ * ateam_geometry::normalize(ateam_geometry::Vector(obstacle_offset_x, obstacle_offset_y));
+    auto offset_vector = approach_radius_ *
+      ateam_geometry::normalize(ateam_geometry::Vector(obstacle_offset_x, obstacle_offset_y));
     return std::make_optional(offset_vector);
   }
 
   // Handle ball near outside goalposts
-  bool is_near_outside_goalposts_x = abs(world.ball.pos.x()) + ball_distance_from_obstacle_ > world.field.field_length / 2;
-  bool is_near_outside_goalposts_y = abs(world.ball.pos.y()) - ball_distance_from_obstacle_ < (world.field.goal_width / 2) + 0.02;
+  bool is_near_outside_goalposts_x = abs(world.ball.pos.x()) + ball_distance_from_obstacle_ >
+    world.field.field_length / 2;
+  bool is_near_outside_goalposts_y = abs(world.ball.pos.y()) - ball_distance_from_obstacle_ <
+    (world.field.goal_width / 2) + 0.02;
   bool is_near_outside_goalposts = is_near_outside_goalposts_x && is_near_outside_goalposts_y;
 
   if (is_near_outside_goalposts) {
@@ -487,14 +497,17 @@ std::optional<ateam_geometry::Vector> OurBallPlacementPlay::calculateObstacleOff
       obstacle_offset_y = (world.ball.pos.y() > 0) ? 1.0 : -1.0;
     }
 
-    auto offset_vector = approach_radius_ * ateam_geometry::normalize(ateam_geometry::Vector(obstacle_offset_x, obstacle_offset_y));
+    auto offset_vector = approach_radius_ *
+      ateam_geometry::normalize(ateam_geometry::Vector(obstacle_offset_x, obstacle_offset_y));
     return std::make_optional(offset_vector);
   }
 
   // Handle ball near walls
-  bool is_near_x_walls =  abs(world.ball.pos.x()) + ball_distance_from_obstacle_ > (world.field.field_length / 2) + world.field.boundary_width;
-  bool is_near_y_walls =  abs(world.ball.pos.y()) + ball_distance_from_obstacle_ > (world.field.field_width / 2) + world.field.boundary_width;
-  bool is_near_wall =  is_near_x_walls || is_near_y_walls;
+  bool is_near_x_walls = abs(world.ball.pos.x()) + ball_distance_from_obstacle_ >
+    (world.field.field_length / 2) + world.field.boundary_width;
+  bool is_near_y_walls = abs(world.ball.pos.y()) + ball_distance_from_obstacle_ >
+    (world.field.field_width / 2) + world.field.boundary_width;
+  bool is_near_wall = is_near_x_walls || is_near_y_walls;
 
   if (is_near_wall) {
     if (is_near_x_walls) {
@@ -504,7 +517,8 @@ std::optional<ateam_geometry::Vector> OurBallPlacementPlay::calculateObstacleOff
       obstacle_offset_y = (world.ball.pos.y() > 0) ? -1.0 : 1.0;
     }
 
-    auto offset_vector = approach_radius_ * ateam_geometry::normalize(ateam_geometry::Vector(obstacle_offset_x, obstacle_offset_y));
+    auto offset_vector = approach_radius_ *
+      ateam_geometry::normalize(ateam_geometry::Vector(obstacle_offset_x, obstacle_offset_y));
     return std::make_optional(offset_vector);
   }
 

--- a/ateam_kenobi/src/plays/our_ball_placement_play.cpp
+++ b/ateam_kenobi/src/plays/our_ball_placement_play.cpp
@@ -47,7 +47,7 @@ stp::PlayScore OurBallPlacementPlay::getScore(const World & world)
 
 void OurBallPlacementPlay::reset()
 {
-  state_ = State::Passing;
+  state_ = State::Placing;
   pass_tactic_.reset();
   dribble_.reset();
   for (auto & emt : easy_move_tos_) {
@@ -73,45 +73,50 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> OurBallPlacem
       }
     }();
 
+  DrawKeepoutArea(world.ball.pos, placement_point_);
+
   const auto point_to_ball = world.ball.pos - placement_point_;
   const auto angle = std::atan2(point_to_ball.y(), point_to_ball.x());
 
   const auto ball_dist = ateam_geometry::norm(point_to_ball);
   const auto ball_speed = ateam_geometry::norm(world.ball.vel);
 
-
-  ateam_geometry::Polygon polygon_points;
-  polygon_points.push_back(
-    placement_point_ +
-    0.5 * ateam_geometry::Vector(std::cos(angle + M_PI / 2), std::sin(angle + M_PI / 2)));
-  polygon_points.push_back(
-    placement_point_ +
-    0.5 * ateam_geometry::Vector(std::cos(angle - M_PI / 2), std::sin(angle - M_PI / 2)));
-  polygon_points.push_back(
-    world.ball.pos +
-    0.5 * ateam_geometry::Vector(std::cos(angle - M_PI / 2), std::sin(angle - M_PI / 2)));
-  polygon_points.push_back(
-    world.ball.pos +
-    0.5 * ateam_geometry::Vector(std::cos(angle + M_PI / 2), std::sin(angle + M_PI / 2)));
-
-  getOverlays().drawCircle(
-    "placement_avoid_point", ateam_geometry::makeCircle(
-      placement_point_,
-      0.5), "red",
-    "00000000");
-  getOverlays().drawCircle(
-    "placement_avoid_ball", ateam_geometry::makeCircle(
-      world.ball.pos,
-      0.5), "red",
-    "00000000");
-  getOverlays().drawPolygon("placement_avoid_zone", polygon_points, "red", "00000000");
-
   getOverlays().drawCircle(
     "placement_pos", ateam_geometry::makeCircle(
       placement_point_,
       0.15), "green");
 
+  auto maybe_offset_vector = calculateObstacleOffset(world);
+
+  const bool use_extract = true;
+
+  if (state_ != State::Placing &&
+    world.ball.visible &&
+    ball_dist < 0.12 &&
+    ball_speed < 0.04) {
+
+    state_ = State::Done;
+
+  // detect ball near goal/walls
+  } else if (use_extract && world.ball.visible && ball_dist > 0.2 && maybe_offset_vector.has_value()) {
+    approach_point_ = world.ball.pos + maybe_offset_vector.value();
+    state_ = State::Extracting;
+    getOverlays().drawCircle("approach_point", ateam_geometry::makeCircle(approach_point_, 0.025), "#0000FFFF");
+  }
+
+  const bool see_ball_clear_of_obstacle = world.ball.visible && !maybe_offset_vector.has_value();
+
   switch (state_) {
+    case State::Extracting:
+      // ball is clear of obstacles
+      if (see_ball_clear_of_obstacle) {
+        state_ = State::Placing;
+        break;
+      }
+
+      getPlayInfo()["State"] = "Extracting";
+      runExtracting(available_robots, world, maybe_motion_commands);
+      break;
     case State::Passing:
       if (pass_tactic_.isDone() ||
         (ball_dist < 1.0 && ball_speed < 0.05) ||
@@ -125,11 +130,14 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> OurBallPlacem
       break;
     case State::Placing:
       // Ball must be placed in a 0.15m radius
-      if (ball_dist < 0.13 && ball_speed < 0.08) {
+      // if (ball_dist < 0.13 && ball_speed < 0.08) {
+      if (dribble_.isDone()
+        || (false && ball_dist < 0.08 && ball_speed < 0.04)) {
         state_ = State::Done;
 
         // Can try to pass if the ball is far away and we have enough robots
-      } else if (ball_dist > 1.0 && available_robots.size() >= 2) {
+      } else if (ball_dist > 1.1 && available_robots.size() >= 2) {
+        pass_tactic_.reset();
         state_ = State::Passing;
       }
       runPlacing(available_robots, world, maybe_motion_commands);
@@ -137,6 +145,7 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> OurBallPlacem
       break;
     case State::Done:
       if (ball_dist > 0.14) {
+        dribble_.reset();
         state_ = State::Placing;
       }
       runDone(available_robots, world, maybe_motion_commands);
@@ -156,26 +165,40 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> OurBallPlacem
 
       ateam_geometry::Point target_position = robot.pos;
       if (ateam_geometry::norm(robot.pos - nearest_point) < 0.6 + kRobotRadius) {
+
         target_position = nearest_point +
           0.7 * ateam_geometry::Vector(std::cos(angle + M_PI / 2), std::sin(angle + M_PI / 2));
 
         const auto alternate_position = nearest_point +
           0.7 * ateam_geometry::Vector(std::cos(angle - M_PI / 2), std::sin(angle - M_PI / 2));
 
+      const auto offset = kRobotRadius * 0.95;
+      const auto x_bound = (world.field.field_length / 2.0) + world.field.boundary_width - offset;
+      const auto y_bound = (world.field.field_width / 2.0) + world.field.boundary_width - offset;
+      ateam_geometry::Rectangle pathable_region(ateam_geometry::Point(-x_bound, -y_bound),
+        ateam_geometry::Point(x_bound, y_bound));
+      
+      if (!CGAL::do_intersect(target_position, pathable_region)) {
+        target_position = alternate_position;
+      } else if (!CGAL::do_intersect(alternate_position, pathable_region)) {
+        // Stick with target_position
+      } else {
+        // Use the shorter path
         if (ateam_geometry::norm(target_position - robot.pos) >
           ateam_geometry::norm(alternate_position - robot.pos))
         {
           target_position = alternate_position;
         }
+      }
+
+        emt.setTargetPosition(target_position);
+        emt.face_point(world.ball.pos);
+        maybe_motion_commands[robot.id] = emt.runFrame(robot, world);
 
         getPlayInfo()["Robots"][std::to_string(robot.id)] = "MOVING";
       } else {
         getPlayInfo()["Robots"][std::to_string(robot.id)] = "-";
       }
-
-      emt.setTargetPosition(target_position);
-      emt.face_point(world.ball.pos);
-      maybe_motion_commands[robot.id] = emt.runFrame(robot, world);
     }
   }
 
@@ -187,33 +210,18 @@ void OurBallPlacementPlay::runPassing(
   std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
   16> & motion_commands)
 {
-  auto byDistToBall = [&world](const Robot & lhs, const Robot & rhs) {
-      return CGAL::compare_distance_to_point(world.ball.pos, lhs.pos, rhs.pos) == CGAL::SMALLER;
-    };
-
-  auto byDistToPlacement = [this](const Robot & lhs, const Robot & rhs) {
-      return CGAL::compare_distance_to_point(placement_point_, lhs.pos, rhs.pos) == CGAL::SMALLER;
-    };
-
-  const auto receiver_robot_iter = std::min_element(
-    available_robots.begin(),
-    available_robots.end(), byDistToPlacement);
-
-  auto kicker_robot_iter = std::min_element(
-    available_robots.begin(),
-    available_robots.end(), byDistToBall);
-
-  // Might be better to prioritize kicker being closer to ball instead
-  // that way if we have a smart passing tactic it can kick the ball earlier
-  if (receiver_robot_iter == kicker_robot_iter) {
-    kicker_robot_iter++;
-    if (kicker_robot_iter >= available_robots.end()) {
-      kicker_robot_iter = available_robots.begin();
-    }
+  if(available_robots.size() < 2) {
+    RCLCPP_ERROR(getLogger(), "Cannot pass with fewer than 2 robots.");
+    return;
   }
 
-  const auto & receiver_robot = *receiver_robot_iter;
-  const auto & kicker_robot = *kicker_robot_iter;
+  std::vector<Robot> candidate_robots{available_robots.begin(), available_robots.end()};
+
+  const auto kicker_robot = play_helpers::getClosestRobot(candidate_robots, world.ball.pos);
+
+  play_helpers::removeRobotWithId(candidate_robots, kicker_robot.id);
+
+  const auto receiver_robot = play_helpers::getClosestRobot(candidate_robots, placement_point_);
 
   getPlayInfo()["Assignments"]["Receiver"] = receiver_robot.id;
   getPlayInfo()["Assignments"]["Kicker"] = kicker_robot.id;
@@ -230,6 +238,135 @@ void OurBallPlacementPlay::runPassing(
     *(motion_commands[receiver_robot.id] = ateam_msgs::msg::RobotMotionCommand{});
 
   pass_tactic_.runFrame(world, kicker_robot, receiver_robot, kicker_command, receiver_command);
+
+  ForwardPlayInfo(pass_tactic_);
+}
+
+void OurBallPlacementPlay::runExtracting(
+  const std::vector<Robot> & available_robots, const World & world,
+  std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
+  16> & motion_commands)
+{
+  const auto approach_point = approach_point_;
+  auto byDistToApproachPoint = [&approach_point](const Robot & lhs, const Robot & rhs) {
+      return CGAL::compare_distance_to_point(approach_point, lhs.pos, rhs.pos) == CGAL::SMALLER;
+    };
+
+  const auto & extract_robot = *std::min_element(
+    available_robots.begin(),
+    available_robots.end(), byDistToApproachPoint);
+
+  getPlayInfo()["Assignments"]["Extractor"] = extract_robot.id;
+
+  auto & emt = easy_move_tos_[extract_robot.id];
+
+  const auto robot_to_ball = (world.ball.pos - extract_robot.pos);
+  const auto ball_to_approach = approach_point_ - world.ball.pos;
+
+  // const double ball_to_approach_angle = std::atan2(ball_to_approach.y(), ball_to_approach.x());
+  const double robot_approach_angle_offset = std::acos((-robot_to_ball * ball_to_approach)
+    / (ateam_geometry::norm(robot_to_ball) * ateam_geometry::norm(ball_to_approach))
+  );
+  const double robot_to_ball_angle = std::atan2(robot_to_ball.y(), robot_to_ball.x());
+
+  const bool robot_near_approach_point = ateam_geometry::norm(
+    extract_robot.pos - approach_point_
+  ) < 0.05;
+  const bool robot_facing_ball = abs(robot_to_ball_angle - extract_robot.theta) < 0.1;
+  const bool robot_near_ball = ateam_geometry::norm(robot_to_ball) <= approach_radius_;
+  const bool robot_already_in_position = robot_near_ball && robot_facing_ball
+    && abs(robot_approach_angle_offset) < 0.3;
+
+  auto motion_command = ateam_msgs::msg::RobotMotionCommand();
+  if (extract_robot.breakbeam_ball_detected_filtered) {
+    getPlayInfo()["ExtractState"] = "extracting ball";
+
+    getPlayInfo()["extract bot approach dist"] = ateam_geometry::norm(extract_robot.pos - approach_point_);
+    if (ateam_geometry::norm(extract_robot.pos - approach_point_) < 0.03) {
+      const bool use_pivot = true;
+      if (use_pivot && !world.ball.visible) {
+        getPlayInfo()["ExtractState"] = "pivoting";
+
+        // This vector feels backwards but it works I guess
+        const double direction = angles::shortest_angular_distance(
+          ateam_geometry::ToHeading(extract_robot.pos - ateam_geometry::Point(0,0)),
+          extract_robot.theta
+        );
+
+        motion_command.twist.angular.z = std::copysign(0.8, direction);
+      } else {
+        state_ = State::Placing;
+      }
+    } else {
+      MotionOptions motion_options;
+      motion_options.completion_threshold = 0;
+      emt.setMotionOptions(motion_options);
+      path_planning::PlannerOptions planner_options = emt.getPlannerOptions();
+      planner_options.avoid_ball = false;
+      planner_options.footprint_inflation = -0.9 * kRobotRadius;
+      emt.setPlannerOptions(planner_options);
+
+      emt.setTargetPosition(approach_point_);
+      emt.setMaxVelocity(0.2);
+      emt.setMaxAccel(1.0);
+      emt.setMaxDecel(1.0);
+      if (world.ball.visible) {
+        emt.face_point(world.ball.pos);
+
+      // If the ball is occluded we sometimes drive past its previous position and try to turn around
+      // so its better to just keep facing the same direction if we lose track of it
+      } else {
+        emt.face_absolute(extract_robot.theta);
+      }
+
+      motion_command = emt.runFrame(extract_robot, world);
+      // motion_command.twist_frame = ateam_msgs::msg::RobotMotionCommand::FRAME_BODY;
+      // motion_command.twist.linear.x = -0.1;
+      // motion_command.twist.linear.y = 0.0;
+    }
+  } else if (robot_already_in_position || robot_near_approach_point) {
+    getPlayInfo()["ExtractState"] = "capturing ball";
+    MotionOptions motion_options;
+    motion_options.completion_threshold = 0;
+    emt.setMotionOptions(motion_options);
+    path_planning::PlannerOptions planner_options = emt.getPlannerOptions();
+    planner_options.avoid_ball = false;
+    planner_options.footprint_inflation = -0.9 * kRobotRadius;
+    emt.setPlannerOptions(planner_options);
+
+    emt.setMaxVelocity(0.35);
+    emt.setMaxAccel(2.0);
+    emt.setMaxDecel(2.0);
+    if (world.ball.visible) {
+      emt.face_point(world.ball.pos);
+
+    // If the ball is occluded we sometimes drive past its previous position and try to turn around
+    // so its better to just keep facing the same direction if we lose track of it
+    } else {
+      emt.face_absolute(extract_robot.theta);
+    }
+    emt.setTargetPosition(world.ball.pos);
+    motion_command = emt.runFrame(extract_robot, world);
+    motion_command.twist_frame = ateam_msgs::msg::RobotMotionCommand::FRAME_BODY;
+    motion_command.twist.linear.x = 0.35;
+    motion_command.twist.linear.y = 0.0;
+  } else {
+    getPlayInfo()["ExtractState"] = "moving to approach point";
+    emt.setMaxVelocity(1.5);
+    emt.setMaxAccel(2.0);
+    emt.setMaxDecel(2.0);
+    emt.face_absolute(ateam_geometry::ToHeading(world.ball.pos - approach_point_));
+    emt.setTargetPosition(approach_point_);
+    motion_command = emt.runFrame(extract_robot, world);
+  }
+
+  const bool should_dribble = extract_robot.breakbeam_ball_detected_filtered ||
+    ateam_geometry::norm(robot_to_ball) < 0.5;
+  if (should_dribble) {
+    motion_command.dribbler_speed = 300;
+  }
+
+  motion_commands[extract_robot.id] = motion_command;
 }
 
 void OurBallPlacementPlay::runPlacing(
@@ -249,7 +386,7 @@ void OurBallPlacementPlay::runPlacing(
 
   dribble_.setTarget(placement_point_);
   motion_commands[place_robot.id] = dribble_.runFrame(world, place_robot);
-  getPlayInfo()["Dribbler"] = dribble_.getPlayInfo();
+  ForwardPlayInfo(dribble_);
 }
 
 void OurBallPlacementPlay::runDone(
@@ -280,5 +417,100 @@ void OurBallPlacementPlay::runDone(
   auto command = emt.runFrame(place_robot, world);
   motion_commands[place_robot.id] = command;
 }
+
+void OurBallPlacementPlay::DrawKeepoutArea(
+  const ateam_geometry::Point & ball_pos,
+  const ateam_geometry::Point & placement_point)
+{
+  const auto point_to_ball = ball_pos - placement_point;
+  const auto angle = std::atan2(point_to_ball.y(), point_to_ball.x());
+
+  auto & overlays = getOverlays();
+
+  const auto keepout_radius = 0.5;
+  const ateam_geometry::Vector pos_offset{keepout_radius * std::cos(angle + M_PI_2),
+    keepout_radius * std::sin(angle + M_PI_2)};
+  const ateam_geometry::Vector neg_offset{keepout_radius * std::cos(angle - M_PI_2),
+    keepout_radius * std::sin(angle - M_PI_2)};
+
+  const ateam_geometry::Arc ball_side_arc{ball_pos, keepout_radius, neg_offset.direction(),
+    pos_offset.direction()};
+  const ateam_geometry::Arc point_side_arc{placement_point, keepout_radius, pos_offset.direction(),
+    neg_offset.direction()};
+  const ateam_geometry::Segment pos_segment{placement_point + pos_offset, ball_pos + pos_offset};
+  const ateam_geometry::Segment neg_segment{placement_point + neg_offset, ball_pos + neg_offset};
+
+
+  overlays.drawArc("placement_avoid_ball_arc", ball_side_arc, "Cyan");
+  overlays.drawArc("placement_avoid_place_arc", point_side_arc, "Cyan");
+  overlays.drawLine("placement_avoid_pos_line", {pos_segment.source(), pos_segment.target()},
+      "Cyan");
+  overlays.drawLine("placement_avoid_neg_line", {neg_segment.source(), neg_segment.target()},
+      "Cyan");
+}
+
+std::optional<ateam_geometry::Vector> OurBallPlacementPlay::calculateObstacleOffset(const World & world)
+{
+  double obstacle_offset_x = 0;
+  double obstacle_offset_y = 0;
+
+  // Handle ball inside goal
+  bool is_inside_goal_x = abs(world.ball.pos.x()) > world.field.field_length / 2;
+  bool is_between_goalposts = abs(world.ball.pos.y()) < world.field.goal_width / 2;
+  bool is_inside_goal = is_inside_goal_x && is_between_goalposts;
+
+  if (is_inside_goal) {
+    bool is_near_back_goal_x = abs(world.ball.pos.x()) + ball_distance_from_obstacle_ > (world.field.field_length / 2) + world.field.goal_depth;
+    bool is_near_inside_goalposts_y = abs(world.ball.pos.y()) + ball_distance_from_obstacle_ > world.field.goal_width / 2;
+
+    if (is_near_back_goal_x) {
+      obstacle_offset_x = (world.ball.pos.x() > 0) ? -1.0 : 1.0;
+    }
+    if (is_near_inside_goalposts_y) {
+      obstacle_offset_y = (world.ball.pos.y() > 0) ? -1.0 : 1.0;
+    }
+
+    auto offset_vector = approach_radius_ * ateam_geometry::normalize(ateam_geometry::Vector(obstacle_offset_x, obstacle_offset_y));
+    return std::make_optional(offset_vector);
+  }
+
+  // Handle ball near outside goalposts
+  bool is_near_outside_goalposts_x = abs(world.ball.pos.x()) + ball_distance_from_obstacle_ > world.field.field_length / 2;
+  bool is_near_outside_goalposts_y = abs(world.ball.pos.y()) - ball_distance_from_obstacle_ < (world.field.goal_width / 2) + 0.02;
+  bool is_near_outside_goalposts = is_near_outside_goalposts_x && is_near_outside_goalposts_y;
+
+  if (is_near_outside_goalposts) {
+    if (is_near_outside_goalposts_x) {
+      obstacle_offset_x = (world.ball.pos.x() > 0) ? -1.0 : 1.0;
+    }
+    if (is_near_outside_goalposts_y) {
+      obstacle_offset_y = (world.ball.pos.y() > 0) ? 1.0 : -1.0;
+    }
+
+    auto offset_vector = approach_radius_ * ateam_geometry::normalize(ateam_geometry::Vector(obstacle_offset_x, obstacle_offset_y));
+    return std::make_optional(offset_vector);
+  }
+
+  // Handle ball near walls
+  bool is_near_x_walls =  abs(world.ball.pos.x()) + ball_distance_from_obstacle_ > (world.field.field_length / 2) + world.field.boundary_width;
+  bool is_near_y_walls =  abs(world.ball.pos.y()) + ball_distance_from_obstacle_ > (world.field.field_width / 2) + world.field.boundary_width;
+  bool is_near_wall =  is_near_x_walls || is_near_y_walls;
+
+  if (is_near_wall) {
+    if (is_near_x_walls) {
+      obstacle_offset_x = (world.ball.pos.x() > 0) ? -1.0 : 1.0;
+    }
+    if (is_near_y_walls) {
+      obstacle_offset_y = (world.ball.pos.y() > 0) ? -1.0 : 1.0;
+    }
+
+    auto offset_vector = approach_radius_ * ateam_geometry::normalize(ateam_geometry::Vector(obstacle_offset_x, obstacle_offset_y));
+    return std::make_optional(offset_vector);
+  }
+
+  // No obstacles to account for
+  return std::nullopt;
+}
+
 
 }  // namespace ateam_kenobi::plays

--- a/ateam_kenobi/src/plays/our_ball_placement_play.hpp
+++ b/ateam_kenobi/src/plays/our_ball_placement_play.hpp
@@ -51,12 +51,27 @@ private:
   std::array<play_helpers::EasyMoveTo, 16> easy_move_tos_;
   ateam_geometry::Point placement_point_;
 
+  double approach_radius_ = kRobotRadius + kBallRadius + 0.3;  // m
+  ateam_geometry::Point approach_point_;
+
+  // Ball should have enough room for the robot to fit between it and the obstacle with a bit of extra space
+  double ball_distance_from_obstacle_ = kRobotDiameter + kBallRadius + 0.03;
+
+  std::optional<ateam_geometry::Vector> calculateObstacleOffset(const World & world);
+
+
   enum class State
   {
+    Extracting,
     Passing,
     Placing,
     Done
   } state_ = State::Passing;
+
+  void runExtracting(
+    const std::vector<Robot> & available_robots, const World & world,
+    std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
+    16> & motion_commands);
 
   void runPassing(
     const std::vector<Robot> & available_robots, const World & world,
@@ -72,6 +87,10 @@ private:
     const std::vector<Robot> & available_robots, const World & world,
     std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
     16> & motion_commands);
+
+  void DrawKeepoutArea(
+    const ateam_geometry::Point & ball_pos,
+    const ateam_geometry::Point & placement_point);
 };
 
 }  // namespace ateam_kenobi::plays

--- a/ateam_kenobi/src/plays/our_ball_placement_play.hpp
+++ b/ateam_kenobi/src/plays/our_ball_placement_play.hpp
@@ -54,7 +54,8 @@ private:
   double approach_radius_ = kRobotRadius + kBallRadius + 0.3;  // m
   ateam_geometry::Point approach_point_;
 
-  // Ball should have enough room for the robot to fit between it and the obstacle with a bit of extra space
+  // Ball should have enough room for the robot to fit between it and the obstacle with a bit of
+  // extra space
   double ball_distance_from_obstacle_ = kRobotDiameter + kBallRadius + 0.03;
 
   std::optional<ateam_geometry::Vector> calculateObstacleOffset(const World & world);

--- a/ateam_kenobi/src/plays/our_penalty_play.cpp
+++ b/ateam_kenobi/src/plays/our_penalty_play.cpp
@@ -30,7 +30,7 @@ namespace ateam_kenobi::plays
 OurPenaltyPlay::OurPenaltyPlay(stp::Options stp_options)
 : stp::Play(kPlayName, stp_options),
   goalie_skill_(createChild<skills::Goalie>("goalie")),
-  line_kick_skill_(createChild<skills::LineKick>("line_kick"))
+  kick_skill_(createChild<skills::UniversalKick>("kick"))
 {
   createIndexedChildren<play_helpers::EasyMoveTo>(move_tos_, "EasyMoveTo");
 }
@@ -90,8 +90,8 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> OurPenaltyPla
   {
     // Stage for kick
     getPlayInfo()["State"] = "Preparing";
-    line_kick_skill_.SetTargetPoint(chooseKickTarget(world));
-    const auto destination = line_kick_skill_.GetAssignmentPoint(world);
+    kick_skill_.SetTargetPoint(chooseKickTarget(world));
+    const auto destination = kick_skill_.GetAssignmentPoint(world);
     auto & move_to = move_tos_[kicking_robot.id];
     move_to.setTargetPosition(destination);
     move_to.face_point(world.ball.pos);
@@ -100,10 +100,10 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> OurPenaltyPla
   } else {
     // Kick ball
     getPlayInfo()["State"] = "Kicking";
-    if (line_kick_skill_.IsDone()) {
-      line_kick_skill_.Reset();
+    if (kick_skill_.IsDone()) {
+      kick_skill_.Reset();
     }
-    motion_commands[kicking_robot.id] = line_kick_skill_.RunFrame(world, kicking_robot);
+    motion_commands[kicking_robot.id] = kick_skill_.RunFrame(world, kicking_robot);
   }
 
   ateam_geometry::Point pattern_point(kRobotDiameter - (world.field.field_length / 2.0),

--- a/ateam_kenobi/src/plays/passing_plays/pass_to_lane_play.cpp
+++ b/ateam_kenobi/src/plays/passing_plays/pass_to_lane_play.cpp
@@ -53,6 +53,10 @@ stp::PlayScore PassToLanePlay::getScore(const World & world)
     return cached_score_;
   }
 
+  if(world.ball.pos.x() > 0.0) {
+    return stp::PlayScore::Min();
+  }
+
   if (play_helpers::WhoHasPossession(world) == play_helpers::PossessionResult::Theirs) {
     return stp::PlayScore::Min();
   }
@@ -90,8 +94,9 @@ ateam_geometry::Segment PassToLanePlay::getTargetSegment(const World & world)
 {
   const auto lane_segment = play_helpers::lanes::GetLaneLongitudinalMidSegment(world, lane_);
   const auto max_center_x = (world.field.field_length / 2.0) - world.field.defense_area_depth;
-  const auto max_x = lane_ ==
-    play_helpers::lanes::Lane::Center ? max_center_x : std::numeric_limits<double>::infinity();
+  // const auto max_x = lane_ ==
+  //   play_helpers::lanes::Lane::Center ? max_center_x : std::numeric_limits<double>::infinity();
+  const auto max_x = max_center_x;
   const auto ball_x = std::min(world.ball.pos.x(), max_x);
   if (direction_ == PassDirection::Forward) {
     return ateam_geometry::Segment{
@@ -101,10 +106,11 @@ ateam_geometry::Segment PassToLanePlay::getTargetSegment(const World & world)
         lane_segment.target().y()}
     };
   } else {
+    const auto lookback = 3.0;
     return ateam_geometry::Segment{
-      ateam_geometry::Point{std::min(lane_segment.source().x(), ball_x),
+      ateam_geometry::Point{std::min(std::max(lane_segment.source().x(), ball_x - lookback), ball_x),
         lane_segment.source().y()},
-      ateam_geometry::Point{std::min(lane_segment.target().x(), ball_x),
+      ateam_geometry::Point{std::min(std::max(lane_segment.target().x(), ball_x - lookback), ball_x),
         lane_segment.target().y()}
     };
   }

--- a/ateam_kenobi/src/plays/passing_plays/pass_to_lane_play.cpp
+++ b/ateam_kenobi/src/plays/passing_plays/pass_to_lane_play.cpp
@@ -108,9 +108,11 @@ ateam_geometry::Segment PassToLanePlay::getTargetSegment(const World & world)
   } else {
     const auto lookback = 3.0;
     return ateam_geometry::Segment{
-      ateam_geometry::Point{std::min(std::max(lane_segment.source().x(), ball_x - lookback), ball_x),
+      ateam_geometry::Point{std::min(std::max(lane_segment.source().x(), ball_x - lookback),
+            ball_x),
         lane_segment.source().y()},
-      ateam_geometry::Point{std::min(std::max(lane_segment.target().x(), ball_x - lookback), ball_x),
+      ateam_geometry::Point{std::min(std::max(lane_segment.target().x(), ball_x - lookback),
+            ball_x),
         lane_segment.target().y()}
     };
   }

--- a/ateam_kenobi/src/plays/passing_plays/pass_to_segment_play.cpp
+++ b/ateam_kenobi/src/plays/passing_plays/pass_to_segment_play.cpp
@@ -71,7 +71,8 @@ stp::PlayScore PassToSegmentPlay::getScore(const World & world)
   const auto pass_chance_multiplier =
     std::clamp(
     largest_window->squared_length() / (ideal_target_length * ideal_target_length), 0.0, 1.0);
-  return pass_chance_multiplier * goal_chance_multiplier * stp::PlayScore::Max();
+  const auto FACTOR = (started_ && ateam_geometry::norm(world.ball.vel) < 0.1) ? 0.6 : 1.0;
+  return (pass_chance_multiplier * goal_chance_multiplier * stp::PlayScore::Max()) * FACTOR;
 }
 
 stp::PlayCompletionState PassToSegmentPlay::getCompletionState()

--- a/ateam_kenobi/src/plays/passing_plays/spatial_pass_play.cpp
+++ b/ateam_kenobi/src/plays/passing_plays/spatial_pass_play.cpp
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 #include "spatial_pass_play.hpp"
+#include <algorithm>
 #include <string>
 #include <vector>
 #include <ateam_common/robot_constants.hpp>
@@ -81,7 +82,8 @@ stp::PlayScore SpatialPassPlay::getScore(const World & world)
   if(!largest_window) {
     return stp::PlayScore::Min();
   }
-  return std::min(90.0, stp::PlayScore::Max() * (largest_window->squared_length() / goal_segment.squared_length()));
+  return std::min(90.0,
+      stp::PlayScore::Max() * (largest_window->squared_length() / goal_segment.squared_length()));
 }
 
 stp::PlayCompletionState SpatialPassPlay::getCompletionState()

--- a/ateam_kenobi/src/plays/passing_plays/spatial_pass_play.cpp
+++ b/ateam_kenobi/src/plays/passing_plays/spatial_pass_play.cpp
@@ -43,9 +43,16 @@ SpatialPassPlay::SpatialPassPlay(stp::Options stp_options)
 
 stp::PlayScore SpatialPassPlay::getScore(const World & world)
 {
+  if (!world.in_play && (
+      world.referee_info.prev_command == ateam_common::GameCommand::PrepareKickoffOurs ||
+      world.referee_info.prev_command == ateam_common::GameCommand::PrepareKickoffTheirs))
+  {
+    return stp::PlayScore::NaN();
+  }
   if (!world.in_play &&
     world.referee_info.running_command != ateam_common::GameCommand::ForceStart &&
-    world.referee_info.running_command != ateam_common::GameCommand::NormalStart)
+    world.referee_info.running_command != ateam_common::GameCommand::NormalStart &&
+    world.referee_info.running_command != ateam_common::GameCommand::DirectFreeOurs)
   {
     return stp::PlayScore::NaN();
   }
@@ -72,9 +79,9 @@ stp::PlayScore SpatialPassPlay::getScore(const World & world)
       their_robots);
   const auto largest_window = play_helpers::window_evaluation::getLargestWindow(windows);
   if(!largest_window) {
-    return stp::PlayScore::NaN();
+    return stp::PlayScore::Min();
   }
-  return stp::PlayScore::Max() * (largest_window->squared_length() / goal_segment.squared_length());
+  return std::min(90.0, stp::PlayScore::Max() * (largest_window->squared_length() / goal_segment.squared_length()));
 }
 
 stp::PlayCompletionState SpatialPassPlay::getCompletionState()
@@ -167,15 +174,14 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
       started_ = true;
     }
 
-    getPlayInfo()["kicker"] = maybe_kicker->id;
-    getPlayInfo()["receiver"] = maybe_receiver->id;
-
     pass_tactic_.runFrame(world, *maybe_kicker, *maybe_receiver, kicker_command, receiver_command);
+
+    ForwardPlayInfo(pass_tactic_);
   }
 
   std::string play_state;
   if(!started_) {
-    play_state = "Prep";
+    play_state = "Not Started";
   } else if(!pass_tactic_.isDone()) {
     play_state = "Passing";
   } else {

--- a/ateam_kenobi/src/plays/stop_plays/defensive_stop_play.cpp
+++ b/ateam_kenobi/src/plays/stop_plays/defensive_stop_play.cpp
@@ -22,6 +22,7 @@
 #include <ranges>
 #include <algorithm>
 #include <limits>
+#include <vector>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
 #include <ateam_common/robot_constants.hpp>
 #include <ateam_geometry/normalize.hpp>

--- a/ateam_kenobi/src/plays/stop_plays/defensive_stop_play.cpp
+++ b/ateam_kenobi/src/plays/stop_plays/defensive_stop_play.cpp
@@ -82,10 +82,10 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> DefensiveStop
 
   std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> motion_commands;
 
+  runPrepBot(world, motion_commands);
+
   helpers::moveBotsTooCloseToBall(world, added_obstacles, motion_commands, easy_move_tos_,
     getOverlays(), getPlayInfo());
-
-  runPrepBot(world, motion_commands);
 
   helpers::moveBotsInObstacles(world, added_obstacles, motion_commands, getPlayInfo());
 
@@ -117,11 +117,20 @@ void DefensiveStopPlay::runPrepBot(
   }
   const auto closest_bot = play_helpers::getClosestRobot(available_robots, target_position);
 
+  // Wait for the closest bot to be out of the ball keepout circle before giving it new commands
+  if(maybe_motion_commands[closest_bot.id]) {
+    return;
+  }
+
   auto & emt = easy_move_tos_[closest_bot.id];
+
+  std::vector<ateam_geometry::AnyShape> obstacles {
+    ateam_geometry::makeDisk(world.ball.pos, stop_plays::stop_helpers::kKeepoutRadiusRules)
+  };
 
   emt.setTargetPosition(target_position);
   emt.face_point(world.ball.pos);
-  maybe_motion_commands[closest_bot.id] = emt.runFrame(closest_bot, world);
+  maybe_motion_commands[closest_bot.id] = emt.runFrame(closest_bot, world, obstacles);
 }
 
 }  // namespace ateam_kenobi::plays

--- a/ateam_kenobi/src/plays/stop_plays/offensive_stop_play.cpp
+++ b/ateam_kenobi/src/plays/stop_plays/offensive_stop_play.cpp
@@ -22,6 +22,7 @@
 #include <ranges>
 #include <algorithm>
 #include <limits>
+#include <vector>
 #include <ateam_msgs/msg/robot_motion_command.hpp>
 #include <ateam_common/robot_constants.hpp>
 #include <ateam_geometry/normalize.hpp>

--- a/ateam_kenobi/src/plays/stop_plays/offensive_stop_play.cpp
+++ b/ateam_kenobi/src/plays/stop_plays/offensive_stop_play.cpp
@@ -83,10 +83,10 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> OffensiveStop
 
   std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> motion_commands;
 
+  runPrepBot(world, motion_commands);
+
   helpers::moveBotsTooCloseToBall(world, added_obstacles, motion_commands, easy_move_tos_,
     getOverlays(), getPlayInfo());
-
-  runPrepBot(world, motion_commands);
 
   helpers::moveBotsInObstacles(world, added_obstacles, motion_commands, getPlayInfo());
 
@@ -119,11 +119,20 @@ void OffensiveStopPlay::runPrepBot(
   }
   const auto closest_bot = play_helpers::getClosestRobot(available_robots, target_position);
 
+  // Wait for the closest bot to be out of the ball keepout circle before giving it new commands
+  if(maybe_motion_commands[closest_bot.id]) {
+    return;
+  }
+
   auto & emt = easy_move_tos_[closest_bot.id];
+
+  std::vector<ateam_geometry::AnyShape> obstacles {
+    ateam_geometry::makeDisk(world.ball.pos, stop_plays::stop_helpers::kKeepoutRadiusRules)
+  };
 
   emt.setTargetPosition(target_position);
   emt.face_point(world.ball.pos);
-  maybe_motion_commands[closest_bot.id] = emt.runFrame(closest_bot, world);
+  maybe_motion_commands[closest_bot.id] = emt.runFrame(closest_bot, world, obstacles);
 }
 
 }  // namespace ateam_kenobi::plays

--- a/ateam_kenobi/src/plays/stop_plays/stop_helpers.cpp
+++ b/ateam_kenobi/src/plays/stop_plays/stop_helpers.cpp
@@ -253,6 +253,9 @@ void moveBotsTooCloseToBall(
       continue;
     }
     const auto & bot = *maybe_bot;
+    if(motion_commands[bot.id]) {
+      continue;
+    }
     auto & emt = easy_move_tos.at(bot.id);
     emt.setTargetPosition(spot);
     emt.face_point(world.ball.pos);
@@ -283,6 +286,9 @@ void moveBotsInObstacles(
   for(auto i = 0ul; i < motion_commands.size(); ++i) {
     const auto & robot = world.our_robots[i];
     if(!robot.IsAvailable()) {
+      continue;
+    }
+    if(motion_commands[i]) {
       continue;
     }
     const auto opt_escape_vel = path_planning::GenerateEscapeVelocity(robot, added_obstacles);

--- a/ateam_kenobi/src/plays/test_plays/all_test_plays.hpp
+++ b/ateam_kenobi/src/plays/test_plays/all_test_plays.hpp
@@ -25,6 +25,7 @@
 #include "spinning_a_play.hpp"
 #include "test_kick_play.hpp"
 #include "test_pass_play.hpp"
+#include "test_pivot_play.hpp"
 #include "test_play.hpp"
 #include "test_spatial_map_play.hpp"
 #include "test_window_eval.hpp"

--- a/ateam_kenobi/src/plays/test_plays/controls_test_play.cpp
+++ b/ateam_kenobi/src/plays/test_plays/controls_test_play.cpp
@@ -38,16 +38,21 @@ ControlsTestPlay::ControlsTestPlay(stp::Options stp_options)
 
   // Drive in square
   waypoints = {
-    {ateam_geometry::Point(1.0, -1.0), AngleMode::face_absolute, 0.0, 3.0},
     {ateam_geometry::Point(-1.0, -1.0), AngleMode::face_absolute, 0.0, 3.0},
+    {ateam_geometry::Point(-3.0, -1.0), AngleMode::face_absolute, 0.0, 3.0},
+    {ateam_geometry::Point(-3.0, 1.0), AngleMode::face_absolute, 0.0, 3.0},
     {ateam_geometry::Point(-1.0, 1.0), AngleMode::face_absolute, 0.0, 3.0},
-    {ateam_geometry::Point(1.0, 1.0), AngleMode::face_absolute, 0.0, 3.0},
   };
+
+  // waypoints = {
+  //   {ateam_geometry::Point(-0.5, -kRobotRadius), AngleMode::face_absolute, M_PI / 2, 3.0},
+  //   {ateam_geometry::Point(-0.5, kRobotRadius), AngleMode::face_absolute, M_PI / 2, 3.0}
+  // };
 
   motion_controller_.v_max = 2.0;
   motion_controller_.t_max = 20.0;
-  motion_controller_.accel_limit = 3.0;
-  motion_controller_.decel_limit = 3.0;
+  motion_controller_.accel_limit = 2.0;
+  motion_controller_.decel_limit = 2.0;
 }
 
 void ControlsTestPlay::reset()
@@ -84,9 +89,11 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> ControlsTestP
 
   auto waypoint_vel = ateam_geometry::Vector(0.0, 0.0);
   const auto prev_index = index == 0 ? waypoints.size() - 1 : index - 1;
+  // const auto next_index = (index + 1) % waypoints.size();
   std::vector<ateam_geometry::Point> path{
     waypoints[prev_index].position,
-    waypoints[index].position
+    waypoints[index].position,
+    // waypoints[next_index].position
   };
   motion_controller_.reset_trajectory(path, waypoint_vel);
 
@@ -152,13 +159,14 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> ControlsTestP
 
 bool ControlsTestPlay::isGoalHit(const Robot & robot)
 {
-  const bool position_goal_hit = ateam_geometry::norm(waypoints[index].position - robot.pos) <
-    position_threshold;
+  const auto target_index = (index) % waypoints.size();
+  const bool position_goal_hit = ateam_geometry::norm(waypoints[target_index].position -
+      robot.pos) < position_threshold;
   const bool heading_goal_hit = [&]() {
-      if (waypoints[index].angle_mode == AngleMode::face_absolute) {
+      if (waypoints[target_index].angle_mode == AngleMode::face_absolute) {
         return std::abs(
           angles::shortest_angular_distance(
-            waypoints[index].heading,
+            waypoints[target_index].heading,
             robot.theta)) < angles::from_degrees(angle_threshold);
       } else {
         return true;

--- a/ateam_kenobi/src/plays/test_plays/test_intercept_play.cpp
+++ b/ateam_kenobi/src/plays/test_plays/test_intercept_play.cpp
@@ -1,0 +1,102 @@
+// Copyright 2025 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "test_intercept_play.hpp"
+#include "core/types/world.hpp"
+#include "core/play_helpers/available_robots.hpp"
+#include "core/play_helpers/robot_assignment.hpp"
+
+namespace ateam_kenobi::plays
+{
+TestInterceptPlay::TestInterceptPlay(stp::Options stp_options)
+: stp::Play(kPlayName, stp_options),
+  capture_skill_(createChild<skills::Capture>("capture")),
+  kick_skill_(createChild<skills::PivotKick>("kick"))
+{
+}
+
+void TestInterceptPlay::enter()
+{
+  ball_has_been_sensed_ = false;
+  ball_has_been_kicked_ = false;
+  capture_skill_.Reset();
+  kick_skill_.Reset();
+}
+
+std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TestInterceptPlay::runFrame(
+  const World & world)
+{
+  std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> maybe_motion_commands;
+
+  // pass_tactic_.setTarget(targets_[target_ind_]);
+
+  const auto available_robots = play_helpers::getAvailableRobots(world);
+  if (available_robots.size() >= 2) {
+
+    const auto receiver = available_robots[0];
+    const auto kicker = available_robots[1];
+
+    getPlayInfo()["kicker_id"] = kicker.id;
+    getPlayInfo()["receiver_id"] = receiver.id;
+
+    auto & kicker_command = maybe_motion_commands.at(kicker.id).emplace();
+    auto & receiver_command = maybe_motion_commands.at(receiver.id).emplace();
+
+    const double kick_speed = 1.5;
+    kick_skill_.SetTargetPoint(receiver.pos);
+    kick_skill_.SetKickSpeed(kick_speed);
+
+    if (capture_skill_.isDone()) {
+      getPlayInfo()["result"] = "CAPTURE IS COMPLETED";
+      return maybe_motion_commands;
+    }
+
+    const double ball_speed = ateam_geometry::norm(world.ball.vel);
+
+    if (!ball_has_been_sensed_ && kicker.breakbeam_ball_detected) {
+      ball_has_been_sensed_ = true;
+    }
+
+    if (ball_has_been_sensed_ && !ball_has_been_kicked_
+      &&  ball_speed > 0.3 * kick_speed){
+      ball_has_been_kicked_ = true;
+    }
+
+    if (ball_has_been_kicked_) {
+      ForwardPlayInfo(capture_skill_);
+      receiver_command = capture_skill_.runFrame(world, receiver);
+    } else {
+      getPlayInfo()["ball sensed"] = ball_has_been_sensed_;
+      getPlayInfo()["ball speed"] = ball_speed;
+
+      kicker_command = kick_skill_.RunFrame(world, kicker);
+
+      // Face the ball
+      const double target_angle = atan2(
+        world.ball.pos.y() - receiver.pos.y(),
+        world.ball.pos.x() - receiver.pos.x());
+      double t_error = angles::shortest_angular_distance(receiver.theta, target_angle);
+      receiver_command.twist.angular.z = 1.5 * t_error;
+    }
+  } 
+
+  return maybe_motion_commands;
+}
+}  // namespace ateam_kenobi::plays

--- a/ateam_kenobi/src/plays/test_plays/test_intercept_play.cpp
+++ b/ateam_kenobi/src/plays/test_plays/test_intercept_play.cpp
@@ -49,7 +49,6 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TestIntercept
 
   const auto available_robots = play_helpers::getAvailableRobots(world);
   if (available_robots.size() >= 2) {
-
     const auto receiver = available_robots[0];
     const auto kicker = available_robots[1];
 
@@ -74,8 +73,9 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TestIntercept
       ball_has_been_sensed_ = true;
     }
 
-    if (ball_has_been_sensed_ && !ball_has_been_kicked_
-      &&  ball_speed > 0.3 * kick_speed){
+    if (ball_has_been_sensed_ && !ball_has_been_kicked_ &&
+      ball_speed > 0.3 * kick_speed)
+    {
       ball_has_been_kicked_ = true;
     }
 
@@ -95,7 +95,7 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TestIntercept
       double t_error = angles::shortest_angular_distance(receiver.theta, target_angle);
       receiver_command.twist.angular.z = 1.5 * t_error;
     }
-  } 
+  }
 
   return maybe_motion_commands;
 }

--- a/ateam_kenobi/src/plays/test_plays/test_intercept_play.hpp
+++ b/ateam_kenobi/src/plays/test_plays/test_intercept_play.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 A Team
+// Copyright 2025 A Team
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,41 +18,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#ifndef PLAYS__TEST_PLAYS__TEST_INTERCEPT_PLAY_HPP_
+#define PLAYS__TEST_PLAYS__TEST_INTERCEPT_PLAY_HPP_
 
-#ifndef PLAYS__OUR_PENALTY_PLAY_HPP_
-#define PLAYS__OUR_PENALTY_PLAY_HPP_
-
+#include <vector>
 #include "core/stp/play.hpp"
-#include "skills/goalie.hpp"
+#include "tactics/pass.hpp"
 #include "skills/universal_kick.hpp"
-#include "core/play_helpers/easy_move_to.hpp"
 
 namespace ateam_kenobi::plays
 {
-
-class OurPenaltyPlay : public stp::Play
+class TestInterceptPlay : public stp::Play
 {
 public:
-  static constexpr const char * kPlayName = "OurPenaltyPlay";
+  static constexpr const char * kPlayName = "TestInterceptPlay";
 
-  explicit OurPenaltyPlay(stp::Options stp_options);
+  explicit TestInterceptPlay(stp::Options stp_options);
 
-  stp::PlayScore getScore(const World & world) override;
-
-  void reset() override;
+  void enter() override;
 
   std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
     16> runFrame(const World & world) override;
 
 private:
-  skills::Goalie goalie_skill_;
+  skills::Capture capture_skill_;
   skills::UniversalKick kick_skill_;
-  std::array<play_helpers::EasyMoveTo, 16> move_tos_;
-  std::chrono::steady_clock::time_point kick_time_ = std::chrono::steady_clock::time_point::max();
-
-  ateam_geometry::Point chooseKickTarget(const World & world);
+  bool ball_has_been_sensed_ = false;
+  bool ball_has_been_kicked_ = false;
 };
-
 }  // namespace ateam_kenobi::plays
-
-#endif  // PLAYS__OUR_PENALTY_PLAY_HPP_
+#endif  // PLAYS__TEST_PLAYS__TEST_INTERCEPT_PLAY_HPP_

--- a/ateam_kenobi/src/plays/test_plays/test_kick_play.hpp
+++ b/ateam_kenobi/src/plays/test_plays/test_kick_play.hpp
@@ -72,7 +72,11 @@ public:
       world,
       robot);
 
-    getPlayInfo()["line kick"] = line_kick_skill_.getPlayInfo();
+    if (use_pivot_kick) {
+      ForwardPlayInfo(pivot_kick_skill_);
+    } else {
+      ForwardPlayInfo(line_kick_skill_);
+    }
     return motion_commands;
   }
 

--- a/ateam_kenobi/src/plays/test_plays/test_pass_play.cpp
+++ b/ateam_kenobi/src/plays/test_plays/test_pass_play.cpp
@@ -30,14 +30,15 @@ TestPassPlay::TestPassPlay(stp::Options stp_options)
   pass_tactic_(createChild<tactics::Pass>("pass"))
 {
   targets_ = {
-    ateam_geometry::Point{-1.5, -1},
-    ateam_geometry::Point{1.5, 1}
+    ateam_geometry::Point{-1, -1.5},
+    ateam_geometry::Point{-1, 1.5}
   };
 }
 
 void TestPassPlay::enter()
 {
   target_ind_ = 0;
+  first_frame_ = true;
   pass_tactic_.reset();
 }
 
@@ -46,16 +47,40 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TestPassPlay:
 {
   std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> maybe_motion_commands;
 
-  if(pass_tactic_.isDone()) {
-    target_ind_ = (target_ind_ + 1) % targets_.size();
-    pass_tactic_.reset();
+  if(first_frame_) {
+    const auto furthest_target_iter = std::max_element(targets_.begin(), targets_.end(), [&world](const auto & t1, const auto & t2) {
+      return CGAL::squared_distance(world.ball.pos, t1) < CGAL::squared_distance(world.ball.pos, t2);
+    });
+    target_ind_ = std::distance(targets_.begin(), furthest_target_iter);
+    first_frame_ = false;
   }
+
+  const auto is_done = pass_tactic_.isDone();
+  if(is_done && !prev_done_) {
+    done_time_ = world.current_time;
+  }
+  const auto done_time = std::chrono::duration_cast<std::chrono::seconds>(world.current_time -
+      done_time_).count();
+
+  if (is_done && done_time > 5) {
+    do {
+      target_ind_ = (target_ind_ + 1) % targets_.size();
+      pass_tactic_.reset();
+    } while (ateam_geometry::norm(targets_[target_ind_] - world.ball.pos) < 0.5);
+  }
+  prev_done_ = is_done;
 
   pass_tactic_.setTarget(targets_[target_ind_]);
 
   play_helpers::GroupAssignmentSet groups;
-  groups.AddPosition("kicker", pass_tactic_.getKickerAssignmentPoint(world));
-  groups.AddPosition("receiver", pass_tactic_.getReceiverAssignmentPoint());
+  
+  const auto kicker_assignment_point = pass_tactic_.getKickerAssignmentPoint(world);
+  groups.AddPosition("kicker", kicker_assignment_point);
+  getOverlays().drawCircle("kick_assignment_pt", ateam_geometry::makeCircle(kicker_assignment_point, 0.05), "#00000000", "LightGreen");
+
+  const auto receiver_assignment_point = pass_tactic_.getReceiverAssignmentPoint();
+  groups.AddPosition("receiver", receiver_assignment_point);
+  getOverlays().drawCircle("receive_assignment_pt", ateam_geometry::makeCircle(receiver_assignment_point, 0.05), "#00000000", "red");
 
   const auto available_robots = play_helpers::getAvailableRobots(world);
   const auto assignments = play_helpers::assignGroups(available_robots, groups);
@@ -70,9 +95,22 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TestPassPlay:
   const auto kicker = *kicker_assignment;
   const auto receiver = *receiver_assignment;
 
+  getOverlays().drawCircle("kicker_halo", ateam_geometry::makeCircle(kicker.pos, kRobotRadius + 0.1), "LightGreen", "#00000000");
+  getOverlays().drawCircle("receiver_halo", ateam_geometry::makeCircle(receiver.pos, kRobotRadius + 0.1), "red", "#00000000");
+
+  getPlayInfo()["kicker_id"] = kicker.id;
+  getPlayInfo()["receiver_id"] = receiver.id;
+  getPlayInfo()["pass_done"] = is_done;
+  getPlayInfo()["done_time"] = done_time;
+  getPlayInfo()["target"]["x"] = targets_[target_ind_].x();
+  getPlayInfo()["target"]["y"] = targets_[target_ind_].y();
+  ForwardPlayInfo(pass_tactic_);
+
   auto & kicker_command = maybe_motion_commands.at(kicker.id).emplace();
-  auto & receiver_command = maybe_motion_commands.at(kicker.id).emplace();
-  pass_tactic_.runFrame(world, kicker, receiver, kicker_command, receiver_command);
+  auto & receiver_command = maybe_motion_commands.at(receiver.id).emplace();
+  if(!is_done) {
+    pass_tactic_.runFrame(world, kicker, receiver, kicker_command, receiver_command);
+  }
 
   return maybe_motion_commands;
 }

--- a/ateam_kenobi/src/plays/test_plays/test_pass_play.cpp
+++ b/ateam_kenobi/src/plays/test_plays/test_pass_play.cpp
@@ -48,8 +48,10 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TestPassPlay:
   std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> maybe_motion_commands;
 
   if(first_frame_) {
-    const auto furthest_target_iter = std::max_element(targets_.begin(), targets_.end(), [&world](const auto & t1, const auto & t2) {
-      return CGAL::squared_distance(world.ball.pos, t1) < CGAL::squared_distance(world.ball.pos, t2);
+    const auto furthest_target_iter = std::max_element(targets_.begin(), targets_.end(),
+        [&world](const auto & t1, const auto & t2) {
+          return CGAL::squared_distance(world.ball.pos, t1) < CGAL::squared_distance(world.ball.pos,
+          t2);
     });
     target_ind_ = std::distance(targets_.begin(), furthest_target_iter);
     first_frame_ = false;
@@ -73,14 +75,16 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TestPassPlay:
   pass_tactic_.setTarget(targets_[target_ind_]);
 
   play_helpers::GroupAssignmentSet groups;
-  
+
   const auto kicker_assignment_point = pass_tactic_.getKickerAssignmentPoint(world);
   groups.AddPosition("kicker", kicker_assignment_point);
-  getOverlays().drawCircle("kick_assignment_pt", ateam_geometry::makeCircle(kicker_assignment_point, 0.05), "#00000000", "LightGreen");
+  getOverlays().drawCircle("kick_assignment_pt",
+      ateam_geometry::makeCircle(kicker_assignment_point, 0.05), "#00000000", "LightGreen");
 
   const auto receiver_assignment_point = pass_tactic_.getReceiverAssignmentPoint();
   groups.AddPosition("receiver", receiver_assignment_point);
-  getOverlays().drawCircle("receive_assignment_pt", ateam_geometry::makeCircle(receiver_assignment_point, 0.05), "#00000000", "red");
+  getOverlays().drawCircle("receive_assignment_pt",
+      ateam_geometry::makeCircle(receiver_assignment_point, 0.05), "#00000000", "red");
 
   const auto available_robots = play_helpers::getAvailableRobots(world);
   const auto assignments = play_helpers::assignGroups(available_robots, groups);
@@ -95,8 +99,10 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TestPassPlay:
   const auto kicker = *kicker_assignment;
   const auto receiver = *receiver_assignment;
 
-  getOverlays().drawCircle("kicker_halo", ateam_geometry::makeCircle(kicker.pos, kRobotRadius + 0.1), "LightGreen", "#00000000");
-  getOverlays().drawCircle("receiver_halo", ateam_geometry::makeCircle(receiver.pos, kRobotRadius + 0.1), "red", "#00000000");
+  getOverlays().drawCircle("kicker_halo",
+      ateam_geometry::makeCircle(kicker.pos, kRobotRadius + 0.1), "LightGreen", "#00000000");
+  getOverlays().drawCircle("receiver_halo",
+      ateam_geometry::makeCircle(receiver.pos, kRobotRadius + 0.1), "red", "#00000000");
 
   getPlayInfo()["kicker_id"] = kicker.id;
   getPlayInfo()["receiver_id"] = receiver.id;

--- a/ateam_kenobi/src/plays/test_plays/test_pass_play.hpp
+++ b/ateam_kenobi/src/plays/test_plays/test_pass_play.hpp
@@ -43,6 +43,9 @@ private:
   tactics::Pass pass_tactic_;
   std::vector<ateam_geometry::Point> targets_;
   size_t target_ind_ = 0;
+  bool prev_done_ = false;
+  bool first_frame_ = true;
+  std::chrono::steady_clock::time_point done_time_;
 };
 }  // namespace ateam_kenobi::plays
 #endif  // PLAYS__TEST_PLAYS__TEST_PASS_PLAY_HPP_

--- a/ateam_kenobi/src/plays/test_plays/test_pivot_play.hpp
+++ b/ateam_kenobi/src/plays/test_plays/test_pivot_play.hpp
@@ -70,7 +70,9 @@ public:
       if(!prev_at_target_) {
         arrival_time_ = world.current_time;
       }
-      const auto seconds_at_target = std::chrono::duration_cast<std::chrono::duration<double>>(world.current_time - arrival_time_).count();
+      const auto seconds_at_target =
+        std::chrono::duration_cast<std::chrono::duration<double>>(world.current_time -
+          arrival_time_).count();
       play_info["Time At Target"] = seconds_at_target;
       if(seconds_at_target > wait_time_) {
         target_angle_ += target_step_;
@@ -85,10 +87,9 @@ public:
 
     play_info["Y Cmd"] = motion_commands[robot.id]->twist.linear.y;
     play_info["Omega Cmd"] = motion_commands[robot.id]->twist.angular.z;
-    
+
     return motion_commands;
   }
-
 
 private:
   static constexpr double target_step_ = M_PI / 2.0;
@@ -155,7 +156,6 @@ private:
     command.twist_frame = ateam_msgs::msg::RobotMotionCommand::FRAME_BODY;
     return command;
   }
-
 };
 
 }  // namespace ateam_kenobi::plays

--- a/ateam_kenobi/src/plays/test_plays/test_pivot_play.hpp
+++ b/ateam_kenobi/src/plays/test_plays/test_pivot_play.hpp
@@ -1,0 +1,163 @@
+// Copyright 2025 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef PLAYS__TEST_PLAYS__TEST_PIVOT_PLAY_HPP_
+#define PLAYS__TEST_PLAYS__TEST_PIVOT_PLAY_HPP_
+
+#include <angles/angles.h>
+#include "core/stp/play.hpp"
+#include "core/play_helpers/available_robots.hpp"
+
+namespace ateam_kenobi::plays
+{
+
+class TestPivotPlay : public stp::Play
+{
+public:
+  static constexpr const char * kPlayName = "TestPivotPlay";
+
+  explicit TestPivotPlay(stp::Options stp_options)
+  : stp::Play(kPlayName, stp_options)
+  {
+  }
+
+  void enter() override
+  {
+    target_angle_ = 0.0;
+  }
+
+  std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
+    16> runFrame(const World & world) override
+  {
+    std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> motion_commands;
+    const auto & robots = play_helpers::getAvailableRobots(world);
+    if (robots.empty()) {
+      return {};
+    }
+    const auto robot = robots.front();
+
+    auto & play_info = getPlayInfo();
+    play_info["Robot"] = robot.id;
+
+    const auto angle_error = angles::shortest_angular_distance(robot.theta, target_angle_);
+
+    const auto at_target = std::abs(angle_error) < target_tolerance_;
+
+    play_info["Angle"] = robot.theta;
+    play_info["Angle Error"] = angle_error;
+
+    play_info["At Target"] = at_target ? "yes" : "no";
+    play_info["Target Angle"] = target_angle_;
+
+    if(at_target) {
+      if(!prev_at_target_) {
+        arrival_time_ = world.current_time;
+      }
+      const auto seconds_at_target = std::chrono::duration_cast<std::chrono::duration<double>>(world.current_time - arrival_time_).count();
+      play_info["Time At Target"] = seconds_at_target;
+      if(seconds_at_target > wait_time_) {
+        target_angle_ += target_step_;
+        target_angle_ = angles::normalize_angle(target_angle_);
+      }
+      motion_commands[robot.id] = ateam_msgs::msg::RobotMotionCommand();
+    } else {
+      play_info["Time At Target"] = 0.0;
+      motion_commands[robot.id] = getPivotCommand(robot, angle_error);
+    }
+    prev_at_target_ = at_target;
+
+    play_info["Y Cmd"] = motion_commands[robot.id]->twist.linear.y;
+    play_info["Omega Cmd"] = motion_commands[robot.id]->twist.angular.z;
+    
+    return motion_commands;
+  }
+
+
+private:
+  static constexpr double target_step_ = M_PI / 2.0;
+  static constexpr double wait_time_ = 2.0;  // s
+  static constexpr double target_tolerance_ = 0.1;  // rad
+  static constexpr double pivot_speed_ = 2.0;  // rad/s
+  static constexpr double pivot_accel_ = 2.0;  // rad/s^2
+  double target_angle_ = 0.0;
+  bool prev_at_target_ = false;
+  std::chrono::steady_clock::time_point arrival_time_;
+
+
+  ateam_msgs::msg::RobotMotionCommand getPivotCommand(const Robot & robot, double angle_error)
+  {
+    ateam_msgs::msg::RobotMotionCommand command;
+
+    const double vel = robot.prev_command_omega;
+    const double dt = 0.01;
+
+    getPlayInfo()["Prev Cmd Omega"] = vel;
+
+    double deceleration_to_reach_target = (vel * vel) / (2 * angle_error);
+
+    getPlayInfo()["Target Decel"] = deceleration_to_reach_target;
+
+    // Cruise
+    double trapezoidal_vel = std::copysign(pivot_speed_, angle_error);
+    const double error_direction = std::copysign(1, angle_error);
+    const double decel_direction = std::copysign(1, vel * angle_error);
+
+    // Decelerate to target velocity
+    if (decel_direction > 0 && abs(deceleration_to_reach_target) > pivot_accel_ * 0.95) {
+      trapezoidal_vel = vel - (error_direction * deceleration_to_reach_target * dt);
+      getPlayInfo()["State"] = "Decel";
+    // Accelerate to speed
+    } else if (abs(vel) < pivot_speed_) {
+      trapezoidal_vel = vel + (error_direction * pivot_accel_ * dt);
+      getPlayInfo()["State"] = "Accel";
+    } else {
+      getPlayInfo()["State"] = "Cruise";
+    }
+
+    getPlayInfo()["Trap Vel"] = trapezoidal_vel;
+
+    const auto min_angular_vel = 1.0;
+    if (abs(trapezoidal_vel) < min_angular_vel) {
+      trapezoidal_vel = std::copysign(min_angular_vel, angle_error);
+    }
+
+    command.twist.angular.z = std::clamp(trapezoidal_vel, -pivot_speed_, pivot_speed_);
+
+    /* rotate in a circle with diameter 0.0427 + 0.18 = 0.2227 (This might be tunable to use 8cm for
+    * real robots)
+    * circumference of 0.6996 meters in a full rotation.
+    * Calculate m/rev * rev/s to get linear m/s
+    */
+    // double diameter = kBallDiameter + kRobotDiameter;
+    double diameter = 2 * .095;
+    double circumference = M_PI * diameter;
+    double velocity = circumference * (command.twist.angular.z / (2 * M_PI));
+
+    command.twist.linear.x = 0.0;
+    command.twist.linear.y = -velocity;
+    command.twist_frame = ateam_msgs::msg::RobotMotionCommand::FRAME_BODY;
+    return command;
+  }
+
+};
+
+}  // namespace ateam_kenobi::plays
+
+#endif  // PLAYS__TEST_PLAYS__TEST_PIVOT_PLAY_HPP_

--- a/ateam_kenobi/src/plays/test_plays/triangle_pass_play.hpp
+++ b/ateam_kenobi/src/plays/test_plays/triangle_pass_play.hpp
@@ -73,6 +73,10 @@ private:
     const std::vector<Robot> & available_robots, const World & world,
     std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
     16> & motion_commands);
+
+  void runIdlers(
+    const std::vector<Robot> & robots, const World & world,
+    std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> & motion_commands);
 };
 
 }  // namespace ateam_kenobi::plays

--- a/ateam_kenobi/src/plays/their_ball_placement_play.cpp
+++ b/ateam_kenobi/src/plays/their_ball_placement_play.cpp
@@ -93,7 +93,7 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TheirBallPlac
       const auto y_bound = (world.field.field_width / 2.0) + world.field.boundary_width - offset;
       ateam_geometry::Rectangle pathable_region(ateam_geometry::Point(-x_bound, -y_bound),
         ateam_geometry::Point(x_bound, y_bound));
-      
+
       if (!CGAL::do_intersect(target_position, pathable_region)) {
         target_position = alternate_position;
       } else if (!CGAL::do_intersect(alternate_position, pathable_region)) {

--- a/ateam_kenobi/src/plays/their_ball_placement_play.cpp
+++ b/ateam_kenobi/src/plays/their_ball_placement_play.cpp
@@ -23,6 +23,7 @@
 #include <angles/angles.h>
 #include <ateam_common/robot_constants.hpp>
 #include "core/play_helpers/available_robots.hpp"
+#include <ateam_geometry/ateam_geometry.hpp>
 
 namespace ateam_kenobi::plays
 {
@@ -70,29 +71,7 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TheirBallPlac
   const auto point_to_ball = world.ball.pos - placement_point;
   const auto angle = std::atan2(point_to_ball.y(), point_to_ball.x());
 
-  ateam_geometry::Polygon polygon_points;
-  polygon_points.push_back(
-    placement_point +
-    0.5 * ateam_geometry::Vector(std::cos(angle + M_PI / 2), std::sin(angle + M_PI / 2)));
-  polygon_points.push_back(
-    placement_point +
-    0.5 * ateam_geometry::Vector(std::cos(angle - M_PI / 2), std::sin(angle - M_PI / 2)));
-  polygon_points.push_back(
-    world.ball.pos +
-    0.5 * ateam_geometry::Vector(std::cos(angle - M_PI / 2), std::sin(angle - M_PI / 2)));
-  polygon_points.push_back(
-    world.ball.pos +
-    0.5 * ateam_geometry::Vector(std::cos(angle + M_PI / 2), std::sin(angle + M_PI / 2)));
-
-  getOverlays().drawCircle(
-    "placement_avoid_point", ateam_geometry::makeCircle(
-      placement_point,
-      0.5), "red", "red");
-  getOverlays().drawCircle(
-    "placement_avoid_ball", ateam_geometry::makeCircle(
-      world.ball.pos,
-      0.5), "red", "red");
-  getOverlays().drawPolygon("placement_avoid_zone", polygon_points, "red", "red");
+  DrawKeepoutArea(world.ball.pos, placement_point);
 
   for (auto ind = 0ul; ind < available_robots.size(); ++ind) {
     const auto & robot = available_robots[ind];
@@ -109,11 +88,23 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TheirBallPlac
       const auto alternate_position = nearest_point +
         0.7 * ateam_geometry::Vector(std::cos(angle - M_PI / 2), std::sin(angle - M_PI / 2));
 
-
-      if (ateam_geometry::norm(target_position - robot.pos) >
-        ateam_geometry::norm(alternate_position - robot.pos))
-      {
+      const auto offset = kRobotRadius * 0.95;
+      const auto x_bound = (world.field.field_length / 2.0) + world.field.boundary_width - offset;
+      const auto y_bound = (world.field.field_width / 2.0) + world.field.boundary_width - offset;
+      ateam_geometry::Rectangle pathable_region(ateam_geometry::Point(-x_bound, -y_bound),
+        ateam_geometry::Point(x_bound, y_bound));
+      
+      if (!CGAL::do_intersect(target_position, pathable_region)) {
         target_position = alternate_position;
+      } else if (!CGAL::do_intersect(alternate_position, pathable_region)) {
+        // Stick with target_position
+      } else {
+        // Use the shorter path
+        if (ateam_geometry::norm(target_position - robot.pos) >
+          ateam_geometry::norm(alternate_position - robot.pos))
+        {
+          target_position = alternate_position;
+        }
       }
 
       getPlayInfo()["Robots"][std::to_string(robot.id)] = "MOVING";
@@ -127,6 +118,37 @@ std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> TheirBallPlac
   }
 
   return maybe_motion_commands;
+}
+
+void TheirBallPlacementPlay::DrawKeepoutArea(
+  const ateam_geometry::Point & ball_pos,
+  const ateam_geometry::Point & placement_point)
+{
+  const auto point_to_ball = ball_pos - placement_point;
+  const auto angle = std::atan2(point_to_ball.y(), point_to_ball.x());
+
+  auto & overlays = getOverlays();
+
+  const auto keepout_radius = 0.5;
+  const ateam_geometry::Vector pos_offset{keepout_radius * std::cos(angle + M_PI_2),
+    keepout_radius * std::sin(angle + M_PI_2)};
+  const ateam_geometry::Vector neg_offset{keepout_radius * std::cos(angle - M_PI_2),
+    keepout_radius * std::sin(angle - M_PI_2)};
+
+  const ateam_geometry::Arc ball_side_arc{ball_pos, keepout_radius, neg_offset.direction(),
+    pos_offset.direction()};
+  const ateam_geometry::Arc point_side_arc{placement_point, keepout_radius, pos_offset.direction(),
+    neg_offset.direction()};
+  const ateam_geometry::Segment pos_segment{placement_point + pos_offset, ball_pos + pos_offset};
+  const ateam_geometry::Segment neg_segment{placement_point + neg_offset, ball_pos + neg_offset};
+
+
+  overlays.drawArc("placement_avoid_ball_arc", ball_side_arc, "Red");
+  overlays.drawArc("placement_avoid_place_arc", point_side_arc, "Red");
+  overlays.drawLine("placement_avoid_pos_line", {pos_segment.source(), pos_segment.target()},
+      "Red");
+  overlays.drawLine("placement_avoid_neg_line", {neg_segment.source(), neg_segment.target()},
+      "Red");
 }
 
 }  // namespace ateam_kenobi::plays

--- a/ateam_kenobi/src/plays/their_ball_placement_play.hpp
+++ b/ateam_kenobi/src/plays/their_ball_placement_play.hpp
@@ -44,6 +44,10 @@ public:
 
 private:
   std::array<play_helpers::EasyMoveTo, 16> easy_move_tos_;
+
+  void DrawKeepoutArea(
+    const ateam_geometry::Point & ball_pos,
+    const ateam_geometry::Point & placement_point);
 };
 
 }  // namespace ateam_kenobi::plays

--- a/ateam_kenobi/src/plays/util_plays/all_util_plays.hpp
+++ b/ateam_kenobi/src/plays/util_plays/all_util_plays.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 A Team
+// Copyright 2024 A Team
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,41 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#ifndef PLAYS__UTIL_PLAYS__ALL_UTIL_PLAYS_HPP_
+#define PLAYS__UTIL_PLAYS__ALL_UTIL_PLAYS_HPP_
 
-#ifndef PLAYS__OUR_PENALTY_PLAY_HPP_
-#define PLAYS__OUR_PENALTY_PLAY_HPP_
+#include "corner_lineup_play.hpp"
 
-#include "core/stp/play.hpp"
-#include "skills/goalie.hpp"
-#include "skills/universal_kick.hpp"
-#include "core/play_helpers/easy_move_to.hpp"
-
-namespace ateam_kenobi::plays
-{
-
-class OurPenaltyPlay : public stp::Play
-{
-public:
-  static constexpr const char * kPlayName = "OurPenaltyPlay";
-
-  explicit OurPenaltyPlay(stp::Options stp_options);
-
-  stp::PlayScore getScore(const World & world) override;
-
-  void reset() override;
-
-  std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>,
-    16> runFrame(const World & world) override;
-
-private:
-  skills::Goalie goalie_skill_;
-  skills::UniversalKick kick_skill_;
-  std::array<play_helpers::EasyMoveTo, 16> move_tos_;
-  std::chrono::steady_clock::time_point kick_time_ = std::chrono::steady_clock::time_point::max();
-
-  ateam_geometry::Point chooseKickTarget(const World & world);
-};
-
-}  // namespace ateam_kenobi::plays
-
-#endif  // PLAYS__OUR_PENALTY_PLAY_HPP_
+#endif  // PLAYS__UTIL_PLAYS__ALL_UTIL_PLAYS_HPP_

--- a/ateam_kenobi/src/plays/util_plays/corner_lineup_play.cpp
+++ b/ateam_kenobi/src/plays/util_plays/corner_lineup_play.cpp
@@ -1,0 +1,81 @@
+// Copyright 2025 A Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#include "corner_lineup_play.hpp"
+#include <ateam_common/robot_constants.hpp>
+#include "core/types/robot.hpp"
+#include "core/play_helpers/available_robots.hpp"
+
+namespace ateam_kenobi::plays
+{
+
+CornerLineupPlay::CornerLineupPlay(stp::Options stp_options, double x_mult, double y_mult)
+: stp::Play(stp_options.name, stp_options),
+  x_mult_(x_mult),
+  y_mult_(y_mult)
+{
+  createIndexedChildren<play_helpers::EasyMoveTo>(easy_move_tos_, "EasyMoveTo");
+  setEnabled(false);
+}
+
+stp::PlayScore CornerLineupPlay::getScore(const World &)
+{
+  return stp::PlayScore::NaN();
+}
+
+void CornerLineupPlay::reset()
+{
+  for (auto & move_to : easy_move_tos_) {
+    move_to.reset();
+  }
+}
+
+std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> CornerLineupPlay::runFrame(
+  const World & world)
+{
+  std::array<std::optional<ateam_msgs::msg::RobotMotionCommand>, 16> maybe_motion_commands;
+
+  const ateam_geometry::Point start_point(x_mult_ * world.field.field_length / 2.0,
+    y_mult_ * world.field.field_width / 2.0);
+  const auto x_dir = -1.0 * std::copysign(1.0, x_mult_);
+  const ateam_geometry::Vector direction(x_dir * 2 * kRobotDiameter, 0.0);
+
+  auto spot_counter = 0;
+  for (auto & robot : world.our_robots) {
+    if (!robot.visible && !robot.radio_connected) {
+      continue;
+    }
+
+    const auto spot = start_point + (direction * spot_counter);
+    spot_counter++;
+
+    if (robot.IsAvailable()) {
+      auto & easy_move_to = easy_move_tos_.at(robot.id);
+      easy_move_to.setTargetPosition(spot);
+      easy_move_to.face_absolute(0.0);
+      maybe_motion_commands.at(robot.id) = easy_move_to.runFrame(robot, world);
+    }
+  }
+
+  return maybe_motion_commands;
+}
+
+}  // namespace ateam_kenobi::plays

--- a/ateam_kenobi/src/plays/util_plays/corner_lineup_play.hpp
+++ b/ateam_kenobi/src/plays/util_plays/corner_lineup_play.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 A Team
+// Copyright 2025 A Team
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,24 +18,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#ifndef PLAYS__UTIL_PLAYS__CORNER_LINEUP_PLAY_HPP_
+#define PLAYS__UTIL_PLAYS__CORNER_LINEUP_PLAY_HPP_
 
-#ifndef PLAYS__OUR_PENALTY_PLAY_HPP_
-#define PLAYS__OUR_PENALTY_PLAY_HPP_
+#include <vector>
+#include <optional>
+#include <array>
 
+#include "ateam_geometry/types.hpp"
+#include "core/types/robot.hpp"
 #include "core/stp/play.hpp"
-#include "skills/goalie.hpp"
-#include "skills/universal_kick.hpp"
 #include "core/play_helpers/easy_move_to.hpp"
 
 namespace ateam_kenobi::plays
 {
 
-class OurPenaltyPlay : public stp::Play
+class CornerLineupPlay : public stp::Play
 {
 public:
-  static constexpr const char * kPlayName = "OurPenaltyPlay";
-
-  explicit OurPenaltyPlay(stp::Options stp_options);
+  explicit CornerLineupPlay(stp::Options stp_options, double x_mult, double y_mult);
 
   stp::PlayScore getScore(const World & world) override;
 
@@ -45,14 +46,10 @@ public:
     16> runFrame(const World & world) override;
 
 private:
-  skills::Goalie goalie_skill_;
-  skills::UniversalKick kick_skill_;
-  std::array<play_helpers::EasyMoveTo, 16> move_tos_;
-  std::chrono::steady_clock::time_point kick_time_ = std::chrono::steady_clock::time_point::max();
-
-  ateam_geometry::Point chooseKickTarget(const World & world);
+  const double x_mult_;
+  const double y_mult_;
+  std::array<play_helpers::EasyMoveTo, 16> easy_move_tos_;
 };
-
 }  // namespace ateam_kenobi::plays
 
-#endif  // PLAYS__OUR_PENALTY_PLAY_HPP_
+#endif  // PLAYS__UTIL_PLAYS__CORNER_LINEUP_PLAY_HPP_


### PR DESCRIPTION
* Adds new plays
   * `CornerLineupPlay`
   * `DefendersOnlyPlay`
   * `TestPivotPlay`
   * `TestInterceptPlay`
* Swaps in `UniversalKick` in many places
* Tweaks `FreeKickOnGoalPlay` scoring and position assignment
* Tweaks `KickOnGoalPlay` scoring and kick target
* Adds extraction support to ball placement play
* Tweaks `PassToLanePlay` scoring and offsets target along segment
* Tweaks `SpatialPassPlay` scoring
* Fixes stop plays handling of assigned prep bot vs closest escaping bot
* Various changes to test plays
* Cleans up ball placement keepout overlays
* Tweaks target selection for robots getting out of the way in `TheirBallPlacementPlay`