### PR TITLE
Fixes ignore side hiccups

### DIFF
--- a/ateam_common/src/game_controller_listener.cpp
+++ b/ateam_common/src/game_controller_listener.cpp
@@ -97,8 +97,8 @@ void GameControllerListener::RefereeMessageCallback(
   if (team_color_ == TeamColor::Unknown) {
     team_side_ = TeamSide::Unknown;
   } else if (!msg->blue_team_on_positive_half.empty()) {
-    bool are_positive_half = !(msg->blue_team_on_positive_half.front() ^ (team_color_ ==
-      TeamColor::Blue));
+    bool are_we_blue = team_color_ == TeamColor::Blue;
+    bool are_positive_half = msg->blue_team_on_positive_half.front() == are_we_blue;
     team_side_ = are_positive_half ? TeamSide::PositiveHalf : TeamSide::NegativeHalf;
     // Our field convention is we should always been on the negative half.
     // So if this is positive for our team we should invert coords

--- a/ateam_kenobi/src/core/path_planning/obstacles.cpp
+++ b/ateam_kenobi/src/core/path_planning/obstacles.cpp
@@ -24,6 +24,7 @@
 #include <ateam_geometry/creation_helpers.hpp>
 #include <ateam_geometry/do_intersect.hpp>
 #include <ateam_common/robot_constants.hpp>
+#include <ateam_msgs/msg/field_info.hpp>
 
 namespace ateam_kenobi::path_planning
 {
@@ -171,11 +172,11 @@ bool IsPointInBounds(
   ateam_geometry::Rectangle pathable_region(ateam_geometry::Point(-x_bound, -y_bound),
     ateam_geometry::Point(x_bound, y_bound));
 
-  if (world.field.ignore_side > 0) {
+  if (world.field.ignore_side == ateam_msgs::msg::FieldInfo::IGNORE_SIDE_THEIRS) {
     pathable_region = ateam_geometry::Rectangle(
       ateam_geometry::Point(-x_bound, -y_bound),
       ateam_geometry::Point(0, y_bound));
-  } else if (world.field.ignore_side < 0) {
+  } else if (world.field.ignore_side == ateam_msgs::msg::FieldInfo::IGNORE_SIDE_OURS) {
     pathable_region = ateam_geometry::Rectangle(
       ateam_geometry::Point(0, y_bound),
       ateam_geometry::Point(x_bound, -y_bound));

--- a/ateam_msgs/msg/FieldInfo.msg
+++ b/ateam_msgs/msg/FieldInfo.msg
@@ -11,3 +11,8 @@ geometry_msgs/Polygon field_corners
 int32 ignore_side
 FieldSidedInfo ours
 FieldSidedInfo theirs
+
+int32 IGNORE_SIDE_NONE = 0
+
+int32 IGNORE_SIDE_OURS = 1
+int32 IGNORE_SIDE_THEIRS = 2

--- a/state_tracking/ateam_field_manager/CMakeLists.txt
+++ b/state_tracking/ateam_field_manager/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(ateam_field_manager)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/state_tracking/ateam_field_manager/src/message_conversions.cpp
+++ b/state_tracking/ateam_field_manager/src/message_conversions.cpp
@@ -148,7 +148,7 @@ ateam_msgs::msg::FieldInfo fromMsg(
       break;
   }
 
-  field_info.ignore_side = ignore_side;
+  field_info.ignore_side = mapIgnoredSide(team_side, ignore_side);
 
   return field_info;
 }
@@ -167,6 +167,30 @@ void invertFieldInfo(ateam_msgs::msg::FieldInfo & info)
   invert_point_array(info.ours.goal_corners.points);
   invert_point_array(info.theirs.defense_area_corners.points);
   invert_point_array(info.theirs.goal_corners.points);
+}
+
+
+int32_t mapIgnoredSide(const ateam_common::TeamSide & team_side, const int ignore_side_raw)
+{
+  if(ignore_side_raw < 0) {
+    if (team_side == ateam_common::TeamSide::PositiveHalf) {
+      return ateam_msgs::msg::FieldInfo::IGNORE_SIDE_THEIRS;
+    } else if (team_side == ateam_common::TeamSide::NegativeHalf) {
+      return ateam_msgs::msg::FieldInfo::IGNORE_SIDE_OURS;
+    } else {
+      return ateam_msgs::msg::FieldInfo::IGNORE_SIDE_NONE;
+    }
+  } else if (ignore_side_raw > 0) {
+    if (team_side == ateam_common::TeamSide::PositiveHalf) {
+      return ateam_msgs::msg::FieldInfo::IGNORE_SIDE_OURS;
+    } else if (team_side == ateam_common::TeamSide::NegativeHalf) {
+      return ateam_msgs::msg::FieldInfo::IGNORE_SIDE_THEIRS;
+    } else {
+      return ateam_msgs::msg::FieldInfo::IGNORE_SIDE_NONE;
+    }
+  } else {
+    return ateam_msgs::msg::FieldInfo::IGNORE_SIDE_NONE;
+  }
 }
 
 std::vector<geometry_msgs::msg::Point32> getPointsFromLines(

--- a/state_tracking/ateam_field_manager/src/message_conversions.hpp
+++ b/state_tracking/ateam_field_manager/src/message_conversions.hpp
@@ -42,6 +42,8 @@ ateam_msgs::msg::FieldInfo fromMsg(
 
 void invertFieldInfo(ateam_msgs::msg::FieldInfo & info);
 
+int32_t mapIgnoredSide(const ateam_common::TeamSide & team_side, const int ignore_side_raw);
+
 std::vector<geometry_msgs::msg::Point32> getPointsFromLines(
   const std::vector<ssl_league_msgs::msg::VisionFieldLineSegment> & lines,
   const std::vector<std::string> & line_names);

--- a/state_tracking/ateam_vision_filter/src/ateam_vision_filter_node.cpp
+++ b/state_tracking/ateam_vision_filter/src/ateam_vision_filter_node.cpp
@@ -107,12 +107,7 @@ public:
   void field_callback(
     const ateam_msgs::msg::FieldInfo::SharedPtr field_info_msg)
   {
-    const auto team_side = game_controller_listener_.GetTeamSide();
-    if (team_side == ateam_common::TeamSide::PositiveHalf) {
-      ignore_side_ = -field_info_msg->ignore_side;
-    } else {
-      ignore_side_ = field_info_msg->ignore_side;
-    }
+    ignore_side_ = field_info_msg->ignore_side;
   }
 
   void timer_callback()

--- a/state_tracking/ateam_vision_filter/src/camera.cpp
+++ b/state_tracking/ateam_vision_filter/src/camera.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include <ateam_msgs/msg/vision_state_mht.hpp>
+#include <ateam_msgs/msg/field_info.hpp>
 
 #include "filters/kalman_filter.hpp"
 #include "filters/interacting_multiple_model_filter.hpp"
@@ -140,10 +141,10 @@ void Camera::removeMeasurementsOnIngoredHalf(std::vector<Eigen::VectorXd> & meas
   measurements.erase(
     std::remove_if(
       measurements.begin(), measurements.end(), [this](const auto & m) {
-        if (ignore_half_ < 0 && m[0] < 0.0) {
+        if (ignore_half_ == ateam_msgs::msg::FieldInfo::IGNORE_SIDE_OURS && m[0] < 0.0) {
           return true;
         }
-        if (ignore_half_ > 0 && m[0] > 0.0) {
+        if (ignore_half_ == ateam_msgs::msg::FieldInfo::IGNORE_SIDE_THEIRS && m[0] > 0.0) {
           return true;
         }
         return false;


### PR DESCRIPTION
To avoid confusion that appeared between different packages, this PR standardizes the `ignore_side` member of the `FieldInfo` message to work in A-Team field coordinates (instead of raw vision coordinates).

`ignore_side` now represents the ignored half as either None, Ours, or Theirs.