### PR TITLE
Comp merge: ateam_bringup

### DIFF
--- a/ateam_bringup/ateam_bringup/actions/__init__.py
+++ b/ateam_bringup/ateam_bringup/actions/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 A Team
+# Copyright 2026 A Team
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -19,11 +19,11 @@
 # THE SOFTWARE.
 
 
-from .interface_from_address_substitution import InterfaceFromAddressSubstitution
-from .package_launch_file_substitution import PackageLaunchFileSubstitution
+from .change_game_contoller_config import ChangeGameControllerConfig
+from .change_game_controller_team_name import ChangeGameControllerTeamName
 
 
 __all__ = [
-    'InterfaceFromAddressSubstitution',
-    'PackageLaunchFileSubstitution'
+    'ChangeGameControllerConfig',
+    'ChangeGameControllerTeamName'
 ]

--- a/ateam_bringup/ateam_bringup/actions/change_game_contoller_config.py
+++ b/ateam_bringup/ateam_bringup/actions/change_game_contoller_config.py
@@ -1,0 +1,66 @@
+# Copyright 2026 A Team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch import LaunchContext, Substitution
+from launch.actions import OpaqueCoroutine
+from launch.utilities import normalize_to_list_of_substitutions
+from typing import Mapping, Union, Any
+
+import json
+import websockets
+
+
+class ChangeGameControllerConfig(OpaqueCoroutine):
+    """Action that sends config delta commands to the GC API"""
+
+    def __init__(self, configs: Mapping[Union[Substitution, str], Any], gc_address: SomeSubstitutionsType) -> None:
+        """Initialize the action."""
+        super().__init__(coroutine=self.my_coroutine)
+        self.__configs = configs
+        self.__gc_address = normalize_to_list_of_substitutions(gc_address)
+
+    async def my_coroutine(self, context: LaunchContext, *args, **kwargs):
+        gc_address = context.perform_substitution(self.__gc_address[0])
+        config_delta = {}
+        for k, v in self.__configs.items():
+            if isinstance(k, Substitution):
+                key = context.perform_substitution(k)
+            else:
+                key = k
+            if isinstance(v, Substitution):
+                value = context.perform_substitution(v)
+            else:
+                value = v
+            config_delta[key] = value
+        await self.send_json_payload(gc_address, config_delta)
+
+    async def send_json_payload(self, address: str, configs: Mapping[str, str]):
+        payload = {
+            'config_delta': configs
+        }
+        server_url = f'ws://{address}:8081/api/control'
+        while True:
+            try:
+                async with websockets.connect(server_url) as ws:
+                    await ws.send(json.dumps(payload))
+                break
+            except ConnectionRefusedError:
+                continue

--- a/ateam_bringup/ateam_bringup/actions/change_game_contoller_config.py
+++ b/ateam_bringup/ateam_bringup/actions/change_game_contoller_config.py
@@ -18,20 +18,22 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from launch.some_substitutions_type import SomeSubstitutionsType
+import json
+from typing import Any, Mapping, Union
+
 from launch import LaunchContext, Substitution
 from launch.actions import OpaqueCoroutine
+from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.utilities import normalize_to_list_of_substitutions
-from typing import Mapping, Union, Any
 
-import json
 import websockets
 
 
 class ChangeGameControllerConfig(OpaqueCoroutine):
-    """Action that sends config delta commands to the GC API"""
+    """Action that sends config delta commands to the GC API."""
 
-    def __init__(self, configs: Mapping[Union[Substitution, str], Any], gc_address: SomeSubstitutionsType) -> None:
+    def __init__(self, configs: Mapping[Union[Substitution, str], Any],
+                 gc_address: SomeSubstitutionsType) -> None:
         """Initialize the action."""
         super().__init__(coroutine=self.my_coroutine)
         self.__configs = configs

--- a/ateam_bringup/ateam_bringup/actions/change_game_controller_team_name.py
+++ b/ateam_bringup/ateam_bringup/actions/change_game_controller_team_name.py
@@ -18,21 +18,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import json
+from typing import Union
+
 import launch
-from launch.some_substitutions_type import SomeSubstitutionsType
 from launch import LaunchContext, Substitution
 from launch.actions import OpaqueCoroutine
+from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.utilities import normalize_to_list_of_substitutions
-from typing import Mapping, Union, Any
 
-import json
 import websockets
 
 
 class ChangeGameControllerTeamName(OpaqueCoroutine):
-    """Action that sends config delta commands to the GC API"""
+    """Action that sends config delta commands to the GC API."""
 
-    def __init__(self, color: Union[Substitution, str], name: Union[Substitution, str], gc_address: SomeSubstitutionsType) -> None:
+    def __init__(self, color: Union[Substitution, str], name: Union[Substitution, str],
+                 gc_address: SomeSubstitutionsType) -> None:
         """Initialize the action."""
         super().__init__(coroutine=self.my_coroutine)
         self.__color = color
@@ -54,7 +56,7 @@ class ChangeGameControllerTeamName(OpaqueCoroutine):
             team_name = self.__team_name
 
         launch.logging.get_logger().info(f'Color: {color}   Name: {team_name}')
-        
+
         await self.send_json_payload(gc_address, color, team_name)
 
     async def send_json_payload(self, address: str, color: str, name: str):

--- a/ateam_bringup/ateam_bringup/actions/change_game_controller_team_name.py
+++ b/ateam_bringup/ateam_bringup/actions/change_game_controller_team_name.py
@@ -1,0 +1,79 @@
+# Copyright 2026 A Team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import launch
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch import LaunchContext, Substitution
+from launch.actions import OpaqueCoroutine
+from launch.utilities import normalize_to_list_of_substitutions
+from typing import Mapping, Union, Any
+
+import json
+import websockets
+
+
+class ChangeGameControllerTeamName(OpaqueCoroutine):
+    """Action that sends config delta commands to the GC API"""
+
+    def __init__(self, color: Union[Substitution, str], name: Union[Substitution, str], gc_address: SomeSubstitutionsType) -> None:
+        """Initialize the action."""
+        super().__init__(coroutine=self.my_coroutine)
+        self.__color = color
+        self.__team_name = name
+        self.__gc_address = normalize_to_list_of_substitutions(gc_address)
+
+    async def my_coroutine(self, context: LaunchContext, *args, **kwargs):
+        gc_address = context.perform_substitution(self.__gc_address[0])
+        color = ''
+        if isinstance(self.__color, Substitution):
+            color = context.perform_substitution(self.__color)
+        else:
+            color = self.__color
+        color = color.upper()
+        team_name = ''
+        if isinstance(self.__team_name, Substitution):
+            team_name = context.perform_substitution(self.__team_name)
+        else:
+            team_name = self.__team_name
+
+        launch.logging.get_logger().info(f'Color: {color}   Name: {team_name}')
+        
+        await self.send_json_payload(gc_address, color, team_name)
+
+    async def send_json_payload(self, address: str, color: str, name: str):
+        payload = {
+            'change': {
+                'origin': 'UI',
+                'revertible': True,
+                'update_team_state_change': {
+                    'for_team': color,
+                    'team_name': name
+                }
+            }
+        }
+        server_url = f'ws://{address}:8081/api/control'
+        launch.logging.get_logger().info(f'Sending: {json.dumps(payload)}')
+        while True:
+            try:
+                async with websockets.connect(server_url) as ws:
+                    await ws.send(json.dumps(payload))
+                break
+            except ConnectionRefusedError:
+                continue

--- a/ateam_bringup/ateam_bringup/substitutions/interface_from_address_substitution.py
+++ b/ateam_bringup/ateam_bringup/substitutions/interface_from_address_substitution.py
@@ -1,0 +1,59 @@
+# Copyright 2026 A Team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import launch
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch import LaunchContext, Substitution
+from launch.utilities import normalize_to_list_of_substitutions
+from typing import Text
+import socket
+
+
+class InterfaceFromAddressSubstitution(Substitution):
+    """Substitution that returns the interface address to use for a given IP address."""
+
+    def __init__(self, address: SomeSubstitutionsType) -> None:
+        """Initialize the substitution."""
+        super().__init__()
+        self.__address = normalize_to_list_of_substitutions(address)
+
+    def perform(self, context: LaunchContext) -> Text:
+        """
+        Perform the substitution, converting the address to an interface address.
+
+        If the address given is empty, this returns an empty string.
+        """
+        address = context.perform_substitution(self.__address[0])
+        return self.get_local_ip(address)
+
+    def get_local_ip(self, target_ip: str, target_port: int = 80) -> str:
+        """Return the local IP of the interface that would be used to reach target_ip."""
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            # UDP "connect" doesn't send any packets — it just asks the OS
+            # to pick a route/interface, which lets us read the local IP.
+            s.connect((target_ip, target_port))
+            local_ip = s.getsockname()[0]
+        except Exception:
+            launch.logging.get_logger().exception(f'Could not determine interface for {target_ip}')
+            raise
+        finally:
+            s.close()
+        return local_ip

--- a/ateam_bringup/ateam_bringup/substitutions/interface_from_address_substitution.py
+++ b/ateam_bringup/ateam_bringup/substitutions/interface_from_address_substitution.py
@@ -18,12 +18,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import launch
-from launch.some_substitutions_type import SomeSubstitutionsType
-from launch import LaunchContext, Substitution
-from launch.utilities import normalize_to_list_of_substitutions
-from typing import Text
 import socket
+from typing import Text
+
+import launch
+from launch import LaunchContext, Substitution
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.utilities import normalize_to_list_of_substitutions
 
 
 class InterfaceFromAddressSubstitution(Substitution):
@@ -52,7 +53,8 @@ class InterfaceFromAddressSubstitution(Substitution):
             s.connect((target_ip, target_port))
             local_ip = s.getsockname()[0]
         except Exception:
-            launch.logging.get_logger().exception(f'Could not determine interface for {target_ip}')
+            launch.logging.get_logger().exception(
+                f'Could not determine interface for {target_ip}')
             raise
         finally:
             s.close()

--- a/ateam_bringup/launch/bringup_physical_core.launch.py
+++ b/ateam_bringup/launch/bringup_physical_core.launch.py
@@ -29,7 +29,7 @@ from launch.actions import (
 )
 from launch.conditions import IfCondition
 from launch.launch_description_sources import FrontendLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, IfElseSubstitution
 from launch_ros.actions import Node
 
 
@@ -43,6 +43,8 @@ def generate_launch_description():
 
         DeclareLaunchArgument('team_name', default_value='A-Team'),
         DeclareLaunchArgument('use_local_gc', default_value='False'),
+
+        DeclareLaunchArgument('gc_use_multicast', default_value='False'),
 
         GroupAction(
             condition=IfCondition(LaunchConfiguration('use_local_gc')),
@@ -60,7 +62,11 @@ def generate_launch_description():
                 'gc_ip_address': LaunchConfiguration('gc_server_address'),
                 'gc_net_interface_address': LaunchConfiguration('gc_interface_address'),
                 'vision_net_interface_address': LaunchConfiguration('vision_interface_address'),
-                'team_name': LaunchConfiguration('team_name')
+                'team_name': LaunchConfiguration('team_name'),
+                'gc_receive_address': IfElseSubstitution(
+                    LaunchConfiguration('gc_use_multicast'),
+                    '224.5.23.1',
+                    '255.255.255.255')
             }.items()
         ),
 
@@ -85,7 +91,7 @@ def generate_launch_description():
             launch_arguments={
                 'team_name': LaunchConfiguration('team_name'),
                 'vision_offset_robot_x': '0.0',
-                'vision_offset_robot_y': '0.0'
+                'vision_offset_robot_y': '0.0',
             }.items()
         ),
 
@@ -107,8 +113,11 @@ def generate_launch_description():
             remappings=remap_indexed_topics([
                 ('~/robot_motion_commands/robot', '/robot_motion_commands/robot'),
                 ('~/robot_feedback/basic/robot', '/robot_feedback/basic/robot'),
-                ('~/robot_feedback/extended/robot', '/robot_feedback/extended/robot'),
-                ('~/robot_feedback/connection/robot', '/robot_feedback/connection/robot')
+                ('~/robot_feedback/extended/robot',
+                 '/robot_feedback/extended/robot'),
+                ('~/robot_feedback/connection/robot',
+                 '/robot_feedback/connection/robot'),
+                ('~/robot_feedback/error/robot', '/robot_feedback/error/robot'),
             ]),
         ),
     ])

--- a/ateam_bringup/launch/bringup_physical_core.launch.py
+++ b/ateam_bringup/launch/bringup_physical_core.launch.py
@@ -20,6 +20,7 @@
 
 from ateam_bringup.substitutions import PackageLaunchFileSubstitution
 from ateam_bringup.utils import remap_indexed_topics
+
 import launch
 from launch.actions import (
     DeclareLaunchArgument,
@@ -29,7 +30,8 @@ from launch.actions import (
 )
 from launch.conditions import IfCondition
 from launch.launch_description_sources import FrontendLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, IfElseSubstitution
+from launch.substitutions import IfElseSubstitution, LaunchConfiguration
+
 from launch_ros.actions import Node
 
 

--- a/ateam_bringup/launch/bringup_simulation.launch.py
+++ b/ateam_bringup/launch/bringup_simulation.launch.py
@@ -18,17 +18,26 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from ateam_bringup.actions import (
+    ChangeGameControllerConfig,
+    ChangeGameControllerTeamName
+)
 from ateam_bringup.substitutions import (
     InterfaceFromAddressSubstitution,
     PackageLaunchFileSubstitution
 )
+
 import launch
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, GroupAction
+from launch.actions import (
+    DeclareLaunchArgument,
+    GroupAction,
+    IncludeLaunchDescription
+)
 from launch.conditions import IfCondition
 from launch.launch_description_sources import FrontendLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
+
 from launch_ros.actions import Node
-from ateam_bringup.actions import ChangeGameControllerTeamName, ChangeGameControllerConfig
 
 
 def generate_launch_description():
@@ -65,9 +74,11 @@ def generate_launch_description():
                     'autoContinue': False
                 }),
                 ChangeGameControllerTeamName(
-                    gc_address='172.17.0.2', color='blue', name=LaunchConfiguration('blue_team')),
+                    gc_address='172.17.0.2', color='blue',
+                    name=LaunchConfiguration('blue_team')),
                 ChangeGameControllerTeamName(
-                    gc_address='172.17.0.2', color='yellow', name=LaunchConfiguration('yellow_team')),
+                    gc_address='172.17.0.2', color='yellow',
+                    name=LaunchConfiguration('yellow_team')),
 
             ],
             condition=IfCondition(LaunchConfiguration('start_gc'))
@@ -78,9 +89,13 @@ def generate_launch_description():
                 PackageLaunchFileSubstitution('ateam_bringup',
                                               'league_bridges.launch.xml')),
             launch_arguments={
-                'gc_net_interface_address': InterfaceFromAddressSubstitution(LaunchConfiguration('gc_ip')),
+                'gc_net_interface_address':
+                    InterfaceFromAddressSubstitution(
+                        LaunchConfiguration('gc_ip')),
                 'gc_ip_address': LaunchConfiguration('gc_ip'),
-                'vision_net_interface_address': InterfaceFromAddressSubstitution(LaunchConfiguration('sim_ip')),
+                'vision_net_interface_address':
+                    InterfaceFromAddressSubstitution(
+                        LaunchConfiguration('sim_ip')),
                 'vision_port': '10020',
                 'team_name': LaunchConfiguration('team_name')
             }.items()

--- a/ateam_bringup/launch/bringup_simulation.launch.py
+++ b/ateam_bringup/launch/bringup_simulation.launch.py
@@ -18,13 +18,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ateam_bringup.substitutions import PackageLaunchFileSubstitution
+from ateam_bringup.substitutions import (
+    InterfaceFromAddressSubstitution,
+    PackageLaunchFileSubstitution
+)
 import launch
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, GroupAction
 from launch.conditions import IfCondition
 from launch.launch_description_sources import FrontendLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from ateam_bringup.actions import ChangeGameControllerTeamName, ChangeGameControllerConfig
 
 
 def generate_launch_description():
@@ -32,9 +36,13 @@ def generate_launch_description():
         DeclareLaunchArgument('start_sim', default_value='True'),
         DeclareLaunchArgument('start_gc', default_value='True'),
         DeclareLaunchArgument('start_ui', default_value='True'),
+        DeclareLaunchArgument('start_kenobi', default_value='True'),
         DeclareLaunchArgument('headless_sim', default_value='True'),
-        DeclareLaunchArgument('sim_radio_ip', default_value='127.0.0.1'),
+        DeclareLaunchArgument('sim_ip', default_value='127.0.0.1'),
+        DeclareLaunchArgument('gc_ip', default_value='172.17.0.2'),
         DeclareLaunchArgument('team_name', default_value='A-Team'),
+        DeclareLaunchArgument('blue_team', default_value='A-Team'),
+        DeclareLaunchArgument('yellow_team', default_value='RoboJackets'),
 
         IncludeLaunchDescription(
             FrontendLaunchDescriptionSource(
@@ -46,10 +54,22 @@ def generate_launch_description():
             condition=IfCondition(LaunchConfiguration('start_sim'))
         ),
 
-        IncludeLaunchDescription(
-            FrontendLaunchDescriptionSource(
-                PackageLaunchFileSubstitution('ateam_bringup',
-                                              'ssl_game_controller.launch.xml')),
+        GroupAction(
+            actions=[
+                IncludeLaunchDescription(
+                    FrontendLaunchDescriptionSource(
+                        PackageLaunchFileSubstitution('ateam_bringup',
+                                                      'ssl_game_controller.launch.xml'))
+                ),
+                ChangeGameControllerConfig(gc_address='172.17.0.2', configs={
+                    'autoContinue': False
+                }),
+                ChangeGameControllerTeamName(
+                    gc_address='172.17.0.2', color='blue', name=LaunchConfiguration('blue_team')),
+                ChangeGameControllerTeamName(
+                    gc_address='172.17.0.2', color='yellow', name=LaunchConfiguration('yellow_team')),
+
+            ],
             condition=IfCondition(LaunchConfiguration('start_gc'))
         ),
 
@@ -58,9 +78,9 @@ def generate_launch_description():
                 PackageLaunchFileSubstitution('ateam_bringup',
                                               'league_bridges.launch.xml')),
             launch_arguments={
-                'gc_net_interface_address': '172.17.0.1',
-                'gc_ip_address': '172.17.0.2',
-                'vision_net_interface_address': '127.0.0.1',
+                'gc_net_interface_address': InterfaceFromAddressSubstitution(LaunchConfiguration('gc_ip')),
+                'gc_ip_address': LaunchConfiguration('gc_ip'),
+                'vision_net_interface_address': InterfaceFromAddressSubstitution(LaunchConfiguration('sim_ip')),
                 'vision_port': '10020',
                 'team_name': LaunchConfiguration('team_name')
             }.items()
@@ -85,7 +105,7 @@ def generate_launch_description():
             executable='ssl_simulation_radio_bridge_node',
             name='radio_bridge',
             parameters=[{
-                'ssl_sim_radio_ip': LaunchConfiguration('sim_radio_ip'),
+                'ssl_sim_radio_ip': LaunchConfiguration('sim_ip'),
                 'gc_team_name': LaunchConfiguration('team_name')
             }]
         ),
@@ -105,6 +125,7 @@ def generate_launch_description():
                 PackageLaunchFileSubstitution(
                     'ateam_bringup', 'kenobi.launch.xml'
                 )
-            )
+            ),
+            condition=IfCondition(LaunchConfiguration('start_kenobi'))
         ),
     ])

--- a/ateam_bringup/launch/league_bridges.launch.xml
+++ b/ateam_bringup/launch/league_bridges.launch.xml
@@ -1,6 +1,7 @@
 <launch>
   <arg name="gc_ip_address" default=""/>
   <arg name="gc_net_interface_address" default=""/>
+  <arg name="gc_receive_address" default="224.5.23.1"/>
   <arg name="vision_net_interface_address" default=""/>
   <arg name="vision_port" default="10006"/>
   <arg name="team_name" default="A-Team"/>
@@ -13,6 +14,7 @@
 
   <node name="ssl_gc_bridge" pkg="ssl_ros_bridge" exec="gc_multicast_bridge_node" respawn="True">
     <param name="net_interface_address" value="$(var gc_net_interface_address)"/>
+    <param name='multicast.address' value="$(var gc_receive_address)"/>
     <remap from="/ssl_gc_bridge/referee_messages" to="/referee_messages"/>
   </node>
   <node name="team_client_node" pkg="ssl_ros_bridge" exec="team_client_node" respawn="True">

--- a/ateam_bringup/package.xml
+++ b/ateam_bringup/package.xml
@@ -12,6 +12,8 @@
 
   <exec_depend>docker.io</exec_depend>
 
+  <depend>python3-websockets</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
Changes:
* Adds `ChangeGameControllerConfig` and `ChangeGameControllerTeamName` actions and uses them to auto-configure the GC during simulation
* Adds `InterfaceFromAddressSubstitution` to automatically deduce the correct interface address given the target IP address. Useful for configuring multi-machine sim setups, but also could be helpful in weird comp networking scenarios.
* Adds some partial support for multicast vs broadcast switching