### PR TITLE
Adds ateam_controls package

### DIFF
--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          ./src/software/install_dependencies.bash
+          ./src/ateam_software/install_dependencies.bash
       
       - name: Build
         shell: bash

--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -19,12 +19,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          source /opt/ros/jazzy/setup.bash
-          sudo apt-get update
-          rosdep update --rosdistro=jazzy
-          rosdep install --from-paths . --ignore-src -y
-          ./src/ateam_software/ateam_ui/install_deps.sh
-          sudo apt install -y python3-clang
+          ./src/software/install_dependencies.bash
       
       - name: Build
         shell: bash

--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -16,6 +16,9 @@ jobs:
           path: src/ateam_software
           submodules: true
       
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1.16.1
+
       - name: Install Dependencies
         shell: bash
         run: |

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -18,12 +18,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          source /opt/ros/jazzy/setup.bash
-          sudo apt-get update
-          rosdep update --rosdistro=jazzy
-          rosdep install --from-paths . --ignore-src -y
-          ./src/ateam_software/ateam_ui/install_deps.sh
-          sudo apt install -y python3-clang
+          ./src/software/install_dependencies.bash
       
       - name: Get Changed Packages
         id: get-changed-packages

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -15,6 +15,9 @@ jobs:
           submodules: true
           fetch-depth: 0
       
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1.16.1
+      
       - name: Install Dependencies
         shell: bash
         run: |

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          ./src/software/install_dependencies.bash
+          ./src/ateam_software/install_dependencies.bash
       
       - name: Get Changed Packages
         id: get-changed-packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "radio/ateam_radio_msgs/software-communication"]
 	path = radio/ateam_radio_msgs/software-communication
 	url = https://github.com/SSL-A-Team/software-communication.git
+[submodule "motion/ateam_controls/controls"]
+	path = motion/ateam_controls/controls
+	url = https://github.com/SSL-A-Team/controls.git

--- a/dep_scripts/apt.bash
+++ b/dep_scripts/apt.bash
@@ -7,7 +7,7 @@ set -e
 echo "Installing APT dependencies..."
 
 sudo apt update
-sudo apt upgrade
+sudo apt upgrade -y
 
 sudo apt install -y python3-clang net-tools
 

--- a/dep_scripts/apt.bash
+++ b/dep_scripts/apt.bash
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+
+# Prefer using rosdep for dependencies available via that tool
+
+set -e
+
+echo "Installing APT dependencies..."
+
+sudo apt update
+sudo apt upgrade
+
+sudo apt install -y python3-clang net-tools
+
+echo "APT dependencies installed."

--- a/dep_scripts/erforce_simulator.bash
+++ b/dep_scripts/erforce_simulator.bash
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+
+set -e 
+
+if [ -n "$SIMULATORCLI_PATH" ]; then
+    echo "ER-Force Simulator already installed."
+    exit 0
+fi
+
+echo "Installing ER-Force Simulator..."
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+ERFORCE_DIR=$SCRIPT_DIR/../../../../erforce
+mkdir $ERFORCE_DIR
+pushd $ERFORCE_DIR
+git clone https://github.com/robotics-erlangen/framework.git
+sudo apt install -y cmake protobuf-compiler libprotobuf-dev qt6-base-dev libqt6opengl6-dev g++ libusb-1.0-0-dev libsdl2-dev libqt6svg6-dev libssl-dev libglu1-mesa-dev
+pushd framework
+mkdir build
+pushd build
+cmake ..
+cmake --build . --target project_bullet simulator-cli
+echo $"export SIMULATORCLI_PATH=$ERFORCE_DIR/framework/build/bin/simulator-cli\n" >> ~/.bashrc
+source ~/.bashrc
+popd
+popd
+popd
+
+echo "ER-Force Simulator installed."

--- a/dep_scripts/ros.bash
+++ b/dep_scripts/ros.bash
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+
+set -e
+
+if [ -f /opt/ros/jazzy/setup.bash ]; then
+    echo "ROS already installed."
+    exit 0
+fi
+
+echo "Installing ROS..."
+
+sudo apt install -y software-properties-common
+sudo add-apt-repository universe
+
+sudo apt update && sudo apt install curl -y
+export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
+curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
+sudo dpkg -i /tmp/ros2-apt-source.deb
+
+sudo apt update
+sudo apt install -y ros-dev-tools
+
+sudo apt install ros-jazzy-desktop
+
+echo "ROS installed."

--- a/dep_scripts/rosdep.bash
+++ b/dep_scripts/rosdep.bash
@@ -6,5 +6,6 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
 source /opt/ros/jazzy/setup.bash
 pushd $SCRIPT_DIR/..
+rosdep update --rosdistro=jazzy
 rosdep install --from-paths . --ignore-src -y
 popd

--- a/dep_scripts/rosdep.bash
+++ b/dep_scripts/rosdep.bash
@@ -1,0 +1,10 @@
+#! /usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+source /opt/ros/jazzy/setup.bash
+pushd $SCRIPT_DIR/..
+rosdep install --from-paths . --ignore-src -y
+popd

--- a/dep_scripts/rust.bash
+++ b/dep_scripts/rust.bash
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+
+set -e
+
+if command -v rustc &> /dev/null; then
+    echo "Rust already installed."
+    exit 0
+fi
+
+echo "Installing Rust..."
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+echo "Rust installed."

--- a/dep_scripts/rust.bash
+++ b/dep_scripts/rust.bash
@@ -9,6 +9,6 @@ fi
 
 echo "Installing Rust..."
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 echo "Rust installed."

--- a/dep_scripts/rust.bash
+++ b/dep_scripts/rust.bash
@@ -10,5 +10,6 @@ fi
 echo "Installing Rust..."
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source $HOME/.cargo/env
 
 echo "Rust installed."

--- a/install_dependencies.bash
+++ b/install_dependencies.bash
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+$SCRIPT_DIR/dep_scripts/apt.bash
+$SCRIPT_DIR/dep_scripts/ros.bash
+$SCRIPT_DIR/dep_scripts/rosdep.bash
+$SCRIPT_DIR/dep_scripts/rust.bash
+$SCRIPT_DIR/ateam_ui/install_deps.sh
+$SCRIPT_DIR/dep_scripts/erforce_simulator.bash

--- a/install_dependencies.bash
+++ b/install_dependencies.bash
@@ -1,12 +1,34 @@
 #! /usr/bin/env bash
 
+# Run this script to install all dependencies for our software.
+# 
+# Options:
+#  -s: Install simulator dependencies (erforce_simulator)
+
+
 set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+INSTALL_SIM="false"
+
+while getopts ":s" opt; do
+  case $opt in
+    s)
+      INSTALL_SIM="true"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
+done
 
 $SCRIPT_DIR/dep_scripts/apt.bash
 $SCRIPT_DIR/dep_scripts/ros.bash
 $SCRIPT_DIR/dep_scripts/rosdep.bash
 $SCRIPT_DIR/dep_scripts/rust.bash
 $SCRIPT_DIR/ateam_ui/install_deps.sh
-$SCRIPT_DIR/dep_scripts/erforce_simulator.bash
+
+if [ "$INSTALL_SIM" = "true" ]; then
+    $SCRIPT_DIR/dep_scripts/erforce_simulator.bash
+fi

--- a/motion/ateam_controls/CMakeLists.txt
+++ b/motion/ateam_controls/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.8)
+project(ateam_controls)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+set(RUST_TARGET_DIR ${CMAKE_CURRENT_SOURCE_DIR}/controls/target)
+
+if((CMAKE_BUILD_TYPE STREQUAL "Release") OR (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
+  set(IMPORTED_LIB_PATH ${RUST_TARGET_DIR}/release/libateam_controls_c.a)
+else()
+  set(IMPORTED_LIB_PATH ${RUST_TARGET_DIR}/debug/libateam_controls_c.a)
+endif()
+
+add_subdirectory(controls)
+
+
+install(
+  DIRECTORY controls/ateam-controls-c/include/
+  DESTINATION include
+)
+install(
+  FILES $<TARGET_FILE:ateam_controls> 
+  DESTINATION lib
+)
+
+ament_export_libraries(-l${CMAKE_INSTALL_PREFIX}/lib/libateam_controls_c.a)
+ament_export_include_directories(${CMAKE_INSTALL_PREFIX}/include)
+
+ament_package()

--- a/motion/ateam_controls/CMakeLists.txt
+++ b/motion/ateam_controls/CMakeLists.txt
@@ -7,14 +7,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-set(RUST_TARGET_DIR ${CMAKE_CURRENT_SOURCE_DIR}/controls/target)
-
-if((CMAKE_BUILD_TYPE STREQUAL "Release") OR (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
-  set(IMPORTED_LIB_PATH ${RUST_TARGET_DIR}/release/libateam_controls_c.a)
-else()
-  set(IMPORTED_LIB_PATH ${RUST_TARGET_DIR}/debug/libateam_controls_c.a)
-endif()
-
 add_subdirectory(controls)
 
 
@@ -27,7 +19,10 @@ install(
   DESTINATION lib
 )
 
-ament_export_libraries(-l${CMAKE_INSTALL_PREFIX}/lib/libateam_controls_c.a)
+
+_ament_cmake_export_libraries_register_environment_hook()
+_ament_cmake_export_libraries_register_package_hook()
+list(APPEND _AMENT_EXPORT_LIBRARIES ${CMAKE_INSTALL_PREFIX}/lib/libateam_controls_c.a)
 ament_export_include_directories(${CMAKE_INSTALL_PREFIX}/include)
 
 ament_package()

--- a/motion/ateam_controls/LICENSE
+++ b/motion/ateam_controls/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/motion/ateam_controls/package.xml
+++ b/motion/ateam_controls/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ateam_controls</name>
+  <version>0.0.0</version>
+  <description>A-Team on-robot controls library</description>
+  <maintainer email="matthew.barulic@gmail.com">Matthew Barulic</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/motion/ateam_controls_testing/scripts/waypoints_test.py
+++ b/motion/ateam_controls_testing/scripts/waypoints_test.py
@@ -59,8 +59,8 @@ def publish_waypoint_command(index: int):
     command_msg.pose.y = waypoint[1]
     command_msg.pose.theta = waypoint[2]
     command_msg.kick_request = RobotMotionCommand.KR_DISABLE
-    command_msg.limit_acc_linear = 4.0
-    command_msg.limit_vel_linear = 2.0
+    command_msg.limit_acc_linear = 3.0
+    command_msg.limit_vel_linear = 3.0
     command_msg.limit_acc_angular = 8.0
     command_msg.limit_vel_angular = 4.0
     command_pub.publish(command_msg)


### PR DESCRIPTION
This PR adds the `ateam_controls` package which includes and exposes our controls repo to colcon packages.

Along the way, I also wrote some dependency installer scripts since we now depend on rust. Future work includes updating the readme and system_setup_scripts repo to use the new dependency install flow.