### PR TITLE
populate halt game state bit in packet

### DIFF
--- a/radio/ateam_radio_bridge/src/radio_bridge_node.cpp
+++ b/radio/ateam_radio_bridge/src/radio_bridge_node.cpp
@@ -292,6 +292,8 @@ private:
       control_msg.reboot_robot = reboot_requested_[id];
       control_msg.game_state_in_stop = game_controller_listener_.GetGameCommand() ==
         ateam_common::GameCommand::Stop;
+      control_msg.game_state_in_halt = game_controller_listener_.GetGameCommand() ==
+        ateam_common::GameCommand::Halt;
       control_msg.emergency_stop = false;
       control_msg.wheel_vel_control_enabled = get_parameter("controls_enabled.wheel_vel").as_bool();
       control_msg.wheel_torque_control_enabled =


### PR DESCRIPTION
Populates a halt game state bit in the basic control bit field header. We use this information to robustly command motors to 0.