### PR TITLE
Fixes get_changed_packages to avoid package name prefix mixups

### DIFF
--- a/.github/workflows/get_changed_packages.sh
+++ b/.github/workflows/get_changed_packages.sh
@@ -15,7 +15,7 @@ for file in $changed_files; do
   while read package_info; do
     package_path=$(echo "$package_info" | awk '{ print $2 }')
     package_name=$(echo "$package_info" | awk '{ print $1 }')
-    if [[ ${file} == ${package_path}* ]]; then
+    if [[ ${file} == "$package_path" || ${file} == "$package_path"/* ]]; then
       changed_packages+=( "$package_name" )
       break
     fi


### PR DESCRIPTION
`get_changed_packages.sh` has a bug where one package name being a prefix of another package name will confuse it.
This PR adjusts the path matching condition to avoid that problem by ensuring paths match on a full directory border.