### PR TITLE
GC Launch Revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
    # In the ateam_ws directory
    ./src/software/ateam_ui/install_deps.sh
 
-   sudo apt install python3-clang net-tools
+   sudo apt install python3-clang
    ```
    <!-- TODO(braulicm): Add custom rosdep keys file -->
 
@@ -124,20 +124,7 @@ ros2 launch ateam_bringup bringup_simulation.launch.py
 
 This will start the simlator, game controller, and our full autonomous gameplay stack at one. Launch arguments are available to disable starting up certain components.
 
-**Note:** If you notice issues receiving vision messages from the simulator, or if vision messages are coming in at an unexpectedly low rate, you may need to enable multicast on your loopback interface. We have a script for that:
-
-```bash
-ros2 run ateam_bringup enable_loopback_multicast.sh
-```
-
-**Note:** If you get a permission error regarding Docker launching (game controller), you need to add you user to the docker permission group.
-
-> [docker-2] docker: permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Head "http://%2Fvar%2Frun%2Fdocker.sock/_ping": dial unix /var/run/docker.sock: connect: permission denied
-
-```bash
-sudo usermod -aG docker $USER
-# you need to log out and log back in after this command. On some Ubuntu 24.04 LTS, you need a full reboot.
-```
+See [Tips & Tricks](#tips-tricks) for common issues.
 
 #### Running Two Gameplay Stacks for Self-Scrimmaging.
 
@@ -151,4 +138,27 @@ ros2 launch ateam_bringup bringup_simulation.launch.py
 
 # In the second terminal
 ros2 launch ateam_bringup bringup_simulation.launch.py start_sim:=false start_gc:=false start_ui:=false team_name:=Unknown
+```
+
+## Tips & Tricks
+
+### Local Multicast
+
+If you notice issues receiving vision messages from the simulator, or if vision messages are coming in at an unexpectedly low rate, you may need to enable multicast on your loopback interface. We have a script for that:
+
+```bash
+ros2 run ateam_bringup enable_loopback_multicast.sh
+```
+
+### Docker Issues
+
+As a general note, prefer installing Docker using one of the [officially supported methods](https://docs.docker.com/engine/install/ubuntu/). The Docker snap package is known to have a lot of usability issues.
+
+If you get a permission error regarding Docker launching (game controller), you need to add you user to the docker permission group.
+
+> [docker-2] docker: permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Head "http://%2Fvar%2Frun%2Fdocker.sock/_ping": dial unix /var/run/docker.sock: connect: permission denied
+
+```bash
+sudo usermod -aG docker $USER
+# you need to log out and log back in after this command. On some Ubuntu 24.04 LTS, you need a full reboot.
 ```

--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ Our software can be run against [the ER-Force Framework simulator](https://githu
       source ~/.bashrc
       ```
 
+### Install SSL Game Controller
+
+You can either use a native install or run it in Docker.
+
+For native, download the binary from [the releases page](https://github.com/RoboCup-SSL/ssl-game-controller/releases). We recommend you rename it to 'ssl-game-controller' and save it somewhere in your PATH.
+
+For Docker, ensure Docker is installed, then pull the GC image.
+
+   ```bash
+   docker pull robocupssl/ssl-game-controller
+   ```
+
 ### Starting Simulation Stack
 
 We have a convenient launch file for starting up the complete stack with the simulator.

--- a/ateam_bringup/launch/bringup_simulation.launch.py
+++ b/ateam_bringup/launch/bringup_simulation.launch.py
@@ -49,7 +49,7 @@ def generate_launch_description():
         IncludeLaunchDescription(
             FrontendLaunchDescriptionSource(
                 PackageLaunchFileSubstitution('ateam_bringup',
-                                              'ssl_game_controller.launch.xml')),
+                                              'ssl_game_controller.launch.py')),
             condition=IfCondition(LaunchConfiguration('start_gc'))
         ),
 

--- a/ateam_bringup/launch/ssl_game_controller.launch.py
+++ b/ateam_bringup/launch/ssl_game_controller.launch.py
@@ -1,0 +1,147 @@
+# Copyright 2026 A Team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pathlib
+import launch
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, GroupAction
+from launch.conditions import IfCondition, UnlessCondition
+from launch.substitutions import (
+    AndSubstitution,
+    LaunchConfiguration,
+    NotSubstitution,
+    PathJoinSubstitution,
+)
+
+
+def generate_launch_description():
+    default_working_dir = pathlib.Path.home() / '.ateam' / 'ssl_game_controller'
+
+    docker_group = GroupAction(
+        condition=IfCondition(
+            AndSubstitution(
+                LaunchConfiguration('gc_use_docker'),
+                NotSubstitution(LaunchConfiguration('gc_expose_to_net')),
+            )
+        ),
+        actions=[
+            ExecuteProcess(
+                cmd=[
+                    'docker',
+                    'run',
+                    '--rm',
+                    '-p',
+                    '8081:8081',
+                    '-p',
+                    '10007:10007',
+                    '-p',
+                    '10008:10008',
+                    '-p',
+                    '10011:10011',
+                    '-v',
+                    LaunchConfiguration('gc_working_dir') + '/config:/config',
+                    'robocupssl/ssl-game-controller',
+                    '-address',
+                    ':8081',
+                ],
+                output='screen',
+                respawn=True,
+            )
+        ],
+    )
+
+    docker_exposed_group = GroupAction(
+        condition=IfCondition(
+            AndSubstitution(
+                LaunchConfiguration('gc_use_docker'),
+                LaunchConfiguration('gc_expose_to_net'),
+            )
+        ),
+        actions=[
+            ExecuteProcess(
+                cmd=[
+                    'docker',
+                    'run',
+                    '--rm',
+                    '--net',
+                    'host',
+                    '-v',
+                    LaunchConfiguration('gc_working_dir') + '/config:/config',
+                    'robocupssl/ssl-game-controller',
+                    '-address',
+                    ':8081',
+                ],
+                output='screen',
+                respawn=True,
+            )
+        ],
+    )
+
+    native_group = GroupAction(
+        condition=UnlessCondition(LaunchConfiguration('gc_use_docker')),
+        actions=[
+            ExecuteProcess(
+                cmd=[
+                    LaunchConfiguration('gc_exec_path'),
+                    '-address',
+                    ':8081',
+                ],
+                output='screen',
+                respawn=True,
+            )
+        ]
+    )
+
+    run_gc_group = GroupAction(
+        actions=[
+            docker_group,
+            docker_exposed_group,
+            native_group,
+        ]
+    )
+
+    create_config_dir = ExecuteProcess(
+        cmd=[
+            'mkdir',
+            '-p',
+            PathJoinSubstitution([LaunchConfiguration('gc_working_dir'), 'config']),
+        ],
+        on_exit=[run_gc_group],
+    )
+
+    create_working_dir = ExecuteProcess(
+        cmd=['mkdir', '-p', LaunchConfiguration('gc_working_dir')],
+        on_exit=[create_config_dir],
+    )
+
+    return launch.LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                'gc_working_dir', default_value=str(default_working_dir)
+            ),
+            DeclareLaunchArgument(
+                'gc_use_docker', default_value='True', choices=['True', 'False']
+            ),
+            DeclareLaunchArgument(
+                'gc_expose_to_net', default_value='False', choices=['True', 'False']
+            ),
+            DeclareLaunchArgument('gc_exec_path', default_value='ssl-game-controller'),
+            create_working_dir,
+        ]
+    )

--- a/ateam_bringup/launch/ssl_game_controller.launch.xml
+++ b/ateam_bringup/launch/ssl_game_controller.launch.xml
@@ -1,9 +1,0 @@
-<launch>
-  <arg name="data_directory" default="$(find-pkg-share ateam_bringup)/data" />
-  <arg name="expose_gc_to_net" default="false" />
-
-  <executable unless="$(var expose_gc_to_net)" cmd="docker run --rm -p 8081:8081 -p 10007:10007 -p 10008:10008 -p 10011:10011 robocupssl/ssl-game-controller -address :8081" output="screen" respawn="True"/>
-  
-  <executable if="$(var expose_gc_to_net)" cmd="docker run --net host --rm robocupssl/ssl-game-controller" output="screen" respawn="True"/>
-  <executable if="$(var expose_gc_to_net)" cmd="socat tcp-listen:8082,reuseaddr,fork tcp:127.0.0.1:8081" />
-</launch>

--- a/ateam_bringup/package.xml
+++ b/ateam_bringup/package.xml
@@ -10,8 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
-  <exec_depend>docker.io</exec_depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
* Adds support for native GC install
* Removes dependency on net-tools by using the `-address` flag
* Reorganizes README a bit for clarity

To support the new behaviors, I had to switch the GC launch file to Python.