### PR TITLE
Default Wheel Vel Control On

### DIFF
--- a/radio/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/radio/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -91,7 +91,7 @@ public:
 
     declare_parameters<bool>("controls_enabled", {
         {"body_vel", true},
-        {"wheel_vel", false},
+        {"wheel_vel", true},
         {"wheel_torque", true}
     });
 


### PR DESCRIPTION
Defaults wheel velocity control to on. This is now the desired control mode for Firmware. Also updates software-communications to main after PR: https://github.com/SSL-A-Team/software-communication/pull/32