### PR TITLE
Removes vestigial power request parameters.

### DIFF
--- a/radio/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/radio/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -72,9 +72,6 @@ public:
         {"wheel_torque", false}
     });
 
-    declare_parameter<bool>("shut_down_robots", false);
-    declare_parameter<bool>("reboot_robots", false);
-
     ateam_common::indexed_topic_helpers::create_indexed_subscribers<ateam_msgs::msg::RobotMotionCommand>(
       motion_command_subscriptions_,
       "~/robot_motion_commands/robot",


### PR DESCRIPTION
Fixes #361

Turns out we had already switched them to using a service and just hadn't removed the old parameter declarations.